### PR TITLE
ci: added macOS build job

### DIFF
--- a/.github/workflows/kernel-unit-tests.yml
+++ b/.github/workflows/kernel-unit-tests.yml
@@ -11,7 +11,7 @@
 #        │
 #        ├──────────────────────────────┐
 #        ▼                              ▼
-#      build     (4 jobs: arch × mode)  macos-tests  (2 jobs: arch)
+#      build     (4 jobs: arch × mode)  macos-build  (2 jobs: arch)
 #        │
 #        ▼
 #    unit-tests  (2 jobs: arch)
@@ -141,14 +141,14 @@ jobs:
           echo "Kernel ELF: $(ls -lh "$elf")"
 
   # ============================================================================
-  # macOS Host Build + Unit Tests (arm64 runner, arch matrix)
+  # macOS Host Build (arm64 runner, arch matrix; unit tests run on Linux)
   # ============================================================================
 
-  macos-tests:
-    name: macos-tests (${{ matrix.arch }})
+  macos-build:
+    name: macos-build (${{ matrix.arch }})
     runs-on: macos-15
     needs: dynpriv-lint
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -216,18 +216,17 @@ jobs:
         if: steps.compiler-rt-cache.outputs.cache-hit != 'true'
         run: make compiler-rt
 
-      - name: Run unit tests
-        env:
-          STLX_TEST_TIMEOUT: "300"
-        run: make test ARCH=${{ matrix.arch }} 2>&1 | tee test-log-macos-${{ matrix.arch }}.txt
+      - name: Build kernel, userland, and disk image
+        run: make image ARCH=${{ matrix.arch }}
 
-      - name: Upload test log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-log-macos-${{ matrix.arch }}
-          path: test-log-macos-${{ matrix.arch }}.txt
-          if-no-files-found: ignore
+      - name: Verify build artifacts
+        run: |
+          for f in "build/kernel/${{ matrix.arch }}/kernel.elf" "images/stellux-${{ matrix.arch }}.img"; do
+            if [[ ! -f "$f" ]]; then
+              echo "::error::missing artifact: $f"
+              exit 1
+            fi
+          done
 
   # ============================================================================
   # Unit Tests (arch matrix)

--- a/.github/workflows/kernel-unit-tests.yml
+++ b/.github/workflows/kernel-unit-tests.yml
@@ -9,8 +9,9 @@
 #
 #   dynpriv-lint  (fast gate)
 #        │
-#        ▼
-#      build     (4 jobs: arch × mode)
+#        ├──────────────────────────────┐
+#        ▼                              ▼
+#      build     (4 jobs: arch × mode)  macos-tests  (2 jobs: arch)
 #        │
 #        ▼
 #    unit-tests  (2 jobs: arch)
@@ -138,6 +139,95 @@ jobs:
             exit 1
           fi
           echo "Kernel ELF: $(ls -lh "$elf")"
