### PR TITLE
fix(sched): closed the kill-before-block race in all blocking paths

### DIFF
--- a/kernel/sched/sched.cpp
+++ b/kernel/sched/sched.cpp
@@ -186,8 +186,42 @@ bool is_kill_pending() {
 
 __PRIVILEGED_CODE void force_wake_for_kill(task* t) {
     __atomic_store_n(&t->kill_pending, 1, __ATOMIC_RELEASE);
+
+    // Pairs with block_task_interrupted_by_kill: the wake below sees BLOCKED,
+    // or the blocker's kill check sees kill_pending. Never neither.
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
     timer::cancel_sleep(t);
     wake(t);
+}
+
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE void prepare_to_block_task() {
+    __atomic_store_n(&current()->state, TASK_STATE_BLOCKED, __ATOMIC_RELEASE);
+}
+
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE bool block_task_interrupted_by_kill() {
+    // Fence pairs with the one in force_wake_for_kill.
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    return __atomic_load_n(&current()->kill_pending, __ATOMIC_ACQUIRE);
+}
+
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE void cancel_block_task() {
+    task* self = current();
+    uint32_t expected = TASK_STATE_BLOCKED;
+    if (!__atomic_compare_exchange_n(&self->state, &expected, TASK_STATE_RUNNING,
+                                      false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+        // A wake already claimed this task READY and will requeue it once
+        // it is off-CPU. Yield so that handoff can complete.
+        yield();
+    }
 }
 
 /**
@@ -378,8 +412,17 @@ __PRIVILEGED_CODE void sleep_ns(uint64_t ns) {
     }
 
     uint64_t deadline = clock::now_ns() + ns;
-    self->state = TASK_STATE_BLOCKED;
+
+    prepare_to_block_task();
     timer::schedule_sleep(self, deadline);
+
+    if (block_task_interrupted_by_kill()) {
+        // Killed before or during sleep entry: do not serve the sleep.
+        timer::cancel_sleep(self);
+        cancel_block_task();
+        return;
+    }
+
     yield();
 }
 

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -110,11 +110,32 @@ __PRIVILEGED_CODE void wake(task* t);
 
 /**
  * @brief Mark a task for termination and wake it if blocked.
- * Sets kill_pending, cancels any timer sleep, and wakes via CAS.
- * Fire-and-forget: does not wait for the task to actually die.
+ * Fire-and-forget: the target is force-woken now or observes the kill
+ * at its next killable blocking attempt (sleep, futex, poll).
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE void force_wake_for_kill(task* t);
+
+/**
+ * @brief Publish intent to block: moves the current task to BLOCKED.
+ * Pair with block_task_interrupted_by_kill before yielding.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE void prepare_to_block_task();
+
+/**
+ * @brief True if a kill arrived since prepare_to_block_task.
+ * On true, the caller must unwind its wait entry and call cancel_block_task.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE bool block_task_interrupted_by_kill();
+
+/**
+ * @brief Revert an unfinished block after the caller unwound its entry.
+ * Yields once if a concurrent wake already claimed the task.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE void cancel_block_task();
 
 /**
  * @brief Check if the current task has been marked for termination.

--- a/kernel/sync/futex.cpp
+++ b/kernel/sync/futex.cpp
@@ -73,7 +73,7 @@ __PRIVILEGED_CODE int32_t futex_wait(uintptr_t uaddr, uint32_t expected,
         return -11; // EAGAIN
     }
 
-    self->state = sched::TASK_STATE_BLOCKED;
+    sched::prepare_to_block_task();
     bucket->waiters.push_back(&waiter);
 
     if (timeout_ns > 0) {
@@ -82,6 +82,18 @@ __PRIVILEGED_CODE int32_t futex_wait(uintptr_t uaddr, uint32_t expected,
     }
 
     spin_unlock_irqrestore(bucket->lock, irq);
+
+    if (sched::block_task_interrupted_by_kill()) {
+        // Killed during futex entry: unwind waiter and timer, don't block.
+        timer::cancel_sleep(self);
+        irq = spin_lock_irqsave(bucket->lock);
+        if (waiter.link.is_linked()) {
+            bucket->waiters.remove(&waiter);
+        }
+        spin_unlock_irqrestore(bucket->lock, irq);
+        sched::cancel_block_task();
+        return -4; // EINTR
+    }
     sched::yield();
 
     // Cancel any outstanding timer to prevent spurious wakes of future

--- a/kernel/sync/poll.cpp
+++ b/kernel/sync/poll.cpp
@@ -27,20 +27,6 @@ __PRIVILEGED_CODE void poll_subscribe(poll_table& pt, wait_queue& wq) {
     spin_unlock_irqrestore(wq.lock, irq);
 }
 
-__PRIVILEGED_CODE static void resolve_aborted_poll_block(sched::task* self) {
-    uint32_t expected = sched::TASK_STATE_BLOCKED;
-    if (__atomic_compare_exchange_n(&self->state, &expected,
-            sched::TASK_STATE_RUNNING, false,
-            __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
-        return;
-    }
-
-    // A concurrent wake already moved us to READY and queued a runqueue entry.
-    // Yield once so the scheduler can consume that entry instead of leaving
-    // sched_link live while we keep executing in C.
-    sched::yield();
-}
-
 __PRIVILEGED_CODE bool poll_wait(poll_table& pt, uint64_t timeout_ns) {
     if (__atomic_load_n(&pt.triggered, __ATOMIC_ACQUIRE)) {
         return true;
@@ -55,17 +41,18 @@ __PRIVILEGED_CODE bool poll_wait(poll_table& pt, uint64_t timeout_ns) {
         return false;
     }
 
-    self->state = sched::TASK_STATE_BLOCKED;
+    sched::prepare_to_block_task();
 
-    // Re-check after setting BLOCKED to close races where a source fires
-    // or kill arrives between the initial checks and the state transition.
-    if (__atomic_load_n(&pt.triggered, __ATOMIC_ACQUIRE)) {
-        resolve_aborted_poll_block(self);
-        return true;
-    }
-    if (__atomic_load_n(&self->kill_pending, __ATOMIC_ACQUIRE)) {
-        resolve_aborted_poll_block(self);
+    if (sched::block_task_interrupted_by_kill()) {
+        sched::cancel_block_task();
         return false;
+    }
+
+    // The kill check's fence also orders this re-check against the BLOCKED
+    // store, closing the race where a source fires during the transition.
+    if (__atomic_load_n(&pt.triggered, __ATOMIC_ACQUIRE)) {
+        sched::cancel_block_task();
+        return true;
     }
 
     if (timeout_ns > 0) {

--- a/kernel/sync/wait_queue.cpp
+++ b/kernel/sync/wait_queue.cpp
@@ -56,6 +56,8 @@ __PRIVILEGED_CODE static void notify_observers_and_unlock(
 }
 
 /**
+ * Not kill-interruptible on its own: a force-woken waiter re-blocks unless
+ * the caller loops on sched::is_kill_pending().
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE
@@ -69,7 +71,7 @@ irq_state wait(wait_queue& wq, spinlock& lock, irq_state saved) {
     }
 
     spin_lock(wq.lock);
-    self->state = sched::TASK_STATE_BLOCKED;
+    sched::prepare_to_block_task();
     wq.waiters.push_back(self);
     spin_unlock(wq.lock);
 

--- a/kernel/tests/framework/helpers.h
+++ b/kernel/tests/framework/helpers.h
@@ -2,23 +2,25 @@
 #define STELLUX_TESTS_FRAMEWORK_HELPERS_H
 
 #include "common/types.h"
+#include "clock/clock.h"
 
 namespace test_helpers {
 
-constexpr uint64_t SPIN_TIMEOUT = 100000000;
+// Wall-clock bound: iteration counts vary ~100x across hosts and emulators.
+constexpr uint64_t SPIN_TIMEOUT_NS = 20000000000ULL; // 20s
 
 inline bool spin_wait(volatile uint32_t* flag) {
-    uint64_t spins = 0;
+    uint64_t deadline = clock::now_ns() + SPIN_TIMEOUT_NS;
     while (!__atomic_load_n(flag, __ATOMIC_ACQUIRE)) {
-        if (++spins > SPIN_TIMEOUT) return false;
+        if (clock::now_ns() > deadline) return false;
     }
     return true;
 }
 
 inline bool spin_wait_ge(volatile uint32_t* value, uint32_t target) {
-    uint64_t spins = 0;
+    uint64_t deadline = clock::now_ns() + SPIN_TIMEOUT_NS;
     while (__atomic_load_n(value, __ATOMIC_ACQUIRE) < target) {
-        if (++spins > SPIN_TIMEOUT) return false;
+        if (clock::now_ns() > deadline) return false;
     }
     return true;
 }

--- a/kernel/tests/sched/kill.test.cpp
+++ b/kernel/tests/sched/kill.test.cpp
@@ -13,6 +13,15 @@ using test_helpers::spin_wait;
 using test_helpers::spin_wait_ge;
 using test_helpers::brief_delay;
 
+// Deterministic handshake: wait until the task has actually blocked.
+static bool wait_until_blocked(sched::task* t) {
+    uint64_t deadline = clock::now_ns() + test_helpers::SPIN_TIMEOUT_NS;
+    while (__atomic_load_n(&t->state, __ATOMIC_ACQUIRE) != sched::TASK_STATE_BLOCKED) {
+        if (clock::now_ns() > deadline) return false;
+    }
+    return true;
+}
+
 TEST_SUITE(kill);
 
 // --- force_wake_kills_sleeping_task ---
@@ -52,7 +61,7 @@ TEST(kill, force_wake_kills_sleeping_task) {
         sched::enqueue(t);
     });
 
-    brief_delay();
+    ASSERT_TRUE(wait_until_blocked(t));
 
     RUN_ELEVATED({
         sched::force_wake_for_kill(t);
@@ -62,6 +71,28 @@ TEST(kill, force_wake_kills_sleeping_task) {
     EXPECT_EQ(__atomic_load_n(&g_sleep_kill_was_pending, __ATOMIC_ACQUIRE), 1u);
     EXPECT_LT(__atomic_load_n(&g_sleep_kill_elapsed_ns, __ATOMIC_ACQUIRE),
               static_cast<uint64_t>(2000000000)); // woke in < 2s, not 5s
+}
+
+// --- kill_before_sleep_aborts_sleep ---
+// A kill issued before the task ever runs must abort its sleep attempt
+// at the block commit point instead of being lost until natural expiry.
+
+TEST(kill, kill_before_sleep_aborts_sleep) {
+    g_sleep_kill_done = 0;
+    g_sleep_kill_was_pending = 0;
+    g_sleep_kill_elapsed_ns = 0;
+
+    RUN_ELEVATED({
+        sched::task* t = sched::create_kernel_task(sleep_kill_fn, nullptr, "kill_presleep");
+        ASSERT_NOT_NULL(t);
+        sched::force_wake_for_kill(t);
+        sched::enqueue(t);
+    });
+
+    ASSERT_TRUE(spin_wait(&g_sleep_kill_done));
+    EXPECT_EQ(__atomic_load_n(&g_sleep_kill_was_pending, __ATOMIC_ACQUIRE), 1u);
+    EXPECT_LT(__atomic_load_n(&g_sleep_kill_elapsed_ns, __ATOMIC_ACQUIRE),
+              static_cast<uint64_t>(2000000000)); // aborted, not slept for 5s
 }
 
 // --- force_wake_kills_blocked_on_wq ---
@@ -221,6 +252,7 @@ static volatile uint32_t g_ikp_before = 0xFF;
 static volatile uint32_t g_ikp_after = 0xFF;
 static volatile uint32_t g_ikp_done = 0;
 static volatile uint32_t g_ikp_flag_set = 0;
+static volatile uint32_t g_ikp_started = 0;
 
 static void ikp_fn(void*) {
     uint32_t before = 0;
@@ -228,6 +260,7 @@ static void ikp_fn(void*) {
         before = sched::is_kill_pending() ? 1 : 0;
     });
     __atomic_store_n(&g_ikp_before, before, __ATOMIC_RELEASE);
+    __atomic_store_n(&g_ikp_started, 1, __ATOMIC_RELEASE);
 
     while (!__atomic_load_n(&g_ikp_flag_set, __ATOMIC_ACQUIRE)) {
         // busy wait for test driver to set kill_pending
@@ -247,6 +280,7 @@ TEST(kill, is_kill_pending_accessor) {
     g_ikp_after = 0xFF;
     g_ikp_done = 0;
     g_ikp_flag_set = 0;
+    g_ikp_started = 0;
 
     sched::task* t = nullptr;
     RUN_ELEVATED({
@@ -255,7 +289,7 @@ TEST(kill, is_kill_pending_accessor) {
         sched::enqueue(t);
     });
 
-    brief_delay();
+    ASSERT_TRUE(spin_wait(&g_ikp_started));
 
     RUN_ELEVATED({
         __atomic_store_n(&t->kill_pending, 1, __ATOMIC_RELEASE);


### PR DESCRIPTION
## Summary
- `force_wake_for_kill` only acts on tasks already sleeping or BLOCKED, so a kill landing while the victim was still *entering* a block was silently lost — delayed until natural wakeup for sleeps, or until an unrelated wake for futexes. This is the root cause of the kill-suite CI flakes.
- Blocking now uses a `sched`-owned protocol — `prepare_to_block_task` / `block_task_interrupted_by_kill` / `cancel_block_task` — adopted by the interruption-capable sites (sleep, futex, poll). `poll_wait` already hand-rolled exactly this pattern; its bespoke copy is deleted in favor of the shared one, which also adds the store-load fence pairing the hand-rolled version lacked.
- Wait-queue waits keep their existing semantics (callers are not kill-aware; aborting there would turn kill-unaware wait loops into hot spins). `wait()` now uses the atomic-release state transition and both docs state the contract honestly. A `wait_killable` variant plus caller audit is explicit follow-up work.
- Proof: new deterministic regression test (`kill_before_sleep_aborts_sleep`) fails on the unfixed kernel at exactly the 5 s natural expiry and passes with the fix; full suite 510/510 across repeated runs on both architectures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core scheduler blocking, kill delivery, and synchronization primitives (sleep, futex, poll); incorrect fencing or unwind logic could cause lost wakeups, stuck tasks, or spurious EINTR.
> 
> **Overview**
> Fixes a race where **`force_wake_for_kill`** could miss a task still **entering** a block, so kills were delayed until natural wakeup (or unrelated wakes). The scheduler now owns a shared **prepare → kill-check → cancel** blocking protocol with **SEQ_CST fences** pairing **`force_wake_for_kill`** and **`block_task_interrupted_by_kill`**.
> 
> **Sleep**, **futex wait**, and **`poll_wait`** adopt that protocol: they unwind timers/waiters and return without yielding when a kill is seen at the commit point. **`poll_wait`** drops its local abort helper in favor of the shared **`cancel_block_task`**. **`sync::wait`** only switches to atomic **`prepare_to_block_task`**; docs state it is **not** kill-interruptible without caller loops on **`is_kill_pending()`**.
> 
> Tests use **wall-clock** spin timeouts and **`wait_until_blocked`** instead of **`brief_delay`**, plus a new **`kill_before_sleep_aborts_sleep`** regression for pre-enqueue kills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 520abb2e4116a88303d7246939e237eb01196e47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->