### PR TITLE
feat(userland): set PYTHONHOME so Python finds its stdlib

### DIFF
--- a/userland/apps/init/src/init.c
+++ b/userland/apps/init/src/init.c
@@ -23,6 +23,7 @@ int main(void) {
     setenv("HOME", "/", 1);
     setenv("SHELL", "/bin/shell", 1);
     setenv("LANG", "C", 1);
+    setenv("PYTHONHOME", "/usr", 1);
 
     int dm_handle = proc_exec("/bin/stlxdm", NULL);
     if (dm_handle >= 0) {

--- a/userland/apps/python/Makefile
+++ b/userland/apps/python/Makefile
@@ -138,10 +138,11 @@ $(PATCH_STAMP): | $(EXTRACT_STAMP)
 	@touch $@
 
 $(CONFIGURE_STAMP): $(PATCH_STAMP) config.site Modules.Setup.local
-	@mkdir -p $(BUILD_DIR)
+	@mkdir -p $(BUILD_DIR)/Modules
 	@echo "[CONF] CPython $(PY_VER) ($(ARCH))"
 	@echo "  SYSROOT=$(SYSROOT)"
 	@echo "  BUILTINS_LIB=$(BUILTINS_LIB)"
+	@cp Modules.Setup.local $(BUILD_DIR)/Modules/Setup.local
 	@cd $(BUILD_DIR) && \
 	CONFIG_SITE=$(CURDIR)/config.site \
 	CC="$(CC)" \
@@ -160,7 +161,6 @@ $(CONFIGURE_STAMP): $(PATCH_STAMP) config.site Modules.Setup.local
 		--disable-ipv6 \
 		--without-ensurepip \
 		--with-build-python=$$(command -v $(HOST_PYTHON))
-	@cp Modules.Setup.local $(BUILD_DIR)/Modules/Setup.local
 	@touch $@
 
 $(BUILD_STAMP): $(CONFIGURE_STAMP)


### PR DESCRIPTION
## Summary
- Python could not import its shipped standard library because getpath's landmark search failed to locate the install prefix, leaving /usr/lib/python3.12 off sys.path.
- init now exports PYTHONHOME=/usr, Python's designed mechanism for a fixed install location, so every interpreter resolves its stdlib deterministically without relying on executable-path introspection.

Made with [Cursor](https://cursor.com)