### PR TITLE
fix(kernel): defined sized+aligned operator delete for clang >= 19

### DIFF
--- a/kernel/common/cxx_abi.cpp
+++ b/kernel/common/cxx_abi.cpp
@@ -22,3 +22,8 @@ void operator delete(void*, unsigned long) noexcept {
 void operator delete(void*, std::align_val_t) noexcept {
     log::fatal("operator delete(void*, align_val_t) called in freestanding kernel");
 }
+
+// Emitted by clang >= 19, which enables C++14 sized deallocation by default.
+void operator delete(void*, unsigned long, std::align_val_t) noexcept {
+    log::fatal("operator delete(void*, size_t, align_val_t) called in freestanding kernel");
+}


### PR DESCRIPTION
## Summary
- Kernels failed to link with clang >= 19 (and Apple clang 17, which is LLVM 19 based): sized deallocation became the compiler default, emitting references to the sized+aligned `operator delete` that the freestanding ABI shims never defined.
- Define the missing overload as a `log::fatal` trap like its siblings, preserving the kernel's no-delete contract.

Made with [Cursor](https://cursor.com)