### PR TITLE
fix(build): added compiler header dependency tracking

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -133,6 +133,9 @@ CXXFLAGS_WARN ?= \
 	-Wall \
 	-Wextra
 
+# Header dependency generation (consumed by the -include at file end)
+CXXFLAGS_DEPS ?= -MMD -MP
+
 
 # Log level config flag
 CXXFLAGS_LOG := -DLOG_LEVEL=$(LOG_LEVEL)
@@ -177,13 +180,15 @@ CXXFLAGS := \
 	$(CXXFLAGS_LOG) \
 	$(CXXFLAGS_CONFIG) \
 	$(CXXFLAGS_INCLUDES) \
+	$(CXXFLAGS_DEPS) \
 	$(CXXFLAGS_EXTRA)
 
 # Assembly flags
 ASFLAGS := \
 	-ffreestanding \
 	$(ASFLAGS_ARCH) \
-	$(CXXFLAGS_INCLUDES)
+	$(CXXFLAGS_INCLUDES) \
+	$(CXXFLAGS_DEPS)
 
 # Linker flags
 LDFLAGS := \
@@ -294,3 +299,5 @@ endif
 	done
 	@echo "]" >> compile_commands.json
 	@echo "Created compile_commands.json"
+
+-include $(OBJECTS:.o=.d)

--- a/userland/lib/libbearssl/Makefile
+++ b/userland/lib/libbearssl/Makefile
@@ -71,6 +71,8 @@ $(BUILD_DIR)/%.o: %.c
 	@echo "[CC]  $< ($(ARCH))"
 	$(UQ)$(CC) $(EXTRA_CFLAGS) -c $< -o $@
 
+-include $(ALL_OBJS:.o=.d)
+
 clean:
 	$(UQ)rm -rf build
 	$(UQ)rm -f $(SYSROOT_LIB)/$(LIB_NAME)

--- a/userland/lib/libstlx/Makefile
+++ b/userland/lib/libstlx/Makefile
@@ -35,6 +35,8 @@ $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
 	@echo "[CC]  $< ($(ARCH))"
 	$(UQ)$(CC) $(CFLAGS_COMMON) -I$(INCLUDE_DIR) -c $< -o $@
 
+-include $(OBJECTS:.o=.d)
+
 clean:
 	$(UQ)rm -rf build
 	$(UQ)rm -f $(SYSROOT_LIB)/$(LIB_NAME)

--- a/userland/lib/libstlxcxx/Makefile
+++ b/userland/lib/libstlxcxx/Makefile
@@ -37,6 +37,8 @@ $(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp
 	@echo "[CXX] $< ($(ARCH))"
 	$(UQ)$(CXX) $(CXXFLAGS_COMMON) -I$(INCLUDE_DIR) -c $< -o $@
 
+-include $(OBJECTS:.o=.d)
+
 clean:
 	$(UQ)rm -rf build
 	$(UQ)rm -f $(SYSROOT_LIB)/$(LIB_NAME)

--- a/userland/lib/libstlxgfx/Makefile
+++ b/userland/lib/libstlxgfx/Makefile
@@ -35,6 +35,8 @@ $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
 	@echo "[CC]  $< ($(ARCH))"
 	$(UQ)$(CC) $(CFLAGS_COMMON) -I$(INCLUDE_DIR) -c $< -o $@
 
+-include $(OBJECTS:.o=.d)
+
 clean:
 	$(UQ)rm -rf build
 	$(UQ)rm -f $(SYSROOT_LIB)/$(LIB_NAME)

--- a/userland/mk/app.mk
+++ b/userland/mk/app.mk
@@ -36,6 +36,8 @@ $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
 	@echo "[CC]  $< ($(ARCH))"
 	$(UQ)$(CC) $(CFLAGS_COMMON) -c $< -o $@
 
+-include $(OBJECTS:.o=.d)
+
 clean:
 	$(UQ)rm -rf build
 	$(UQ)rm -f $(TARGET)

--- a/userland/mk/cxxapp.mk
+++ b/userland/mk/cxxapp.mk
@@ -56,6 +56,8 @@ $(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp
 	@echo "[CXX] $< ($(ARCH))"
 	$(UQ)$(CXX) $(CXXFLAGS_COMMON) -c $< -o $@
 
+-include $(OBJECTS:.o=.d)
+
 clean:
 	$(UQ)rm -rf build
 	$(UQ)rm -f $(TARGET)

--- a/userland/mk/toolchain.mk
+++ b/userland/mk/toolchain.mk
@@ -32,7 +32,8 @@ CFLAGS_COMMON := \
 	-isystem $(SYSROOT)/include \
 	-std=c11 -O2 -g \
 	-Wall -Wextra -Werror \
-	-fno-stack-protector
+	-fno-stack-protector \
+	-MMD -MP
 
 # C++ flags for userland applications (requires 'make libcxx' sysroot).
 # libc++ headers must come before musl C headers in the include path.
@@ -44,7 +45,8 @@ CXXFLAGS_COMMON := \
 	-isystem $(SYSROOT)/include \
 	-std=c++20 -O2 -g \
 	-Wall -Wextra -Werror \
-	-fno-stack-protector
+	-fno-stack-protector \
+	-MMD -MP
 
 # Runtime builtins are required for compiler helper symbols referenced by musl
 # (notably on aarch64 long-double printf paths). Preference order: the


### PR DESCRIPTION
## Summary
- Header edits did not rebuild objects compiled from unchanged sources, so the linker silently mixed ABI-incompatible objects; most recently a config struct layout change shipped an stlxdm whose taskbar module read fields at stale offsets, hiding the dock.
- Compiles emit dependency files (-MMD -MP via a kernel CXXFLAGS_DEPS component and the userland common flags), and each Makefile -includes the generated .d files, so a header edit rebuilds exactly its dependents.
- Flag-change and sysroot-update staleness remain separate concerns covered by full rebuilds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only build correctness change; no runtime, security, or application logic modified.
> 
> **Overview**
> **Incremental builds now rebuild objects when included headers change**, fixing cases where stale `.o` files could be linked after ABI/layout changes (e.g. config struct updates) without recompiling dependents.
> 
> The kernel adds **`CXXFLAGS_DEPS`** (`-MMD -MP`) to C++ and assembly compiles and **`-include`s** generated `*.d` files next to objects. Userland centralizes the same flags in **`CFLAGS_COMMON` / `CXXFLAGS_COMMON`** in `toolchain.mk`, and kernel libs, apps, and cxx apps **`-include`** their object dependency lists.
> 
> **Out of scope:** flag or sysroot changes still need a full rebuild; this only tracks header edits per translation unit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5415af7dfcde0a7d251ba8e4358c526ae8183965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->