### PR TITLE
feat(build): macOS deps, host-aware toolchain-check, and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,16 +497,7 @@ check-limine:
 # ============================================================================
 
 deps:
-	@echo "Installing required packages (Debian/Ubuntu)..."
-	sudo apt install -y clang lld llvm \
-		libclang-rt-dev \
-		gcc-aarch64-linux-gnu \
-		linux-libc-dev-arm64-cross \
-		cmake \
-		qemu-system-x86 qemu-system-arm \
-		ovmf qemu-efi-aarch64 \
-		mtools gdisk xorriso \
-		gdb-multiarch
+	$(HOST_DEPS_INSTALL)
 	@echo ""
 	@echo "Done. Run 'make toolchain-check' to verify."
 
@@ -779,18 +770,20 @@ doom-wad:
 	fi
 
 toolchain-check:
-	@echo "=== Toolchain Check ==="
+	@echo "=== Toolchain Check ($(HOST_OS)) ==="
 	@echo ""
 	@printf "%-24s" "clang:" && \
-		(which clang > /dev/null 2>&1 && clang --version | head -1 || echo "NOT FOUND")
+		(command -v $(STLX_CC) > /dev/null 2>&1 && $(STLX_CC) --version | head -1 || echo "NOT FOUND")
 	@printf "%-24s" "clang++:" && \
