### PR TITLE
feat(proc): added envp plumbing through proc_create

### DIFF
--- a/kernel/sched/sched.cpp
+++ b/kernel/sched/sched.cpp
@@ -602,6 +602,8 @@ __PRIVILEGED_CODE task* create_kernel_task(
  *
  * @param user_argc Number of user-provided args (excluding program name).
  * @param user_argv Kernel-copied argument strings, or nullptr for none.
+ * @param user_envc Number of environment strings.
+ * @param user_envp Kernel-copied environment strings, or nullptr for none.
  * @return 16-byte-aligned user stack pointer pointing to argc, or 0 on error.
  * @note Privilege: **required**
  */
@@ -611,7 +613,9 @@ __PRIVILEGED_CODE static uintptr_t setup_user_stack(
     const exec::loaded_image& image,
     const char* name,
     int user_argc,
-    const char* const* user_argv
+    const char* const* user_argv,
+    int user_envc,
+    const char* const* user_envp
 ) {
     uint8_t* page_kva = static_cast<uint8_t*>(paging::phys_to_virt(last_page_phys));
     uintptr_t page_base_va = pmm::page_align_down(stack_top - 1);
@@ -622,19 +626,25 @@ __PRIVILEGED_CODE static uintptr_t setup_user_stack(
 
     int total_argc = 1 + user_argc; // argv[0] = name, argv[1..] = user args
 
-    constexpr size_t MAX_ARGV_PTRS = 66; // 1 name + 64 user args + slack
+    constexpr size_t MAX_ARGV_PTRS = 1 + MAX_ARG_STRINGS; // program name + user args
+    constexpr size_t MAX_ENVP_PTRS = MAX_ARG_STRINGS;
     constexpr size_t AUXV_ENTRIES = 5;
     constexpr size_t AUXV_WORDS = AUXV_ENTRIES * 2;
 
-    size_t struct_words = 1 + static_cast<size_t>(total_argc) + 1 + 1 + AUXV_WORDS;
+    size_t struct_words = 1 + static_cast<size_t>(total_argc) + 1
+                        + static_cast<size_t>(user_envc) + 1 + AUXV_WORDS;
     size_t struct_bytes = struct_words * sizeof(uint64_t);
 
     // Pre-compute total string space needed (8-byte aligned per arg)
     size_t name_len = string::strnlen(name, TASK_NAME_MAX - 1) + 1;
     size_t total_string_bytes = (name_len + 7) & ~7ULL;
     for (int i = 0; i < user_argc; i++) {
-        size_t arg_len = string::strnlen(user_argv[i], 255) + 1;
+        size_t arg_len = string::strnlen(user_argv[i], MAX_ARG_STRLEN - 1) + 1;
         total_string_bytes += (arg_len + 7) & ~7ULL;
+    }
+    for (int i = 0; i < user_envc; i++) {
+        size_t env_len = string::strnlen(user_envp[i], MAX_ARG_STRLEN - 1) + 1;
+        total_string_bytes += (env_len + 7) & ~7ULL;
     }
 
     if (total_string_bytes + struct_bytes + 16 > pmm::PAGE_SIZE) {
@@ -653,22 +663,34 @@ __PRIVILEGED_CODE static uintptr_t setup_user_stack(
 
     // argv[1..user_argc] = user-provided args
     for (int i = 0; i < user_argc; i++) {
-        size_t arg_len = string::strnlen(user_argv[i], 255) + 1;
+        size_t arg_len = string::strnlen(user_argv[i], MAX_ARG_STRLEN - 1) + 1;
         size_t arg_padded = (arg_len + 7) & ~7ULL;
         str_cursor -= arg_padded;
         write(str_cursor, user_argv[i], arg_len);
         argv_vas[1 + i] = str_cursor;
     }
 
+    uintptr_t envp_vas[MAX_ENVP_PTRS];
+    for (int i = 0; i < user_envc; i++) {
+        size_t env_len = string::strnlen(user_envp[i], MAX_ARG_STRLEN - 1) + 1;
+        size_t env_padded = (env_len + 7) & ~7ULL;
+        str_cursor -= env_padded;
+        write(str_cursor, user_envp[i], env_len);
+        envp_vas[i] = str_cursor;
+    }
+
     uintptr_t sp = (str_cursor - struct_bytes) & ~0xFULL;
 
-    uint64_t data[1 + MAX_ARGV_PTRS + 1 + 1 + AUXV_WORDS];
+    uint64_t data[1 + MAX_ARGV_PTRS + 1 + MAX_ENVP_PTRS + 1 + AUXV_WORDS];
     size_t idx = 0;
     data[idx++] = static_cast<uint64_t>(total_argc);
     for (int i = 0; i < total_argc; i++) {
         data[idx++] = argv_vas[i];
     }
     data[idx++] = 0; // argv terminator (NULL)
+    for (int i = 0; i < user_envc; i++) {
+        data[idx++] = envp_vas[i];
+    }
     data[idx++] = 0; // envp terminator (NULL)
     data[idx++] = AT_PAGESZ; data[idx++] = pmm::PAGE_SIZE;
     data[idx++] = AT_PHDR;   data[idx++] = image.phdr_vaddr;
@@ -685,7 +707,8 @@ __PRIVILEGED_CODE static uintptr_t setup_user_stack(
  */
 __PRIVILEGED_CODE task* create_user_task(
     exec::loaded_image* image, const char* name,
-    int argc, const char* const* argv
+    int argc, const char* const* argv,
+    int envc, const char* const* envp
 ) {
     if (!image || !image->mm_ctx) {
         log::error("sched: invalid loaded image for user task");
@@ -772,9 +795,10 @@ __PRIVILEGED_CODE task* create_user_task(
     }
 
     uintptr_t user_sp = setup_user_stack(
-        last_stack_page_phys, mm::USER_STACK_TOP, *image, name, argc, argv);
+        last_stack_page_phys, mm::USER_STACK_TOP, *image, name,
+        argc, argv, envc, envp);
     if (user_sp == 0) {
-        log::error("sched: user stack setup failed (argv too large?)");
+        log::error("sched: user stack setup failed (argv/envp too large?)");
         mm::mm_context_unmap(mm_ctx, stack_max_base, total_bytes);
         vmm::free(sys_stack_base);
         heap::kfree_delete(t);

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -12,6 +12,10 @@ struct task;
 constexpr int32_t OK         = 0;
 constexpr int32_t ERR_NO_MEM = -1;
 
+// Exec-style string limits shared by proc_create copying and the user stack builder
+constexpr size_t MAX_ARG_STRLEN  = 256; // bytes per argv/envp string, including NUL
+constexpr size_t MAX_ARG_STRINGS = 64;  // strings per argv/envp array
+
 /**
  * @brief Initialize the scheduler for the BSP. Creates idle task,
  * per-CPU runqueue, and scheduling policy. Call after mm::init().
@@ -55,12 +59,15 @@ task* create_kernel_task(void (*entry)(void*), void* arg, const char* name,
  * @param name Debug name (copied into embedded task storage).
  * @param argc Number of user-provided arguments (excluding program name).
  * @param argv Array of kernel-copied argument strings, or nullptr for none.
+ * @param envc Number of environment strings.
+ * @param envp Array of kernel-copied environment strings, or nullptr for none.
  * @return task pointer on success, nullptr on failure.
  * @note Privilege: **required**
  */
 [[nodiscard]] __PRIVILEGED_CODE
 task* create_user_task(exec::loaded_image* image, const char* name,
-                       int argc = 0, const char* const* argv = nullptr);
+                       int argc = 0, const char* const* argv = nullptr,
+                       int envc = 0, const char* const* envp = nullptr);
 
 /**
  * @brief Create a new user thread in an existing user process.

--- a/kernel/syscall/handlers/sys_proc.cpp
+++ b/kernel/syscall/handlers/sys_proc.cpp
@@ -9,6 +9,7 @@
 #include "dynpriv/dynpriv.h"
 #include "exec/elf.h"
 #include "mm/uaccess.h"
+#include "mm/heap.h"
 #include "fs/fs.h"
 #include "fs/node.h"
 #include "fs/fstypes.h"
@@ -22,9 +23,83 @@ struct process_info {
     int cpu;
 };
 
-constexpr uint32_t MAX_PROC_ARGC = 64;
-constexpr size_t MAX_PROC_ARG_LEN = 256;
 constexpr size_t MAX_PROC_ARGV_TOTAL = 3500;
+
+// One bounded user string array copied into kernel storage
+struct proc_string_array {
+    char buf[MAX_PROC_ARGV_TOTAL];
+    const char* ptrs[sched::MAX_ARG_STRINGS];
+    int count;
+};
+
+// Everything proc_create copies out of user string arrays, heap-held
+// because the buffers dwarf the system stack
+struct proc_create_strings {
+    proc_string_array argv;
+    proc_string_array envp;
+};
+
+// Copies a NULL-terminated user pointer array of strings into arr. The
+// user address stays an opaque integer until uaccess validates each access.
+int64_t copy_proc_string_array_from_user(
+    proc_string_array& arr, uint64_t u_array
+) {
+    arr.count = 0;
+    if (u_array == 0) {
+        return 0;
+    }
+
+    size_t buf_offset = 0;
+    for (size_t i = 0; i < sched::MAX_ARG_STRINGS; i++) {
+        uintptr_t uptr = 0;
+        int32_t rc = mm::uaccess::copy_from_user(
+            &uptr,
+            reinterpret_cast<const uintptr_t*>(u_array) + i,
+            sizeof(uptr));
+        if (rc != mm::uaccess::OK) {
+            return syscall::EFAULT;
+        }
+        if (uptr == 0) {
+            break;
+        }
+
+        size_t remaining = MAX_PROC_ARGV_TOTAL - buf_offset;
+        if (remaining == 0) {
+            return syscall::ENAMETOOLONG;
+        }
+        size_t cap = remaining < sched::MAX_ARG_STRLEN
+                   ? remaining : sched::MAX_ARG_STRLEN;
+
+        rc = mm::uaccess::copy_cstr_from_user(
+            arr.buf + buf_offset, cap,
+            reinterpret_cast<const char*>(uptr));
+        if (rc == mm::uaccess::ERR_NAMETOOLONG) {
+            return syscall::ENAMETOOLONG;
+        }
+        if (rc != mm::uaccess::OK) {
+            return syscall::EFAULT;
+        }
+
+        size_t len = string::strnlen(arr.buf + buf_offset, cap);
+
+        arr.ptrs[arr.count] = arr.buf + buf_offset;
+        buf_offset += len + 1;
+        arr.count++;
+    }
+
+    return 0;
+}
+
+// Copies the full proc_create string payload in one step
+int64_t copy_proc_create_strings_from_user(
+    proc_create_strings& strs, uint64_t u_argv, uint64_t u_envp
+) {
+    int64_t rc = copy_proc_string_array_from_user(strs.argv, u_argv);
+    if (rc != 0) {
+        return rc;
+    }
+    return copy_proc_string_array_from_user(strs.envp, u_envp);
+}
 
 __PRIVILEGED_CODE static const char* path_basename(const char* path) {
     const char* base = path;
@@ -51,7 +126,7 @@ __PRIVILEGED_CODE static int64_t map_elf_error(int32_t rc) {
 
 } // anonymous namespace
 
-DEFINE_SYSCALL2(proc_create, u_path, u_argv) {
+DEFINE_SYSCALL3(proc_create, u_path, u_argv, u_envp) {
     sched::task* caller = sched::current();
     if (!caller) {
         return syscall::EIO;
@@ -68,59 +143,30 @@ DEFINE_SYSCALL2(proc_create, u_path, u_argv) {
         return syscall::EFAULT;
     }
 
-    char kargv_buf[MAX_PROC_ARGV_TOTAL];
-    const char* kargv_ptrs[MAX_PROC_ARGC];
-    int kargc = 0;
+    auto* strs = heap::kalloc_new<proc_create_strings>();
+    if (!strs) {
+        return syscall::ENOMEM;
+    }
 
-    if (u_argv != 0) {
-        size_t buf_offset = 0;
-        for (uint32_t i = 0; i < MAX_PROC_ARGC; i++) {
-            uintptr_t uptr = 0;
-            int32_t rc = mm::uaccess::copy_from_user(
-                &uptr,
-                reinterpret_cast<const uintptr_t*>(u_argv) + i,
-                sizeof(uptr));
-            if (rc != mm::uaccess::OK) {
-                return syscall::EFAULT;
-            }
-            if (uptr == 0) {
-                break;
-            }
-
-            size_t remaining = MAX_PROC_ARGV_TOTAL - buf_offset;
-            if (remaining == 0) {
-                return syscall::ENAMETOOLONG;
-            }
-            size_t cap = remaining < MAX_PROC_ARG_LEN ? remaining : MAX_PROC_ARG_LEN;
-
-            rc = mm::uaccess::copy_cstr_from_user(
-                kargv_buf + buf_offset,
-                cap,
-                reinterpret_cast<const char*>(uptr));
-            if (rc == mm::uaccess::ERR_NAMETOOLONG) {
-                return syscall::ENAMETOOLONG;
-            }
-            if (rc != mm::uaccess::OK) {
-                return syscall::EFAULT;
-            }
-
-            size_t len = string::strnlen(kargv_buf + buf_offset, cap);
-
-            kargv_ptrs[kargc] = kargv_buf + buf_offset;
-            buf_offset += len + 1;
-            kargc++;
-        }
+    int64_t rc = copy_proc_create_strings_from_user(*strs, u_argv, u_envp);
+    if (rc != 0) {
+        heap::kfree_delete(strs);
+        return rc;
     }
 
     exec::loaded_image loaded;
     int32_t elf_rc = exec::load_elf(kpath, &loaded, caller->cwd);
     if (elf_rc != exec::OK) {
+        heap::kfree_delete(strs);
         return map_elf_error(elf_rc);
     }
 
     const char* name = path_basename(kpath);
     sched::task* child = sched::create_user_task(
-        &loaded, name, kargc, kargc > 0 ? kargv_ptrs : nullptr);
+        &loaded, name,
+        strs->argv.count, strs->argv.count > 0 ? strs->argv.ptrs : nullptr,
+        strs->envp.count, strs->envp.count > 0 ? strs->envp.ptrs : nullptr);
+    heap::kfree_delete(strs);
     if (!child) {
         exec::unload_elf(&loaded);
         return syscall::ENOMEM;

--- a/userland/lib/libstlx/include/stlx/proc.h
+++ b/userland/lib/libstlx/include/stlx/proc.h
@@ -21,10 +21,17 @@ typedef struct {
 
 /**
  * Create a process from an ELF binary. Loads the ELF, creates a task in
- * TASK_STATE_CREATED (not scheduled). Returns a handle on success, -1 on
- * failure with errno set.
+ * TASK_STATE_CREATED (not scheduled). The child inherits the caller's
+ * environment. Returns a handle on success, -1 on failure with errno set.
  */
 int proc_create(const char* path, const char* argv[]);
+
+/**
+ * Like proc_create, but with an explicit NULL-terminated environment
+ * instead of inheriting the caller's.
+ */
+int proc_create_with_env(const char* path, const char* argv[],
+                         const char* envp[]);
 
 /**
  * Convenience: proc_create + proc_start in one call. Returns handle on

--- a/userland/lib/libstlx/src/proc.c
+++ b/userland/lib/libstlx/src/proc.c
@@ -4,7 +4,12 @@
 #include <unistd.h>
 
 int proc_create(const char* path, const char* argv[]) {
-    return (int)syscall(SYS_PROC_CREATE, path, argv);
+    return proc_create_with_env(path, argv, (const char**)environ);
+}
+
+int proc_create_with_env(const char* path, const char* argv[],
+                         const char* envp[]) {
+    return (int)syscall(SYS_PROC_CREATE, path, argv, envp);
 }
 
 int proc_exec(const char* path, const char* argv[]) {


### PR DESCRIPTION
## Summary
- Programs like Vim need TERM and HOME, but the kernel wrote an empty envp block and had no way to carry environment into a child.
- proc_create gains an envp argument copied with the same bounded limits as argv, now shared constants (MAX_ARG_STRLEN, MAX_ARG_STRINGS) between the copy path and the stack builder so the two can never drift.
- libstlx proc_create passes the caller's environ through (inheritance by default, matching cwd and stdio), with proc_create_with_env for explicit control. The kernel never invents environment values.

Made with [Cursor](https://cursor.com)