### PR TITLE
feat(build): centralized host toolchain resolution in scripts/host.mk

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -19,10 +19,14 @@ RELEASE ?= 0
 # Toolchain
 # ============================================================================
 
-CXX := clang++
-AS := clang
-LD := ld.lld
-OBJCOPY := llvm-objcopy
+# Host toolchain resolution (Linux: PATH names, macOS: Homebrew LLVM keg).
+# Path is computed from this file's location since it is included from kernel/.
+include $(dir $(lastword $(MAKEFILE_LIST)))scripts/host.mk
+
+CXX := $(STLX_CXX)
+AS := $(STLX_CC)
+LD := $(STLX_LLD)
+OBJCOPY := $(STLX_OBJCOPY)
 
 # ============================================================================
 # Debug Flags

--- a/scripts/host.mk
+++ b/scripts/host.mk
@@ -1,0 +1,43 @@
+#
+# host.mk - Host OS detection and toolchain resolution
+#
+# Central host interface: consumer makefiles use the
+# STLX_* variables and never branch on the host OS.
+#
+
+ifndef STLX_HOST_MK_INCLUDED
+STLX_HOST_MK_INCLUDED := 1
+
+HOST_OS := $(shell uname -s)
+
+ifeq ($(HOST_OS),Darwin)
+
+# Homebrew LLVM keg (Apple Silicon, then Intel prefix). Overridable.
+STLX_LLVM_DIR ?= $(firstword $(wildcard /opt/homebrew/opt/llvm /usr/local/opt/llvm))
+
+# $(1) = tool inside the llvm keg, $(2) = PATH fallback (also used when no keg)
+stlx_llvm_tool = $(if $(and $(STLX_LLVM_DIR),$(wildcard $(STLX_LLVM_DIR)/bin/$(1))),$(STLX_LLVM_DIR)/bin/$(1),$(2))
+
+STLX_CC      := $(call stlx_llvm_tool,clang,clang)
+STLX_CXX     := $(call stlx_llvm_tool,clang++,clang++)
+STLX_LLD     := $(call stlx_llvm_tool,ld.lld,ld.lld)
+STLX_AR      := $(call stlx_llvm_tool,llvm-ar,llvm-ar)
+STLX_RANLIB  := $(call stlx_llvm_tool,llvm-ranlib,llvm-ranlib)
+STLX_OBJCOPY := $(call stlx_llvm_tool,llvm-objcopy,llvm-objcopy)
+
+else
+
+STLX_CC      := clang
+STLX_CXX     := clang++
+STLX_LLD     := ld.lld
+STLX_AR      := llvm-ar
+STLX_RANLIB  := llvm-ranlib
+STLX_OBJCOPY := llvm-objcopy
+
+endif
+
+# Fail at parse time if the interface is incomplete for this host.
+$(foreach v,HOST_OS STLX_CC STLX_CXX STLX_LLD STLX_AR STLX_RANLIB STLX_OBJCOPY,\
+	$(if $($(v)),,$(error scripts/host.mk: $(v) is undefined for host '$(HOST_OS)')))
+
+endif # STLX_HOST_MK_INCLUDED

--- a/userland/lib/libbearssl/Makefile
+++ b/userland/lib/libbearssl/Makefile
@@ -12,8 +12,6 @@
 USERLAND_ROOT ?= $(shell cd $(dir $(lastword $(MAKEFILE_LIST)))/../.. && pwd)
 include $(USERLAND_ROOT)/mk/toolchain.mk
 
-AR ?= llvm-ar
-
 BUILD_DIR   := build/$(ARCH)
 LIB_NAME    := libbearssl.a
 TARGET      := $(BUILD_DIR)/$(LIB_NAME)

--- a/userland/lib/libstlx/Makefile
+++ b/userland/lib/libstlx/Makefile
@@ -5,8 +5,6 @@
 USERLAND_ROOT ?= $(shell cd $(dir $(lastword $(MAKEFILE_LIST)))/../.. && pwd)
 include $(USERLAND_ROOT)/mk/toolchain.mk
 
-AR ?= llvm-ar
-
 SRC_DIR     := src
 INCLUDE_DIR := include
 BUILD_DIR   := build/$(ARCH)

--- a/userland/lib/libstlxcxx/Makefile
+++ b/userland/lib/libstlxcxx/Makefile
@@ -7,8 +7,6 @@
 USERLAND_ROOT ?= $(shell cd $(dir $(lastword $(MAKEFILE_LIST)))/../.. && pwd)
 include $(USERLAND_ROOT)/mk/toolchain.mk
 
-AR ?= llvm-ar
-
 SRC_DIR     := src
 INCLUDE_DIR := include
 BUILD_DIR   := build/$(ARCH)

--- a/userland/lib/libstlxgfx/Makefile
+++ b/userland/lib/libstlxgfx/Makefile
@@ -5,8 +5,6 @@
 USERLAND_ROOT ?= $(shell cd $(dir $(lastword $(MAKEFILE_LIST)))/../.. && pwd)
 include $(USERLAND_ROOT)/mk/toolchain.mk
 
-AR ?= llvm-ar
-
 SRC_DIR     := src
 INCLUDE_DIR := include
 BUILD_DIR   := build/$(ARCH)

--- a/userland/mk/toolchain.mk
+++ b/userland/mk/toolchain.mk
@@ -5,8 +5,12 @@
 # Included by app.mk and other build rules.
 #
 
-CC  := clang
-CXX := clang++
+# Host toolchain resolution via the shared host interface.
+include $(USERLAND_ROOT)/../scripts/host.mk
+
+CC  := $(STLX_CC)
+CXX := $(STLX_CXX)
+AR  := $(STLX_AR)
 
 SYSROOT := $(USERLAND_ROOT)/sysroot/$(ARCH)
 TARGET_TRIPLE := $(ARCH)-linux-musl


### PR DESCRIPTION
## Summary
- Toolchain names were hardcoded in `config.mk` and `userland/mk/toolchain.mk`, blocking macOS hosts where LLVM is keg-only and Apple's `ar`/`ranlib` cannot index ELF archives.
- `scripts/host.mk` now exports a validated `STLX_*` tool interface — plain PATH names on Linux, Homebrew LLVM keg on macOS — and consumer makefiles never branch on the host OS.
- Userland archives use `llvm-ar` explicitly; the removed `AR ?= llvm-ar` lines never took effect because make's built-in `AR` default already defines the variable.

Made with [Cursor](https://cursor.com)