+
+  # ============================================================================
+  # macOS Host Build + Unit Tests (arm64 runner, arch matrix)
+  # ============================================================================
+
+  macos-tests:
+    name: macos-tests (${{ matrix.arch }})
+    runs-on: macos-15
+    needs: dynpriv-lint
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Runner diagnostics
+        run: |
+          sw_vers
+          sysctl -n machdep.cpu.brand_string hw.ncpu hw.memsize
+          df -h / | tail -1
+
+      - name: Install build dependencies
+        run: |
+          make deps
+          brew install python@3.12
+
+      - name: Fetch Limine EFI binaries
+        run: make limine
+
+      - name: Cache musl sysroot
+        uses: actions/cache@v4
+        id: musl-cache
+        with:
+          path: userland/sysroot
+          key: macos-musl-sysroot-1.2.5-v2
+
+      - name: Build musl libc
+        if: steps.musl-cache.outputs.cache-hit != 'true'
+        run: make musl
+
+      - name: Cache libc++ sysroot
+        uses: actions/cache@v4
+        id: libcxx-cache
+        with:
+          path: |
+            userland/sysroot/x86_64/lib/libc++.a
+            userland/sysroot/x86_64/lib/libc++abi.a
+            userland/sysroot/x86_64/lib/libunwind.a
+            userland/sysroot/x86_64/include/c++
+            userland/sysroot/aarch64/lib/libc++.a
+            userland/sysroot/aarch64/lib/libc++abi.a
+            userland/sysroot/aarch64/lib/libunwind.a
+            userland/sysroot/aarch64/include/c++
+          key: macos-libcxx-sysroot-18.1.8-v2
+
+      - name: Build libc++
+        if: steps.libcxx-cache.outputs.cache-hit != 'true'
+        run: make libcxx
+
+      - name: Cache compiler-rt builtins
+        uses: actions/cache@v4
+        id: compiler-rt-cache
+        with:
+          path: |
+            userland/sysroot/x86_64/lib/libclang_rt.builtins-x86_64.a
+            userland/sysroot/aarch64/lib/libclang_rt.builtins-aarch64.a
+          key: macos-compiler-rt-builtins-18.1.8-v2
+
+      - name: Build compiler-rt builtins
+        if: steps.compiler-rt-cache.outputs.cache-hit != 'true'
+        run: make compiler-rt
+
+      - name: Run unit tests
+        env:
+          STLX_TEST_TIMEOUT: "300"
+        run: make test ARCH=${{ matrix.arch }} 2>&1 | tee test-log-macos-${{ matrix.arch }}.txt
+
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-log-macos-${{ matrix.arch }}
+          path: test-log-macos-${{ matrix.arch }}.txt
+          if-no-files-found: ignore
 
   # ============================================================================
   # Unit Tests (arch matrix)

--- a/userland/apps/python/patches/0002-skip-checksharedmods-on-cross-host.patch
+++ b/userland/apps/python/patches/0002-skip-checksharedmods-on-cross-host.patch
@@ -1,0 +1,20 @@
+Skip the host-side shared-module check when cross-compiling from a
+non-Linux host. The check runs the build interpreter with PYTHONPATH
+pointing into the cross-build tree, so importing its own dependencies
+(e.g. math) can dlopen cross-built Linux ELF modules and crash on
+macOS. On Linux hosts the check runs unchanged.
+
+--- a/Tools/build/check_extension_modules.py
++++ b/Tools/build/check_extension_modules.py
+@@ -18,6 +18,11 @@ Module information is parsed from several sources:
+ 
+ See --help for more information
+ """
++import sys
++
++if not sys.platform.startswith("linux"):
++    raise SystemExit(0)
++
+ import argparse
+ import collections
+ import enum


### PR DESCRIPTION
## Summary
- macOS support had no CI enforcement — nothing stopped a change from silently breaking it.
- A `macos-15` (arm64) job builds the sysroots (Darwin-scoped caches), kernel, userland, and disk image for both architectures on every push; unit-test execution stays on the Linux jobs.
- Runs parallel to the build matrix; warm runs fit inside the existing pipeline envelope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow and a macOS-only skip in Python’s extension-module lint; runtime kernel behavior is unchanged.
> 
> **Overview**
> Adds **macOS CI coverage** so cross-host builds are enforced on every push/PR, without moving QEMU unit tests off Linux.
> 
> A new **`macos-build`** job runs on `macos-15` in parallel with the existing Ubuntu **`build`** matrix (both still gate on **`dynpriv-lint`**). It cross-builds **x86_64** and **aarch64**, reusing Darwin-specific cache keys for musl/libc++/compiler-rt, then runs **`make image`** and asserts **`kernel.elf`** plus **`images/stellux-<arch>.img`** exist. **`unit-tests`** remains **`needs: build`** only.
> 
> A small **Python patch** exits early from **`check_extension_modules.py`** on non-Linux hosts so macOS cross-builds do not run a host-side shared-module check that can **`dlopen`** Linux ELF modules and crash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eac2a96e3ba763991858c2286f772bf24d42cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->