### PR TITLE
feat(build): portable sysroot pipeline (musl, libc++, compiler-rt)

### DIFF
--- a/.github/workflows/kernel-unit-tests.yml
+++ b/.github/workflows/kernel-unit-tests.yml
@@ -84,7 +84,7 @@ jobs:
         id: musl-cache
         with:
           path: userland/sysroot
-          key: musl-sysroot-1.2.5
+          key: musl-sysroot-1.2.5-v2
 
       - name: Build musl libc
         if: steps.musl-cache.outputs.cache-hit != 'true'
@@ -103,7 +103,7 @@ jobs:
             userland/sysroot/aarch64/lib/libc++abi.a
             userland/sysroot/aarch64/lib/libunwind.a
             userland/sysroot/aarch64/include/c++
-          key: libcxx-sysroot-18.1.8
+          key: libcxx-sysroot-18.1.8-v2
 
       - name: Build libc++
         if: steps.libcxx-cache.outputs.cache-hit != 'true'
@@ -116,7 +116,7 @@ jobs:
           path: |
             userland/sysroot/x86_64/lib/libclang_rt.builtins-x86_64.a
             userland/sysroot/aarch64/lib/libclang_rt.builtins-aarch64.a
-          key: compiler-rt-builtins-18.1.8
+          key: compiler-rt-builtins-18.1.8-v2
 
       - name: Build compiler-rt builtins
         if: steps.compiler-rt-cache.outputs.cache-hit != 'true'
@@ -179,7 +179,7 @@ jobs:
         id: musl-cache
         with:
           path: userland/sysroot
-          key: musl-sysroot-1.2.5
+          key: musl-sysroot-1.2.5-v2
 
       - name: Build musl libc
         if: steps.musl-cache.outputs.cache-hit != 'true'
@@ -198,7 +198,7 @@ jobs:
             userland/sysroot/aarch64/lib/libc++abi.a
             userland/sysroot/aarch64/lib/libunwind.a
             userland/sysroot/aarch64/include/c++
-          key: libcxx-sysroot-18.1.8
+          key: libcxx-sysroot-18.1.8-v2
 
       - name: Build libc++
         if: steps.libcxx-cache.outputs.cache-hit != 'true'
@@ -211,7 +211,7 @@ jobs:
           path: |
             userland/sysroot/x86_64/lib/libclang_rt.builtins-x86_64.a
             userland/sysroot/aarch64/lib/libclang_rt.builtins-aarch64.a
-          key: compiler-rt-builtins-18.1.8
+          key: compiler-rt-builtins-18.1.8-v2
 
       - name: Build compiler-rt builtins
         if: steps.compiler-rt-cache.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ compile_commands.json
 userland/sysroot/
 userland/musl-*
 userland/llvm-project-*