-		(which clang++ > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND")
+		(command -v $(STLX_CXX) > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND")
 	@printf "%-24s" "aarch64-linux-gnu-gcc:" && \
-		(which aarch64-linux-gnu-gcc > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND")
+		(which aarch64-linux-gnu-gcc > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND (Linux builtins fallback)")
 	@printf "%-24s" "ld.lld:" && \
-		(which ld.lld > /dev/null 2>&1 && ld.lld --version | head -1 || echo "NOT FOUND")
+		(command -v $(STLX_LLD) > /dev/null 2>&1 && $(STLX_LLD) --version | head -1 || echo "NOT FOUND")
+	@printf "%-24s" "llvm-ar:" && \
+		(command -v $(STLX_AR) > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND")
 	@printf "%-24s" "llvm-objcopy:" && \
-		(which llvm-objcopy > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND (optional)")
+		(command -v $(STLX_OBJCOPY) > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND (optional)")
 	@printf "%-24s" "qemu-system-x86_64:" && \
 		(which qemu-system-x86_64 > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND")
 	@printf "%-24s" "qemu-system-aarch64:" && \
@@ -802,9 +795,9 @@ toolchain-check:
 	@printf "%-24s" "mformat:" && \
 		(which mformat > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND")
 	@printf "%-24s" "sgdisk:" && \
-		(which sgdisk > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND")
-	@printf "%-24s" "gdb-multiarch:" && \
-		(which gdb-multiarch > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND (for AArch64 debugging)")
+		(command -v $(SGDISK) > /dev/null 2>&1 && echo "OK" || echo "NOT FOUND")
+	@printf "%-24s" "gdb (aarch64-capable):" && \
+		(which $(GDB_MULTIARCH) > /dev/null 2>&1 && echo "OK ($(GDB_MULTIARCH))" || echo "NOT FOUND (for AArch64 debugging)")
 	@printf "%-24s" "Limine BOOTX64.EFI:" && \
 		(test -f $(BOOT_DIR)/BOOTX64.EFI && echo "OK" || echo "NOT FOUND - run 'make limine'")
 	@printf "%-24s" "Limine BOOTAA64.EFI:" && \
@@ -824,7 +817,7 @@ toolchain-check:
 		 if [ -f "$$SR" ]; then \
 			echo "$$SR"; \
 		 else \
-			BRT=$$(clang --target=x86_64-linux-musl --rtlib=compiler-rt -print-libgcc-file-name 2>/dev/null); \
+			BRT=$$($(STLX_CC) --target=x86_64-linux-musl --rtlib=compiler-rt -print-libgcc-file-name 2>/dev/null); \
 			if [ -f "$$BRT" ]; then \
 				echo "$$BRT"; \
 			elif which x86_64-linux-gnu-gcc > /dev/null 2>&1; then \
@@ -839,7 +832,7 @@ toolchain-check:
 		 if [ -f "$$SR" ]; then \
 			echo "$$SR"; \
 		 else \
-			BRT=$$(clang --target=aarch64-linux-musl --rtlib=compiler-rt -print-libgcc-file-name 2>/dev/null); \
+			BRT=$$($(STLX_CC) --target=aarch64-linux-musl --rtlib=compiler-rt -print-libgcc-file-name 2>/dev/null); \
 			if [ -f "$$BRT" ]; then \
 				echo "$$BRT"; \
 			elif which aarch64-linux-gnu-gcc > /dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ the [pftf/RPi4](https://github.com/pftf/RPi4) project.
 
 ### Prerequisites
 
-Debian/Ubuntu is the primary development environment. The kernel is built with
-Clang/LLD; userland applications link against a statically-built musl libc.
+Linux (Debian/Ubuntu) and macOS are both supported development
+environments, with the same commands on either OS. The kernel is built
+with Clang/LLD; userland applications link against a statically-built
+musl libc.
 
 Clone the repository and run the one-time setup:
 
@@ -90,13 +92,20 @@ make deps
 make limine
 make musl
 make libcxx
+make compiler-rt
 ```
 
-`make deps` installs system packages (clang, lld, llvm, qemu, ovmf, mtools,
-etc.). `make limine` downloads the Limine bootloader binaries. `make musl`
-builds musl 1.2.5 for both x86_64 and aarch64. `make libcxx` builds the
-LLVM C++ runtime (libc++, libc++abi, libunwind) against the musl sysroot
-for C++ userland application support.
+`make deps` installs system packages -- via apt on Linux (clang, lld,
+llvm, qemu, ovmf, mtools, etc.) and via [Homebrew](https://brew.sh) on
+macOS (llvm, lld, qemu, mtools, gptfdisk, etc.). `make limine` downloads
+the Limine bootloader binaries. `make musl` builds musl 1.2.5 for both
+x86_64 and aarch64. `make libcxx` builds the LLVM C++ runtime (libc++,
+libc++abi, libunwind) against the musl sysroot for C++ userland
+application support. `make compiler-rt` builds the compiler runtime
+builtins for both architectures.
+
+The optional CPython userland app additionally requires a host
+`python3.12` (e.g. `brew install python@3.12` / `apt install python3.12`).
 
 Run `make toolchain-check` to verify everything is in place.
 
@@ -151,7 +160,8 @@ make connect-gdb-x86_64
 ```
 
 The same pattern applies for AArch64 (`run-qemu-aarch64-debug-headless`,
-`connect-gdb-aarch64`). On AArch64, the Makefile uses `gdb-multiarch`.
+`connect-gdb-aarch64`). On AArch64, the Makefile uses `gdb-multiarch`
+where available (Linux) and multi-target `gdb` otherwise (macOS).
 
 ### Baremetal Debugging
 

--- a/scripts/dynpriv-lint.sh
+++ b/scripts/dynpriv-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # dynpriv-lint.sh — Lint dynamic privilege annotations for consistency.
 #
@@ -12,6 +12,12 @@
 #   scripts/dynpriv-lint.sh kernel/mm  # scan only kernel/mm/
 
 set -euo pipefail
+
+# mapfile requires bash >= 4; macOS ships 3.2 (brew install bash).
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "error: this script requires bash >= 4 (on macOS: brew install bash)" >&2
+    exit 1
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/scripts/host.mk
+++ b/scripts/host.mk
@@ -40,6 +40,16 @@ define HOST_USB_INSTRUCTIONS
 	@echo "  4. Eject: diskutil eject /dev/diskN, then boot the PC from USB"
 endef
 
+define HOST_DEPS_INSTALL
+	@echo "Installing required packages (Homebrew)..."
+	@command -v brew > /dev/null 2>&1 || \
+		{ echo "ERROR: Homebrew not found. Install it from https://brew.sh first."; exit 1; }
+	brew install llvm lld cmake qemu mtools gptfdisk coreutils bash gdb
+	@echo ""
+	@echo "Note: the 'python' userland app also needs a host python3.12"
+	@echo "(e.g. 'brew install python@3.12')."
+endef
+
 # Extra CMake flags for cross-building the LLVM runtimes from a Darwin
 # host: force cross mode so CMake applies no Apple platform rules.
 CMAKE_HOST_FLAGS := \
@@ -104,6 +114,19 @@ define HOST_USB_INSTRUCTIONS
 	@echo "  4. Boot your PC from USB (check BIOS/UEFI boot menu)"
 endef
 
+define HOST_DEPS_INSTALL
+	@echo "Installing required packages (Debian/Ubuntu)..."
+	sudo apt install -y clang lld llvm \
+		libclang-rt-dev \
+		gcc-aarch64-linux-gnu \
+		linux-libc-dev-arm64-cross \
+		cmake \
+		qemu-system-x86 qemu-system-arm \
+		ovmf qemu-efi-aarch64 \
+		mtools gdisk xorriso \
+		gdb-multiarch
+endef
+
 # No extra CMake flags: the LLVM runtimes cross-build natively on Linux.
 CMAKE_HOST_FLAGS :=
 
@@ -134,7 +157,8 @@ NPROC := $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
 # CMAKE_HOST_FLAGS is exempt: it is legitimately empty on Linux.
 $(foreach v,HOST_OS STLX_CC STLX_CXX STLX_LLD STLX_AR STLX_RANLIB STLX_OBJCOPY \
 	STLX_STRIP STLX_READELF \
-	SGDISK GDB_MULTIARCH NPROC HOST_USB_INSTRUCTIONS HOST_SYSROOT_HEADERS_INSTALL,\
+	SGDISK GDB_MULTIARCH NPROC \
+	HOST_USB_INSTRUCTIONS HOST_SYSROOT_HEADERS_INSTALL HOST_DEPS_INSTALL,\
 	$(if $(value $(v)),,$(error scripts/host.mk: $(v) is undefined for host '$(HOST_OS)')))
 
 endif # STLX_HOST_MK_INCLUDED


### PR DESCRIPTION
## Summary
- Onboarding assumed Debian: apt-only `make deps`, `toolchain-check` probing Debian tool names, and `dynpriv-lint.sh` failing cryptically under macOS's bash 3.2.
- `deps` installs per host through the `HOST_DEPS_INSTALL` interface (Homebrew on macOS, verbatim apt on Linux), `toolchain-check` reports the resolved `STLX_*` tools, the lint script guards its bash requirement with an actionable error, and the README documents the identical two-OS setup flow.

Made with [Cursor](https://cursor.com)