### PR TITLE
feat(userland): add stlxstd C++ threading library with futex-based sync primitives

### DIFF
--- a/kernel/sched/sched.cpp
+++ b/kernel/sched/sched.cpp
@@ -816,7 +816,7 @@ __PRIVILEGED_CODE task* create_user_thread(
     t->exec.system_stack_top = sys_stack_top;
     t->exec.pt_root = paging::supervisor_pt_root_for_user_task(creator->exec.mm_ctx->pt_root);
     t->exec.user_pt_root = creator->exec.mm_ctx->pt_root;
-    t->exec.tls_base = 0;
+    t->exec.tls_base = creator->exec.tls_base;
     t->task_stack_base = 0; // user stack is not VMM-allocated
     t->sys_stack_base = sys_stack_base;
 

--- a/userland/apps/Makefile
+++ b/userland/apps/Makefile
@@ -5,7 +5,7 @@
 APP_DIRS := init hello shell ls cat rm stat touch sleep true false clear ptytest date \
 			clockbench stlxdm stlxterm doom ping ifconfig nslookup arp udpecho tcpecho \
 			fetch polltest dropbear blackjack wordle hangman snake tetris \
-			grep wc head threadtest uname kill cxxtest
+			grep wc head threadtest uname kill cxxtest synctest
 APP_COUNT := $(words $(APP_DIRS))
 
 all:

--- a/userland/apps/synctest/Makefile
+++ b/userland/apps/synctest/Makefile
@@ -1,0 +1,3 @@
+APP_NAME := synctest
+APP_LIBS := stlxcxx
+include ../../mk/cxxapp.mk

--- a/userland/apps/synctest/src/synctest.cpp
+++ b/userland/apps/synctest/src/synctest.cpp
@@ -1,0 +1,209 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <time.h>
+#include <stlxstd/thread.h>
+#include <stlxstd/mutex.h>
+#include <stlxstd/condition_variable.h>
+#include <stlxstd/barrier.h>
+
+static int g_passed = 0;
+static int g_failed = 0;
+
+static void check(const char* name, bool ok) {
+    printf("  %s: %s\n", ok ? "PASS" : "FAIL", name);
+    if (ok) g_passed++;
+    else g_failed++;
+}
+
+// --- Test 1: Mutex stress ---
+
+static constexpr int MUTEX_THREADS = 8;
+static constexpr int MUTEX_ITERS = 10000;
+
+static void test_mutex_stress() {
+    stlxstd::mutex mtx;
+    int counter = 0;
+
+    stlxstd::thread threads[MUTEX_THREADS];
+    for (int i = 0; i < MUTEX_THREADS; i++) {
+        threads[i] = stlxstd::thread([&] {
+            for (int j = 0; j < MUTEX_ITERS; j++) {
+                stlxstd::lock_guard<stlxstd::mutex> guard(mtx);
+                counter++;
+            }
+        });
+    }
+    for (int i = 0; i < MUTEX_THREADS; i++) {
+        threads[i].join();
+    }
+
+    check("mutex stress (8 threads x 10000)", counter == MUTEX_THREADS * MUTEX_ITERS);
+}
+
+// --- Test 2: Condition variable producer/consumer ---
+
+static constexpr int ITEMS = 100;
+
+static void test_condvar_producer_consumer() {
+    stlxstd::mutex mtx;
+    stlxstd::condition_variable cv;
+    int produced = 0;
+    int consumed = 0;
+    bool done = false;
+
+    stlxstd::thread consumer([&] {
+        stlxstd::unique_lock<stlxstd::mutex> lock(mtx);
+        while (!done || produced > consumed) {
+            cv.wait(lock, [&] { return produced > consumed || done; });
+            while (produced > consumed) {
+                consumed++;
+            }
+        }
+    });
+
+    stlxstd::thread producer([&] {
+        for (int i = 0; i < ITEMS; i++) {
+            {
+                stlxstd::lock_guard<stlxstd::mutex> guard(mtx);
+                produced++;
+            }
+            cv.notify_one();
+        }
+        {
+            stlxstd::lock_guard<stlxstd::mutex> guard(mtx);
+            done = true;
+        }
+        cv.notify_one();
+    });
+
+    producer.join();
+    consumer.join();
+
+    check("condvar producer/consumer (100 items)", consumed == ITEMS);
+}
+
+// --- Test 3: Barrier synchronization ---
+
+static constexpr int BARRIER_THREADS = 4;
+
+static void test_barrier() {
+    stlxstd::barrier bar(BARRIER_THREADS);
+    volatile int flags[BARRIER_THREADS] = {};
+    volatile int verified[BARRIER_THREADS] = {};
+
+    stlxstd::thread threads[BARRIER_THREADS];
+    for (int i = 0; i < BARRIER_THREADS; i++) {
+        threads[i] = stlxstd::thread([&, i] {
+            __atomic_store_n(&flags[i], 1, __ATOMIC_RELEASE);
+            bar.arrive_and_wait();
+            // After barrier: all flags must be set
+            bool all_set = true;
+            for (int j = 0; j < BARRIER_THREADS; j++) {
+                if (!__atomic_load_n(&flags[j], __ATOMIC_ACQUIRE)) {
+                    all_set = false;
+                }
+            }
+            __atomic_store_n(&verified[i], all_set ? 1 : 0, __ATOMIC_RELEASE);
+        });
+    }
+    for (int i = 0; i < BARRIER_THREADS; i++) {
+        threads[i].join();
+    }
+
+    bool ok = true;
+    for (int i = 0; i < BARRIER_THREADS; i++) {
+        if (!verified[i]) ok = false;
+    }
+    check("barrier (4 threads)", ok);
+}
+
+// --- Test 4: Thread join ---
+
+static void test_thread_join() {
+    volatile int value = 0;
+
+    stlxstd::thread t([&] {
+        __atomic_store_n(&value, 42, __ATOMIC_RELEASE);
+    });
+    t.join();
+
+    check("thread join", __atomic_load_n(&value, __ATOMIC_ACQUIRE) == 42);
+}
+
+// --- Test 5: Thread detach ---
+
+static void test_thread_detach() {
+    volatile int flag = 0;
+
+    {
+        stlxstd::thread t([&] {
+            __atomic_store_n(&flag, 1, __ATOMIC_RELEASE);
+        });
+        t.detach();
+    }
+
+    // Brief busy-wait for the detached thread to run
+    for (int i = 0; i < 10000000; i++) {
+        if (__atomic_load_n(&flag, __ATOMIC_ACQUIRE)) break;
+        asm volatile("" ::: "memory");
+    }
+
+    check("thread detach", __atomic_load_n(&flag, __ATOMIC_ACQUIRE) == 1);
+}
+
+// --- Test 6: Multiple independent mutexes ---
+
+static constexpr int MULTI_THREADS = 4;
+static constexpr int MULTI_ITERS = 5000;
+
+static void test_multi_mutex() {
+    stlxstd::mutex mtx_a, mtx_b;
+    int counter_a = 0;
+    int counter_b = 0;
+
+    stlxstd::thread threads[MULTI_THREADS];
+    for (int i = 0; i < MULTI_THREADS; i++) {
+        threads[i] = stlxstd::thread([&] {
+            for (int j = 0; j < MULTI_ITERS; j++) {
+                {
+                    stlxstd::lock_guard<stlxstd::mutex> guard(mtx_a);
+                    counter_a++;
+                }
+                {
+                    stlxstd::lock_guard<stlxstd::mutex> guard(mtx_b);
+                    counter_b++;
+                }
+            }
+        });
+    }
+    for (int i = 0; i < MULTI_THREADS; i++) {
+        threads[i].join();
+    }
+
+    bool ok = (counter_a == MULTI_THREADS * MULTI_ITERS) &&
+              (counter_b == MULTI_THREADS * MULTI_ITERS);
+    check("multi-mutex (2 locks, 4 threads x 5000)", ok);
+}
+
+int main() {
+    printf("\nsynctest: Stellux synchronization test suite\n\n");
+
+    printf("[mutex]\n");
+    test_mutex_stress();
+
+    printf("\n[condition variable]\n");
+    test_condvar_producer_consumer();
+
+    printf("\n[barrier]\n");
+    test_barrier();
+
+    printf("\n[thread lifecycle]\n");
+    test_thread_join();
+    test_thread_detach();
+
+    printf("\n[multi-mutex]\n");
+    test_multi_mutex();
+
+    printf("\n--- Results: %d passed, %d failed ---\n\n", g_passed, g_failed);
+    return g_failed > 0 ? 1 : 0;
+}

--- a/userland/lib/Makefile
+++ b/userland/lib/Makefile
@@ -2,7 +2,7 @@
 # Stellux Userland - Libraries
 #
 
-LIB_DIRS := libstlx libstlxgfx libbearssl
+LIB_DIRS := libstlx libstlxcxx libstlxgfx libbearssl
 LIB_COUNT := $(words $(LIB_DIRS))
 
 all:

--- a/userland/lib/libstlx/include/stlx/barrier.h
+++ b/userland/lib/libstlx/include/stlx/barrier.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     uint32_t count;
     uint32_t generation;
@@ -13,5 +17,9 @@ void stlx_barrier_init(stlx_barrier_t* b, uint32_t count);
 
 /* Block until all count threads have called barrier_wait. Reusable. */
 void stlx_barrier_wait(stlx_barrier_t* b);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* STLX_BARRIER_H */

--- a/userland/lib/libstlx/include/stlx/barrier.h
+++ b/userland/lib/libstlx/include/stlx/barrier.h
@@ -8,7 +8,7 @@ extern "C" {
 #endif
 
 typedef struct {
-    uint32_t count;
+    uint64_t count;
     uint32_t generation;
     uint32_t total;
 } stlx_barrier_t;

--- a/userland/lib/libstlx/include/stlx/barrier.h
+++ b/userland/lib/libstlx/include/stlx/barrier.h
@@ -1,0 +1,17 @@
+#ifndef STLX_BARRIER_H
+#define STLX_BARRIER_H
+
+#include <stdint.h>
+
+typedef struct {
+    uint32_t count;
+    uint32_t generation;
+    uint32_t total;
+} stlx_barrier_t;
+
+void stlx_barrier_init(stlx_barrier_t* b, uint32_t count);
+
+/* Block until all count threads have called barrier_wait. Reusable. */
+void stlx_barrier_wait(stlx_barrier_t* b);
+
+#endif /* STLX_BARRIER_H */

--- a/userland/lib/libstlx/include/stlx/cond.h
+++ b/userland/lib/libstlx/include/stlx/cond.h
@@ -1,0 +1,21 @@
+#ifndef STLX_COND_H
+#define STLX_COND_H
+
+#include <stdint.h>
+#include <stlx/mutex.h>
+
+typedef struct { uint32_t seq; } stlx_cond_t;
+
+#define STLX_COND_INIT { 0 }
+
+/* Atomically unlocks the mutex and sleeps until signaled, then re-locks.
+ * Callers must re-check the predicate in a loop (spurious wakeups allowed). */
+void stlx_cond_wait(stlx_cond_t* cv, stlx_mutex_t* m);
+
+/* Wake one waiter. */
+void stlx_cond_signal(stlx_cond_t* cv);
+
+/* Wake all waiters. */
+void stlx_cond_broadcast(stlx_cond_t* cv);
+
+#endif /* STLX_COND_H */

--- a/userland/lib/libstlx/include/stlx/cond.h
+++ b/userland/lib/libstlx/include/stlx/cond.h
@@ -4,6 +4,10 @@
 #include <stdint.h>
 #include <stlx/mutex.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct { uint32_t seq; } stlx_cond_t;
 
 #define STLX_COND_INIT { 0 }
@@ -17,5 +21,9 @@ void stlx_cond_signal(stlx_cond_t* cv);
 
 /* Wake all waiters. */
 void stlx_cond_broadcast(stlx_cond_t* cv);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* STLX_COND_H */

--- a/userland/lib/libstlx/include/stlx/futex.h
+++ b/userland/lib/libstlx/include/stlx/futex.h
@@ -1,0 +1,16 @@
+#ifndef STLX_FUTEX_H
+#define STLX_FUTEX_H
+
+#include <stdint.h>
+
+/* Block if *addr == expected. timeout_ns=0 waits indefinitely.
+ * Returns 0 on wake, negative errno on error (-EAGAIN, -ETIMEDOUT). */
+int stlx_futex_wait(uint32_t* addr, uint32_t expected, uint64_t timeout_ns);
+
+/* Wake up to count threads waiting on addr. Returns number woken. */
+int stlx_futex_wake(uint32_t* addr, uint32_t count);
+
+/* Wake all threads waiting on addr. Returns number woken. */
+int stlx_futex_wake_all(uint32_t* addr);
+
+#endif /* STLX_FUTEX_H */

--- a/userland/lib/libstlx/include/stlx/futex.h
+++ b/userland/lib/libstlx/include/stlx/futex.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Block if *addr == expected. timeout_ns=0 waits indefinitely.
  * Returns 0 on wake, negative errno on error (-EAGAIN, -ETIMEDOUT). */
 int stlx_futex_wait(uint32_t* addr, uint32_t expected, uint64_t timeout_ns);
@@ -12,5 +16,9 @@ int stlx_futex_wake(uint32_t* addr, uint32_t count);
 
 /* Wake all threads waiting on addr. Returns number woken. */
 int stlx_futex_wake_all(uint32_t* addr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* STLX_FUTEX_H */

--- a/userland/lib/libstlx/include/stlx/mutex.h
+++ b/userland/lib/libstlx/include/stlx/mutex.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* State 0: unlocked, 1: locked (no waiters), 2: locked (with waiters) */
 typedef struct { uint32_t state; } stlx_mutex_t;
 
@@ -13,5 +17,9 @@ void stlx_mutex_unlock(stlx_mutex_t* m);
 
 /* Returns 0 if acquired, -1 if already held. */
 int stlx_mutex_trylock(stlx_mutex_t* m);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* STLX_MUTEX_H */

--- a/userland/lib/libstlx/include/stlx/mutex.h
+++ b/userland/lib/libstlx/include/stlx/mutex.h
@@ -1,0 +1,17 @@
+#ifndef STLX_MUTEX_H
+#define STLX_MUTEX_H
+
+#include <stdint.h>
+
+/* State 0: unlocked, 1: locked (no waiters), 2: locked (with waiters) */
+typedef struct { uint32_t state; } stlx_mutex_t;
+
+#define STLX_MUTEX_INIT { 0 }
+
+void stlx_mutex_lock(stlx_mutex_t* m);
+void stlx_mutex_unlock(stlx_mutex_t* m);
+
+/* Returns 0 if acquired, -1 if already held. */
+int stlx_mutex_trylock(stlx_mutex_t* m);
+
+#endif /* STLX_MUTEX_H */

--- a/userland/lib/libstlx/include/stlx/proc.h
+++ b/userland/lib/libstlx/include/stlx/proc.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Wait status decode macros (Linux-compatible bit layout). */
 #define STLX_WIFEXITED(s)    (((s) & 0x7F) == 0)
 #define STLX_WEXITSTATUS(s)  (((s) >> 8) & 0xFF)
@@ -95,5 +99,9 @@ static inline int proc_thread_start(int handle) { return proc_start(handle); }
 static inline int proc_thread_join(int handle, int* exit_code) { return proc_wait(handle, exit_code); }
 static inline int proc_thread_detach(int handle) { return proc_detach(handle); }
 static inline int proc_thread_kill(int handle) { return proc_kill(handle); }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* STLX_PROC_H */

--- a/userland/lib/libstlx/include/stlx/syscall_nums.h
+++ b/userland/lib/libstlx/include/stlx/syscall_nums.h
@@ -12,4 +12,8 @@
 #define SYS_PROC_KILL_TID       1018
 #define SYS_PTY_CREATE          1020
 
+#define SYS_FUTEX_WAIT          1030
+#define SYS_FUTEX_WAKE          1031
+#define SYS_FUTEX_WAKE_ALL      1032
+
 #endif /* STLX_SYSCALL_NUMS_H */

--- a/userland/lib/libstlx/src/barrier.c
+++ b/userland/lib/libstlx/src/barrier.c
@@ -9,10 +9,13 @@ void stlx_barrier_init(stlx_barrier_t* b, uint32_t count) {
 
 void stlx_barrier_wait(stlx_barrier_t* b) {
     uint32_t gen = __atomic_load_n(&b->generation, __ATOMIC_ACQUIRE);
+
+    // Count grows monotonically (no reset). The last thread in each round
+    // is identified by count being a multiple of total. This eliminates
+    // the race between resetting count and advancing generation.
     uint32_t arrived = __atomic_fetch_add(&b->count, 1, __ATOMIC_ACQ_REL) + 1;
 
-    if (arrived == b->total) {
-        __atomic_store_n(&b->count, 0, __ATOMIC_RELAXED);
+    if (arrived % b->total == 0) {
         __atomic_fetch_add(&b->generation, 1, __ATOMIC_RELEASE);
         stlx_futex_wake_all(&b->generation);
     } else {

--- a/userland/lib/libstlx/src/barrier.c
+++ b/userland/lib/libstlx/src/barrier.c
@@ -13,7 +13,7 @@ void stlx_barrier_wait(stlx_barrier_t* b) {
     // Count grows monotonically (no reset). The last thread in each round
     // is identified by count being a multiple of total. This eliminates
     // the race between resetting count and advancing generation.
-    uint32_t arrived = __atomic_fetch_add(&b->count, 1, __ATOMIC_ACQ_REL) + 1;
+    uint64_t arrived = __atomic_fetch_add(&b->count, 1, __ATOMIC_ACQ_REL) + 1;
 
     if (arrived % b->total == 0) {
         __atomic_fetch_add(&b->generation, 1, __ATOMIC_RELEASE);

--- a/userland/lib/libstlx/src/barrier.c
+++ b/userland/lib/libstlx/src/barrier.c
@@ -1,0 +1,23 @@
+#include <stlx/barrier.h>
+#include <stlx/futex.h>
+
+void stlx_barrier_init(stlx_barrier_t* b, uint32_t count) {
+    b->count = 0;
+    b->generation = 0;
+    b->total = count;
+}
+
+void stlx_barrier_wait(stlx_barrier_t* b) {
+    uint32_t gen = __atomic_load_n(&b->generation, __ATOMIC_ACQUIRE);
+    uint32_t arrived = __atomic_fetch_add(&b->count, 1, __ATOMIC_ACQ_REL) + 1;
+
+    if (arrived == b->total) {
+        __atomic_store_n(&b->count, 0, __ATOMIC_RELAXED);
+        __atomic_fetch_add(&b->generation, 1, __ATOMIC_RELEASE);
+        stlx_futex_wake_all(&b->generation);
+    } else {
+        while (__atomic_load_n(&b->generation, __ATOMIC_ACQUIRE) == gen) {
+            stlx_futex_wait(&b->generation, gen, 0);
+        }
+    }
+}

--- a/userland/lib/libstlx/src/cond.c
+++ b/userland/lib/libstlx/src/cond.c
@@ -1,0 +1,19 @@
+#include <stlx/cond.h>
+#include <stlx/futex.h>
+
+void stlx_cond_wait(stlx_cond_t* cv, stlx_mutex_t* m) {
+    uint32_t seq = __atomic_load_n(&cv->seq, __ATOMIC_RELAXED);
+    stlx_mutex_unlock(m);
+    stlx_futex_wait(&cv->seq, seq, 0);
+    stlx_mutex_lock(m);
+}
+
+void stlx_cond_signal(stlx_cond_t* cv) {
+    __atomic_fetch_add(&cv->seq, 1, __ATOMIC_RELEASE);
+    stlx_futex_wake(&cv->seq, 1);
+}
+
+void stlx_cond_broadcast(stlx_cond_t* cv) {
+    __atomic_fetch_add(&cv->seq, 1, __ATOMIC_RELEASE);
+    stlx_futex_wake_all(&cv->seq);
+}

--- a/userland/lib/libstlx/src/futex.c
+++ b/userland/lib/libstlx/src/futex.c
@@ -1,0 +1,16 @@
+#define _GNU_SOURCE
+#include <stlx/futex.h>
+#include <stlx/syscall_nums.h>
+#include <unistd.h>
+
+int stlx_futex_wait(uint32_t* addr, uint32_t expected, uint64_t timeout_ns) {
+    return (int)syscall(SYS_FUTEX_WAIT, addr, expected, timeout_ns);
+}
+
+int stlx_futex_wake(uint32_t* addr, uint32_t count) {
+    return (int)syscall(SYS_FUTEX_WAKE, addr, count);
+}
+
+int stlx_futex_wake_all(uint32_t* addr) {
+    return (int)syscall(SYS_FUTEX_WAKE_ALL, addr);
+}

--- a/userland/lib/libstlx/src/mutex.c
+++ b/userland/lib/libstlx/src/mutex.c
@@ -1,0 +1,35 @@
+#include <stlx/mutex.h>
+#include <stlx/futex.h>
+
+void stlx_mutex_lock(stlx_mutex_t* m) {
+    uint32_t c = 0;
+    if (__atomic_compare_exchange_n(&m->state, &c, 1, 0,
+            __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)) {
+        return;
+    }
+
+    do {
+        if (c == 2 || __atomic_compare_exchange_n(&m->state, &c, 2, 0,
+                __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+            stlx_futex_wait(&m->state, 2, 0);
+        }
+        c = 0;
+    } while (!__atomic_compare_exchange_n(&m->state, &c, 2, 0,
+                __ATOMIC_ACQUIRE, __ATOMIC_RELAXED));
+}
+
+void stlx_mutex_unlock(stlx_mutex_t* m) {
+    uint32_t prev = __atomic_exchange_n(&m->state, 0, __ATOMIC_RELEASE);
+    if (prev == 2) {
+        stlx_futex_wake(&m->state, 1);
+    }
+}
+
+int stlx_mutex_trylock(stlx_mutex_t* m) {
+    uint32_t c = 0;
+    if (__atomic_compare_exchange_n(&m->state, &c, 1, 0,
+            __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)) {
+        return 0;
+    }
+    return -1;
+}

--- a/userland/lib/libstlxcxx/Makefile
+++ b/userland/lib/libstlxcxx/Makefile
@@ -1,0 +1,47 @@
+#
+# Stellux Userland - libstlxcxx Static Library
+#
+# C++ threading wrappers (stlxstd::thread, mutex, etc.) built on libstlx.
+#
+
+USERLAND_ROOT ?= $(shell cd $(dir $(lastword $(MAKEFILE_LIST)))/../.. && pwd)
+include $(USERLAND_ROOT)/mk/toolchain.mk
+
+AR ?= llvm-ar
+
+SRC_DIR     := src
+INCLUDE_DIR := include
+BUILD_DIR   := build/$(ARCH)
+LIB_NAME    := libstlxcxx.a
+TARGET      := $(BUILD_DIR)/$(LIB_NAME)
+
+SYSROOT_LIB := $(USERLAND_ROOT)/sysroot/$(ARCH)/lib
+SYSROOT_INC := $(USERLAND_ROOT)/sysroot/$(ARCH)/include/stlxstd
+
+SOURCES := $(wildcard $(SRC_DIR)/*.cpp)
+OBJECTS := $(SOURCES:$(SRC_DIR)/%.cpp=$(BUILD_DIR)/%.o)
+
+all: $(TARGET) install-headers
+
+$(TARGET): $(OBJECTS)
+	$(UQ)mkdir -p $(dir $@)
+	@echo "[AR]  libstlxcxx.a ($(ARCH))"
+	$(UQ)$(AR) crs $@ $(OBJECTS)
+	$(UQ)mkdir -p $(SYSROOT_LIB)
+	$(UQ)cp $@ $(SYSROOT_LIB)/
+
+install-headers:
+	$(UQ)mkdir -p $(SYSROOT_INC)
+	$(UQ)cp $(INCLUDE_DIR)/stlxstd/*.h $(SYSROOT_INC)/
+
+$(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp
+	$(UQ)mkdir -p $(dir $@)
+	@echo "[CXX] $< ($(ARCH))"
+	$(UQ)$(CXX) $(CXXFLAGS_COMMON) -I$(INCLUDE_DIR) -c $< -o $@
+
+clean:
+	$(UQ)rm -rf build
+	$(UQ)rm -f $(SYSROOT_LIB)/$(LIB_NAME)
+	$(UQ)rm -rf $(SYSROOT_INC)
+
+.PHONY: all install-headers clean

--- a/userland/lib/libstlxcxx/include/stlxstd/barrier.h
+++ b/userland/lib/libstlxcxx/include/stlxstd/barrier.h
@@ -1,0 +1,28 @@
+#ifndef STLXSTD_BARRIER_H
+#define STLXSTD_BARRIER_H
+
+#include <stlx/barrier.h>
+#include <stdint.h>
+
+namespace stlxstd {
+
+class barrier {
+public:
+    explicit barrier(uint32_t count) {
+        stlx_barrier_init(&b_, count);
+    }
+
+    ~barrier() = default;
+
+    barrier(const barrier&) = delete;
+    barrier& operator=(const barrier&) = delete;
+
+    void arrive_and_wait() { stlx_barrier_wait(&b_); }
+
+private:
+    stlx_barrier_t b_;
+};
+
+} // namespace stlxstd
+
+#endif // STLXSTD_BARRIER_H

--- a/userland/lib/libstlxcxx/include/stlxstd/condition_variable.h
+++ b/userland/lib/libstlxcxx/include/stlxstd/condition_variable.h
@@ -1,0 +1,35 @@
+#ifndef STLXSTD_CONDITION_VARIABLE_H
+#define STLXSTD_CONDITION_VARIABLE_H
+
+#include <stlx/cond.h>
+#include <stlxstd/mutex.h>
+
+namespace stlxstd {
+
+class condition_variable {
+public:
+    condition_variable() : cv_(STLX_COND_INIT) {}
+    ~condition_variable() = default;
+
+    condition_variable(const condition_variable&) = delete;
+    condition_variable& operator=(const condition_variable&) = delete;
+
+    void wait(unique_lock<mutex>& lock) {
+        stlx_cond_wait(&cv_, lock.mutex_ptr()->native());
+    }
+
+    template<typename Pred>
+    void wait(unique_lock<mutex>& lock, Pred pred) {
+        while (!pred()) wait(lock);
+    }
+
+    void notify_one() { stlx_cond_signal(&cv_); }
+    void notify_all() { stlx_cond_broadcast(&cv_); }
+
+private:
+    stlx_cond_t cv_;
+};
+
+} // namespace stlxstd
+
+#endif // STLXSTD_CONDITION_VARIABLE_H

--- a/userland/lib/libstlxcxx/include/stlxstd/mutex.h
+++ b/userland/lib/libstlxcxx/include/stlxstd/mutex.h
@@ -1,0 +1,82 @@
+#ifndef STLXSTD_MUTEX_H
+#define STLXSTD_MUTEX_H
+
+#include <stlx/mutex.h>
+
+namespace stlxstd {
+
+struct defer_lock_t {};
+inline constexpr defer_lock_t defer_lock{};
+
+class mutex {
+public:
+    mutex() : m_(STLX_MUTEX_INIT) {}
+    ~mutex() = default;
+
+    mutex(const mutex&) = delete;
+    mutex& operator=(const mutex&) = delete;
+
+    void lock() { stlx_mutex_lock(&m_); }
+    void unlock() { stlx_mutex_unlock(&m_); }
+    bool try_lock() { return stlx_mutex_trylock(&m_) == 0; }
+
+    stlx_mutex_t* native() { return &m_; }
+
+private:
+    stlx_mutex_t m_;
+};
+
+template<typename Mutex>
+class lock_guard {
+public:
+    explicit lock_guard(Mutex& m) : m_(m) { m_.lock(); }
+    ~lock_guard() { m_.unlock(); }
+
+    lock_guard(const lock_guard&) = delete;
+    lock_guard& operator=(const lock_guard&) = delete;
+
+private:
+    Mutex& m_;
+};
+
+template<typename Mutex>
+class unique_lock {
+public:
+    explicit unique_lock(Mutex& m) : m_(&m), owned_(true) { m_->lock(); }
+    unique_lock(Mutex& m, defer_lock_t) : m_(&m), owned_(false) {}
+    ~unique_lock() { if (owned_) m_->unlock(); }
+
+    unique_lock(const unique_lock&) = delete;
+    unique_lock& operator=(const unique_lock&) = delete;
+
+    unique_lock(unique_lock&& o) : m_(o.m_), owned_(o.owned_) {
+        o.m_ = nullptr;
+        o.owned_ = false;
+    }
+
+    unique_lock& operator=(unique_lock&& o) {
+        if (this != &o) {
+            if (owned_) m_->unlock();
+            m_ = o.m_;
+            owned_ = o.owned_;
+            o.m_ = nullptr;
+            o.owned_ = false;
+        }
+        return *this;
+    }
+
+    void lock() { m_->lock(); owned_ = true; }
+    void unlock() { m_->unlock(); owned_ = false; }
+    bool try_lock() { owned_ = m_->try_lock(); return owned_; }
+
+    bool owns_lock() const { return owned_; }
+    Mutex* mutex_ptr() const { return m_; }
+
+private:
+    Mutex* m_;
+    bool owned_;
+};
+
+} // namespace stlxstd
+
+#endif // STLXSTD_MUTEX_H

--- a/userland/lib/libstlxcxx/include/stlxstd/thread.h
+++ b/userland/lib/libstlxcxx/include/stlxstd/thread.h
@@ -18,11 +18,13 @@ template<typename Fn>
 struct thread_context_impl : thread_context {
     Fn fn;
 
+    static void call(thread_context* base) {
+        auto* self = static_cast<thread_context_impl*>(base);
+        self->fn();
+    }
+
     explicit thread_context_impl(Fn&& f) : fn(static_cast<Fn&&>(f)) {
-        invoke = [](thread_context* base) {
-            auto* self = static_cast<thread_context_impl*>(base);
-            self->fn();
-        };
+        invoke = &call;
     }
 };
 

--- a/userland/lib/libstlxcxx/include/stlxstd/thread.h
+++ b/userland/lib/libstlxcxx/include/stlxstd/thread.h
@@ -8,6 +8,11 @@
 #include <new>
 
 namespace stlxstd {
+
+template<typename T> struct remove_ref { using type = T; };
+template<typename T> struct remove_ref<T&> { using type = T; };
+template<typename T> struct remove_ref<T&&> { using type = T; };
+
 namespace detail {
 
 struct thread_context {
@@ -47,7 +52,10 @@ public:
 
     template<typename Fn>
     explicit thread(Fn&& fn) {
-        using ctx_t = detail::thread_context_impl<Fn>;
+        // Decay Fn so lvalue references become value types (same as std::thread).
+        // Without this, passing an lvalue stores a reference that can dangle.
+        using Decayed = typename remove_ref<Fn>::type;
+        using ctx_t = detail::thread_context_impl<Decayed>;
         auto* ctx = static_cast<ctx_t*>(malloc(sizeof(ctx_t)));
         if (!ctx) abort();
         new (ctx) ctx_t(static_cast<Fn&&>(fn));

--- a/userland/lib/libstlxcxx/include/stlxstd/thread.h
+++ b/userland/lib/libstlxcxx/include/stlxstd/thread.h
@@ -12,6 +12,7 @@ namespace detail {
 
 struct thread_context {
     void (*invoke)(thread_context*);
+    void (*destroy)(thread_context*);
 };
 
 template<typename Fn>
@@ -23,8 +24,13 @@ struct thread_context_impl : thread_context {
         self->fn();
     }
 
+    static void destruct(thread_context* base) {
+        static_cast<thread_context_impl*>(base)->~thread_context_impl();
+    }
+
     explicit thread_context_impl(Fn&& f) : fn(static_cast<Fn&&>(f)) {
         invoke = &call;
+        destroy = &destruct;
     }
 };
 

--- a/userland/lib/libstlxcxx/include/stlxstd/thread.h
+++ b/userland/lib/libstlxcxx/include/stlxstd/thread.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <new>
 
 namespace stlxstd {
 namespace detail {

--- a/userland/lib/libstlxcxx/include/stlxstd/thread.h
+++ b/userland/lib/libstlxcxx/include/stlxstd/thread.h
@@ -1,0 +1,117 @@
+#ifndef STLXSTD_THREAD_H
+#define STLXSTD_THREAD_H
+
+#include <stlx/proc.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+namespace stlxstd {
+namespace detail {
+
+struct thread_context {
+    void (*invoke)(thread_context*);
+};
+
+template<typename Fn>
+struct thread_context_impl : thread_context {
+    Fn fn;
+
+    explicit thread_context_impl(Fn&& f) : fn(static_cast<Fn&&>(f)) {
+        invoke = [](thread_context* base) {
+            auto* self = static_cast<thread_context_impl*>(base);
+            self->fn();
+        };
+    }
+};
+
+// Defined in thread.cpp
+extern "C" void stlxstd_thread_entry(void* arg);
+
+} // namespace detail
+
+class thread {
+public:
+    static constexpr size_t STACK_SIZE = 64 * 1024;
+
+    thread() : m_handle(-1), m_stack(nullptr) {}
+
+    template<typename Fn>
+    explicit thread(Fn&& fn) {
+        using ctx_t = detail::thread_context_impl<Fn>;
+        auto* ctx = static_cast<ctx_t*>(malloc(sizeof(ctx_t)));
+        if (!ctx) abort();
+        new (ctx) ctx_t(static_cast<Fn&&>(fn));
+
+        m_stack = mmap(nullptr, STACK_SIZE, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+        if (m_stack == MAP_FAILED) {
+            ctx->~ctx_t();
+            free(ctx);
+            abort();
+        }
+
+        void* stack_top = static_cast<char*>(m_stack) + STACK_SIZE;
+        m_handle = proc_create_thread(detail::stlxstd_thread_entry, ctx,
+                                      stack_top, "stlxstd");
+        if (m_handle < 0) {
+            ctx->~ctx_t();
+            free(ctx);
+            munmap(m_stack, STACK_SIZE);
+            m_stack = nullptr;
+            abort();
+        }
+
+        proc_thread_start(m_handle);
+    }
+
+    ~thread() {
+        if (joinable()) abort();
+    }
+
+    thread(const thread&) = delete;
+    thread& operator=(const thread&) = delete;
+
+    thread(thread&& o) : m_handle(o.m_handle), m_stack(o.m_stack) {
+        o.m_handle = -1;
+        o.m_stack = nullptr;
+    }
+
+    thread& operator=(thread&& o) {
+        if (this != &o) {
+            if (joinable()) abort();
+            m_handle = o.m_handle;
+            m_stack = o.m_stack;
+            o.m_handle = -1;
+            o.m_stack = nullptr;
+        }
+        return *this;
+    }
+
+    bool joinable() const { return m_handle >= 0; }
+
+    void join() {
+        if (!joinable()) return;
+        proc_thread_join(m_handle, nullptr);
+        munmap(m_stack, STACK_SIZE);
+        m_handle = -1;
+        m_stack = nullptr;
+    }
+
+    // Stack is intentionally not freed on detach. The thread is still
+    // using it. It will be reclaimed when the process exits.
+    void detach() {
+        if (!joinable()) return;
+        proc_thread_detach(m_handle);
+        m_handle = -1;
+        m_stack = nullptr;
+    }
+
+private:
+    int m_handle;
+    void* m_stack;
+};
+
+} // namespace stlxstd
+
+#endif // STLXSTD_THREAD_H

--- a/userland/lib/libstlxcxx/src/thread.cpp
+++ b/userland/lib/libstlxcxx/src/thread.cpp
@@ -7,6 +7,7 @@ namespace stlxstd::detail {
 extern "C" void stlxstd_thread_entry(void* arg) {
     auto* ctx = static_cast<thread_context*>(arg);
     ctx->invoke(ctx);
+    ctx->destroy(ctx);
     free(ctx);
     _exit(0);
 }

--- a/userland/lib/libstlxcxx/src/thread.cpp
+++ b/userland/lib/libstlxcxx/src/thread.cpp
@@ -1,0 +1,14 @@
+#include <stlxstd/thread.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+namespace stlxstd::detail {
+
+extern "C" void stlxstd_thread_entry(void* arg) {
+    auto* ctx = static_cast<thread_context*>(arg);
+    ctx->invoke(ctx);
+    free(ctx);
+    _exit(0);
+}
+
+} // namespace stlxstd::detail


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Builds the userland synchronization stack on top of the kernel futex primitive (merged in #123). Three layers:

### C Layer (libstlx extensions)
- **`stlx_futex_wait/wake/wake_all`** — thin syscall wrappers for SYS_FUTEX_WAIT/WAKE/WAKE_ALL
- **`stlx_mutex_t`** — three-state mutex (Drepper algorithm): atomic CAS fast path, futex slow path
- **`stlx_cond_t`** — sequence-counter condition variable
- **`stlx_barrier_t`** — generation-counter reusable barrier

### C++ Layer (new libstlxcxx)
- **`stlxstd::thread`** — RAII thread with mmap'd stack, join/detach, type-erased callable support
- **`stlxstd::mutex`** — wraps `stlx_mutex_t`
- **`stlxstd::lock_guard<M>` / `unique_lock<M>`** — RAII lock management
- **`stlxstd::condition_variable`** — wraps `stlx_cond_t` with predicated wait
- **`stlxstd::barrier`** — wraps `stlx_barrier_t`

### Test App
- **`synctest`** — validates all primitives: mutex stress (8 threads × 10K iterations), condvar producer/consumer, barrier synchronization, thread join/detach, multi-mutex independence

### Kernel Fix
- **TLS inheritance for user threads** — `create_user_thread` now inherits the creator's TLS base instead of setting it to 0. Without this, any `%fs`-relative access (musl errno, malloc, etc.) in a child thread would null-deref.

## Design Decisions
- Uncontended mutex lock/unlock is a single atomic CAS — zero syscalls
- `stlxstd::thread` detach intentionally leaks the stack (freed at process exit) — can't munmap a stack you're running on
- Thread callable dispatch uses function pointer (no virtual/RTTI dependency)
- Apps opt into libstlxcxx via `APP_LIBS := stlxcxx` in their Makefile
- All libstlx C headers now have `extern "C"` guards for C++ linkage

## Testing
- All 509 kernel unit tests pass
- Both x86_64 and aarch64 userland builds succeed (40/40 apps)
- synctest passes all 6 tests on Stellux x86_64
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d6b4de0-6523-4db4-8f47-b325c125ecba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d6b4de0-6523-4db4-8f47-b325c125ecba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

