### PR TITLE
feat(userland): environment defaults in init and stlxterm

### DIFF
--- a/userland/apps/init/src/init.c
+++ b/userland/apps/init/src/init.c
@@ -2,6 +2,7 @@
 #define _POSIX_C_SOURCE 199309L
 #include <stlx/proc.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -16,6 +17,12 @@ int main(void) {
     open("/dev/console", O_RDWR); // fd 2
 
     setvbuf(stdout, NULL, _IONBF, 0);
+
+    // Base environment inherited by every descendant process
+    setenv("PATH", "/bin:/usr/bin", 1);
+    setenv("HOME", "/", 1);
+    setenv("SHELL", "/bin/shell", 1);
+    setenv("LANG", "C", 1);
 
     int dm_handle = proc_exec("/bin/stlxdm", NULL);
     if (dm_handle >= 0) {

--- a/userland/apps/stlxterm/src/stlxterm.c
+++ b/userland/apps/stlxterm/src/stlxterm.c
@@ -147,6 +147,9 @@ int main(void) {
     ioctl(slave_fd, STLX_TCSETS_RAW, 0);
     fcntl(master_fd, F_SETFL, O_NONBLOCK);
 
+    // Declare the escape dialect this terminal implements
+    setenv("TERM", "xterm", 1);
+
     int shell_proc = proc_create("/bin/shell", NULL);
     if (shell_proc < 0) {
         printf("stlxterm: failed to create shell\r\n");


### PR DESCRIPTION
## Summary
- With envp plumbing in place, nothing seeded the initial environment, so getenv(TERM) still returned nothing everywhere.
- init sets the system-wide baseline (PATH=/bin:/usr/bin, HOME, SHELL, LANG) once at the top of the process tree; every descendant inherits it.
- stlxterm declares TERM=xterm before spawning its shell, since only the terminal emulator knows which escape dialect it implements. The raw console shell correctly gets no TERM.

Made with [Cursor](https://cursor.com)