+userland/linux-headers-*
 userland/build/
 initrd/bin/*
 initrd/usr/

--- a/Makefile
+++ b/Makefile
@@ -515,6 +515,9 @@ MUSL_URL     := https://musl.libc.org/releases/musl-$(MUSL_VERSION).tar.gz
 MUSL_DIR     := userland/musl-$(MUSL_VERSION)
 MUSL_TARBALL := userland/musl-$(MUSL_VERSION).tar.gz
 
+# LLVM archive tools work on ELF from any host (Apple's ar/ranlib do not).
+MUSL_TOOL_OVERRIDES := AR=$(STLX_AR) RANLIB=$(STLX_RANLIB)
+
 musl:
 	@echo "Building musl $(MUSL_VERSION) for x86_64 and aarch64..."
 	@mkdir -p userland
@@ -528,19 +531,19 @@ musl:
 	@echo "Building musl for x86_64..."
 	@mkdir -p $(MUSL_DIR)/build-x86_64
 	cd $(MUSL_DIR)/build-x86_64 && \
-		CC="clang --target=x86_64-linux-musl" \
+		CC="$(STLX_CC) --target=x86_64-linux-musl" \
 		../configure --prefix=$(abspath userland/sysroot/x86_64) --disable-shared > /dev/null
-	$(MAKE) -C $(MUSL_DIR)/build-x86_64 -j$$(nproc) > /dev/null
-	$(MAKE) -C $(MUSL_DIR)/build-x86_64 install > /dev/null
+	$(MAKE) -C $(MUSL_DIR)/build-x86_64 $(MUSL_TOOL_OVERRIDES) -j$(NPROC) > /dev/null
+	$(MAKE) -C $(MUSL_DIR)/build-x86_64 $(MUSL_TOOL_OVERRIDES) install > /dev/null
 	@echo "musl x86_64 installed to userland/sysroot/x86_64/"
 	@echo ""
 	@echo "Building musl for aarch64..."
 	@mkdir -p $(MUSL_DIR)/build-aarch64
 	cd $(MUSL_DIR)/build-aarch64 && \
-		CC="clang --target=aarch64-linux-musl" \
+		CC="$(STLX_CC) --target=aarch64-linux-musl" \
 		../configure --prefix=$(abspath userland/sysroot/aarch64) --disable-shared > /dev/null
-	$(MAKE) -C $(MUSL_DIR)/build-aarch64 -j$$(nproc) > /dev/null
-	$(MAKE) -C $(MUSL_DIR)/build-aarch64 install > /dev/null
+	$(MAKE) -C $(MUSL_DIR)/build-aarch64 $(MUSL_TOOL_OVERRIDES) -j$(NPROC) > /dev/null
+	$(MAKE) -C $(MUSL_DIR)/build-aarch64 $(MUSL_TOOL_OVERRIDES) install > /dev/null
 	@echo "musl aarch64 installed to userland/sysroot/aarch64/"
 	@echo ""
 	@echo "musl $(MUSL_VERSION) ready for both architectures."
@@ -549,6 +552,17 @@ LLVM_VERSION := 18.1.8
 LLVM_URL     := https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LLVM_VERSION)/llvm-project-$(LLVM_VERSION).src.tar.xz
 LLVM_DIR     := userland/llvm-project-$(LLVM_VERSION).src
 LLVM_TARBALL := userland/llvm-project-$(LLVM_VERSION).src.tar.xz
+
+# Linux UAPI headers for userland apps that include <linux/...>; the
+# per-host sourcing strategy lives in scripts/host.mk.
+.PHONY: linux-headers
+linux-headers:
+	@test -f userland/sysroot/x86_64/lib/libc.a || \
+		(echo "ERROR: musl sysroot not found. Run 'make musl' first." && exit 1)
+	@test -f userland/sysroot/aarch64/lib/libc.a || \
+		(echo "ERROR: musl sysroot not found. Run 'make musl' first." && exit 1)
+	@echo "Installing Linux kernel headers into sysroots..."
+	$(HOST_SYSROOT_HEADERS_INSTALL)
 
 libcxx:
 	@echo "Building libc++ $(LLVM_VERSION) for x86_64 and aarch64..."
@@ -564,22 +578,19 @@ libcxx:
 		(echo "Extracting..." && \
 		 cd userland && tar xf llvm-project-$(LLVM_VERSION).src.tar.xz)
 	@echo ""
-	@echo "Installing Linux kernel headers into sysroots..."
-	@cp -r /usr/include/linux userland/sysroot/x86_64/include/
-	@cp -r /usr/include/asm-generic userland/sysroot/x86_64/include/
-	@cp -r /usr/include/x86_64-linux-gnu/asm userland/sysroot/x86_64/include/
-	@cp -r /usr/aarch64-linux-gnu/include/linux userland/sysroot/aarch64/include/
-	@cp -r /usr/aarch64-linux-gnu/include/asm-generic userland/sysroot/aarch64/include/
-	@cp -r /usr/aarch64-linux-gnu/include/asm userland/sysroot/aarch64/include/
+	$(Q)$(MAKE) --no-print-directory linux-headers
 	@echo ""
 	@echo "Building libc++ for x86_64..."
 	@mkdir -p $(LLVM_DIR)/build-x86_64
 	cd $(LLVM_DIR)/build-x86_64 && cmake -G "Unix Makefiles" ../runtimes \
+		$(CMAKE_HOST_FLAGS) \
 		-DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
-		-DCMAKE_C_COMPILER=clang \
-		-DCMAKE_CXX_COMPILER=clang++ \
+		-DCMAKE_C_COMPILER=$(STLX_CC) \
+		-DCMAKE_CXX_COMPILER=$(STLX_CXX) \
+		-DCMAKE_ASM_COMPILER=$(STLX_CC) \
 		-DCMAKE_C_COMPILER_TARGET=x86_64-linux-musl \
 		-DCMAKE_CXX_COMPILER_TARGET=x86_64-linux-musl \
+		-DCMAKE_ASM_COMPILER_TARGET=x86_64-linux-musl \
 		-DCMAKE_SYSROOT=$(abspath userland/sysroot/x86_64) \
 		-DCMAKE_INSTALL_PREFIX=$(abspath userland/sysroot/x86_64) \
 		-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
@@ -604,18 +615,20 @@ libcxx:
 		-DLIBUNWIND_USE_COMPILER_RT=ON \
 		'-DCMAKE_C_FLAGS=--target=x86_64-linux-musl --sysroot=$(abspath userland/sysroot/x86_64)' \
 		'-DCMAKE_CXX_FLAGS=--target=x86_64-linux-musl --sysroot=$(abspath userland/sysroot/x86_64) -nostdinc++ -nostdlib++' \
+		'-DCMAKE_ASM_FLAGS=--target=x86_64-linux-musl --sysroot=$(abspath userland/sysroot/x86_64)' \
 		> /dev/null
-	$(MAKE) -C $(LLVM_DIR)/build-x86_64 -j$$(nproc) cxx cxxabi unwind > /dev/null
+	$(MAKE) -C $(LLVM_DIR)/build-x86_64 -j$(NPROC) cxx cxxabi unwind > /dev/null
 	$(MAKE) -C $(LLVM_DIR)/build-x86_64 install-cxx install-cxxabi install-unwind > /dev/null
 	@echo "libc++ x86_64 installed to userland/sysroot/x86_64/"
 	@echo ""
 	@echo "Building libc++ for aarch64..."
 	@mkdir -p $(LLVM_DIR)/build-aarch64
 	cd $(LLVM_DIR)/build-aarch64 && cmake -G "Unix Makefiles" ../runtimes \
+		$(CMAKE_HOST_FLAGS) \
 		-DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
-		-DCMAKE_C_COMPILER=clang \
-		-DCMAKE_CXX_COMPILER=clang++ \
-		-DCMAKE_ASM_COMPILER=clang \
+		-DCMAKE_C_COMPILER=$(STLX_CC) \
+		-DCMAKE_CXX_COMPILER=$(STLX_CXX) \
+		-DCMAKE_ASM_COMPILER=$(STLX_CC) \
 		-DCMAKE_C_COMPILER_TARGET=aarch64-linux-musl \
 		-DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-musl \
 		-DCMAKE_ASM_COMPILER_TARGET=aarch64-linux-musl \
@@ -645,7 +658,7 @@ libcxx:
 		'-DCMAKE_CXX_FLAGS=--target=aarch64-linux-musl --sysroot=$(abspath userland/sysroot/aarch64) -nostdlibinc -isystem $(abspath userland/sysroot/aarch64)/include -nostdinc++ -nostdlib++' \
 		'-DCMAKE_ASM_FLAGS=--target=aarch64-linux-musl --sysroot=$(abspath userland/sysroot/aarch64)' \
 		> /dev/null
-	$(MAKE) -C $(LLVM_DIR)/build-aarch64 -j$$(nproc) cxx cxxabi unwind > /dev/null
+	$(MAKE) -C $(LLVM_DIR)/build-aarch64 -j$(NPROC) cxx cxxabi unwind > /dev/null
 	$(MAKE) -C $(LLVM_DIR)/build-aarch64 install-cxx install-cxxabi install-unwind > /dev/null
 	@echo "libc++ aarch64 installed to userland/sysroot/aarch64/"
 	@echo ""
@@ -674,8 +687,9 @@ compiler-rt:
 	@echo "Building compiler-rt builtins for x86_64..."
 	@mkdir -p $(LLVM_DIR)/build-compiler-rt-x86_64
 	cd $(LLVM_DIR)/build-compiler-rt-x86_64 && cmake -G "Unix Makefiles" ../compiler-rt \
-		-DCMAKE_C_COMPILER=clang \
-		-DCMAKE_ASM_COMPILER=clang \
+		$(CMAKE_HOST_FLAGS) \
+		-DCMAKE_C_COMPILER=$(STLX_CC) \
+		-DCMAKE_ASM_COMPILER=$(STLX_CC) \
 		-DCMAKE_C_COMPILER_TARGET=x86_64-linux-musl \
 		-DCMAKE_ASM_COMPILER_TARGET=x86_64-linux-musl \
 		-DCMAKE_SYSROOT=$(abspath userland/sysroot/x86_64) \
@@ -692,7 +706,7 @@ compiler-rt:
 		'-DCMAKE_C_FLAGS=--target=x86_64-linux-musl --sysroot=$(abspath userland/sysroot/x86_64) -nostdlibinc -isystem $(abspath userland/sysroot/x86_64)/include' \
 		'-DCMAKE_ASM_FLAGS=--target=x86_64-linux-musl --sysroot=$(abspath userland/sysroot/x86_64) -nostdlibinc -isystem $(abspath userland/sysroot/x86_64)/include' \
 		> /dev/null
-	$(MAKE) -C $(LLVM_DIR)/build-compiler-rt-x86_64 -j$$(nproc) builtins > /dev/null
+	$(MAKE) -C $(LLVM_DIR)/build-compiler-rt-x86_64 -j$(NPROC) builtins > /dev/null
 	@cp "$$(find $(LLVM_DIR)/build-compiler-rt-x86_64 -name 'libclang_rt.builtins*.a' -print -quit)" \
 		userland/sysroot/x86_64/lib/libclang_rt.builtins-x86_64.a
 	@echo "compiler-rt builtins x86_64 installed to userland/sysroot/x86_64/lib/"
@@ -700,8 +714,9 @@ compiler-rt:
 	@echo "Building compiler-rt builtins for aarch64..."
 	@mkdir -p $(LLVM_DIR)/build-compiler-rt-aarch64
 	cd $(LLVM_DIR)/build-compiler-rt-aarch64 && cmake -G "Unix Makefiles" ../compiler-rt \
-		-DCMAKE_C_COMPILER=clang \
-		-DCMAKE_ASM_COMPILER=clang \
+		$(CMAKE_HOST_FLAGS) \
+		-DCMAKE_C_COMPILER=$(STLX_CC) \
+		-DCMAKE_ASM_COMPILER=$(STLX_CC) \
 		-DCMAKE_C_COMPILER_TARGET=aarch64-linux-musl \
 		-DCMAKE_ASM_COMPILER_TARGET=aarch64-linux-musl \
 		-DCMAKE_SYSROOT=$(abspath userland/sysroot/aarch64) \
@@ -718,7 +733,7 @@ compiler-rt:
 		'-DCMAKE_C_FLAGS=--target=aarch64-linux-musl --sysroot=$(abspath userland/sysroot/aarch64) -nostdlibinc -isystem $(abspath userland/sysroot/aarch64)/include' \
 		'-DCMAKE_ASM_FLAGS=--target=aarch64-linux-musl --sysroot=$(abspath userland/sysroot/aarch64) -nostdlibinc -isystem $(abspath userland/sysroot/aarch64)/include' \
 		> /dev/null
-	$(MAKE) -C $(LLVM_DIR)/build-compiler-rt-aarch64 -j$$(nproc) builtins > /dev/null
+	$(MAKE) -C $(LLVM_DIR)/build-compiler-rt-aarch64 -j$(NPROC) builtins > /dev/null
 	@cp "$$(find $(LLVM_DIR)/build-compiler-rt-aarch64 -name 'libclang_rt.builtins*.a' -print -quit)" \
 		userland/sysroot/aarch64/lib/libclang_rt.builtins-aarch64.a
 	@echo "compiler-rt builtins aarch64 installed to userland/sysroot/aarch64/lib/"

--- a/scripts/host.mk
+++ b/scripts/host.mk
@@ -38,6 +38,46 @@ define HOST_USB_INSTRUCTIONS
 	@echo "  4. Eject: diskutil eject /dev/diskN, then boot the PC from USB"
 endef
 
+# Extra CMake flags for cross-building the LLVM runtimes from a Darwin
+# host: force cross mode so CMake applies no Apple platform rules.
+CMAKE_HOST_FLAGS := \
+	-DCMAKE_SYSTEM_NAME=Linux \
+	-DCMAKE_AR=$(STLX_AR) \
+	-DCMAKE_RANLIB=$(STLX_RANLIB)
+
+# Alpine's linux-headers package (plain tar.gz, one per arch). Alpine keeps
+# only the latest version per branch: on a stale pin, bump version + sha256s.
+LINUX_HEADERS_ALPINE  := v3.22
+LINUX_HEADERS_VERSION := 6.14.2-r0
+LINUX_HEADERS_SHA256_x86_64  := b0d7184f0e8d926961b82dff3d8a6a1f85db100dfc97e3fa1e6a25bbe9fd0f71
+LINUX_HEADERS_SHA256_aarch64 := 08bc7264055d4ceca249e21f47875ccd7ae2dc7eaf49e235a83b1059e06d9089
+
+# $(1) = target arch
+define stlx_install_alpine_headers
+	@apk="userland/linux-headers-$(LINUX_HEADERS_VERSION)-$(1).apk"; \
+	url="https://dl-cdn.alpinelinux.org/alpine/$(LINUX_HEADERS_ALPINE)/main/$(1)/linux-headers-$(LINUX_HEADERS_VERSION).apk"; \
+	if [ ! -f "$$apk" ]; then \
+		curl -sfL -o "$$apk" "$$url" || { rm -f "$$apk"; \
+			echo "ERROR: download failed: $$url"; \
+			echo "The Alpine linux-headers pin is likely stale; bump it in scripts/host.mk."; \
+			exit 1; }; \
+	fi && \
+	{ echo "$(LINUX_HEADERS_SHA256_$(1))  $$apk" | shasum -a 256 -c - > /dev/null || { \
+		echo "ERROR: sha256 mismatch for $$apk; bump the pin in scripts/host.mk."; exit 1; }; } && \
+	tmp="userland/linux-headers-extract-$(1)" && \
+	rm -rf "$$tmp" && mkdir -p "$$tmp" && \
+	tar -xzf "$$apk" -C "$$tmp" usr/include 2>/dev/null && \
+	cp -R "$$tmp/usr/include/linux" "$$tmp/usr/include/asm" "$$tmp/usr/include/asm-generic" \
+		"userland/sysroot/$(1)/include/" && \
+	rm -rf "$$tmp" && \
+	echo "  $(1): Alpine linux-headers $(LINUX_HEADERS_VERSION) installed"
+endef
+
+define HOST_SYSROOT_HEADERS_INSTALL
+$(call stlx_install_alpine_headers,x86_64)
+$(call stlx_install_alpine_headers,aarch64)
+endef
+
 else
 
 STLX_CC      := clang
@@ -60,6 +100,19 @@ define HOST_USB_INSTRUCTIONS
 	@echo "  4. Boot your PC from USB (check BIOS/UEFI boot menu)"
 endef
 
+# No extra CMake flags: the LLVM runtimes cross-build natively on Linux.
+CMAKE_HOST_FLAGS :=
+
+# Linux UAPI headers come from the distro packages (make deps).
+define HOST_SYSROOT_HEADERS_INSTALL
+	@cp -r /usr/include/linux userland/sysroot/x86_64/include/
+	@cp -r /usr/include/asm-generic userland/sysroot/x86_64/include/
+	@cp -r /usr/include/x86_64-linux-gnu/asm userland/sysroot/x86_64/include/
+	@cp -r /usr/aarch64-linux-gnu/include/linux userland/sysroot/aarch64/include/
+	@cp -r /usr/aarch64-linux-gnu/include/asm-generic userland/sysroot/aarch64/include/
+	@cp -r /usr/aarch64-linux-gnu/include/asm userland/sysroot/aarch64/include/
+endef
+
 endif
 
 # Host-neutral command detection (existence-based, not OS-based).
@@ -70,9 +123,13 @@ SGDISK := $(firstword $(shell command -v sgdisk 2>/dev/null) \
 # Debian ships aarch64 support in gdb-multiarch; Homebrew gdb is multi-target.
 GDB_MULTIARCH := $(if $(shell command -v gdb-multiarch 2>/dev/null),gdb-multiarch,gdb)
 
+# Logical CPU count for third-party builds (getconf works on both hosts).
+NPROC := $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
+
 # Fail at parse time if the interface is incomplete for this host.
+# CMAKE_HOST_FLAGS is exempt: it is legitimately empty on Linux.
 $(foreach v,HOST_OS STLX_CC STLX_CXX STLX_LLD STLX_AR STLX_RANLIB STLX_OBJCOPY \
-	SGDISK GDB_MULTIARCH HOST_USB_INSTRUCTIONS,\
+	SGDISK GDB_MULTIARCH NPROC HOST_USB_INSTRUCTIONS HOST_SYSROOT_HEADERS_INSTALL,\
 	$(if $(value $(v)),,$(error scripts/host.mk: $(v) is undefined for host '$(HOST_OS)')))
 
 endif # STLX_HOST_MK_INCLUDED


### PR DESCRIPTION
## Summary
- `make musl`/`make libcxx`/`make compiler-rt` assumed a Linux host: distro kernel headers copied from `/usr/include`, GNU `ar`/`ranlib`, `nproc`, and CMake host defaults that break under Apple platform rules.
- Tools and parallelism now come from the `host.mk` interface; on macOS the LLVM runtimes get cross-mode CMake flags and UAPI headers come from a sha256-pinned Alpine linux-headers package with a clear stale-pin error; the x86_64 libc++ build pins its ASM compiler target (latent bug the aarch64 invocation already avoided).
- CI cache keys bumped (`-v2`) so the cold path is proven on Linux; verified on macOS from a wiped sysroot including negative tests for the 404 and checksum-mismatch paths.

Made with [Cursor](https://cursor.com)