### PR TITLE
feat(signals): added signal state types

### DIFF
--- a/kernel/sched/sched.cpp
+++ b/kernel/sched/sched.cpp
@@ -588,6 +588,7 @@ __PRIVILEGED_CODE task* create_kernel_task(
     t->proc_res = nullptr;
     t->cwd = nullptr;
     t->kill_pending = 0;
+    t->sig = {};
     t->group = nullptr;
     t->group_link = {};
 
@@ -846,6 +847,7 @@ __PRIVILEGED_CODE task* create_user_task(
     t->proc_res = nullptr;
     t->cwd = nullptr;
     t->kill_pending = 0;
+    t->sig = {};
 
     auto* tg = heap::kalloc_new<thread_group>();
     if (!tg) {
@@ -864,6 +866,7 @@ __PRIVILEGED_CODE task* create_user_task(
     }
     tg->lock = sync::SPINLOCK_INIT;
     tg->leader = t;
+    tg->pid = t->tid;
     tg->threads.init();
     tg->thread_count = 0;
     t->group = tg; // task takes ownership of the initial ref (refcount=1)
@@ -936,6 +939,8 @@ __PRIVILEGED_CODE task* create_user_thread(
     t->exit_code = 0;
     t->cleanup_stage = TASK_CLEANUP_STAGE_ACTIVE;
     t->kill_pending = 0;
+    t->sig = {};
+    t->sig.blocked = __atomic_load_n(&creator->sig.blocked, __ATOMIC_ACQUIRE);
     string::memcpy(t->name, name, string::strnlen(name, TASK_NAME_MAX - 1)); 
     t->name[string::strnlen(name, TASK_NAME_MAX - 1)] = '\0';
 
@@ -1028,6 +1033,7 @@ __PRIVILEGED_CODE int32_t init() {
     resource::init_task_handles(idle);
     idle->proc_res = nullptr;
     idle->cwd = nullptr;
+    idle->sig = {};
     idle->group = nullptr;
     idle->group_link = {};
 

--- a/kernel/sched/task.h
+++ b/kernel/sched/task.h
@@ -6,6 +6,7 @@
 #include "common/hashmap.h"
 #include "rc/ref_counted.h"
 #include "rc/reaper.h"
+#include "signals/signal_types.h"
 #include "sync/spinlock.h"
 #include "resource/handle_table.h"
 
@@ -67,6 +68,9 @@ struct task {
     uintptr_t      task_stack_base;
     uintptr_t      sys_stack_base;
 
+    // Signals (per-thread blocked mask and pending set)
+    signals::task_signals sig;
+
     // Scheduler state
     list::node              sched_link;
     list::node              wait_link;
@@ -95,8 +99,12 @@ static_assert(__builtin_offsetof(task, exec) == 0,
 struct thread_group : rc::ref_counted<thread_group> {
     sync::spinlock lock;
     task*          leader;
+    uint32_t       pid; // process leader tid
     list::head<task, &task::group_link> threads; // non-leader threads only
     uint32_t       thread_count; // number of live non-leader threads
+
+    // Signals (per-process action table and shared pending set)
+    signals::group_signals sig;
 
     /**
      * @note Privilege: **required**

--- a/kernel/signals/signal_types.h
+++ b/kernel/signals/signal_types.h
@@ -1,0 +1,88 @@
+#ifndef STELLUX_SIGNALS_SIGNAL_TYPES_H
+#define STELLUX_SIGNALS_SIGNAL_TYPES_H
+
+#include "common/types.h"
+#include "sync/spinlock.h"
+
+namespace signals {
+
+// Signal numbers matching the musl ABI
+constexpr uint32_t SIGHUP   = 1;
+constexpr uint32_t SIGINT   = 2;
+constexpr uint32_t SIGQUIT  = 3;
+constexpr uint32_t SIGILL   = 4;
+constexpr uint32_t SIGTRAP  = 5;
+constexpr uint32_t SIGABRT  = 6;
+constexpr uint32_t SIGBUS   = 7;
+constexpr uint32_t SIGFPE   = 8;
+constexpr uint32_t SIGKILL  = 9;
+constexpr uint32_t SIGUSR1  = 10;
+constexpr uint32_t SIGSEGV  = 11;
+constexpr uint32_t SIGUSR2  = 12;
+constexpr uint32_t SIGPIPE  = 13;
+constexpr uint32_t SIGALRM  = 14;
+constexpr uint32_t SIGTERM  = 15;
+constexpr uint32_t SIGCHLD  = 17;
+constexpr uint32_t SIGCONT  = 18;
+constexpr uint32_t SIGSTOP  = 19;
+constexpr uint32_t SIGTSTP  = 20;
+constexpr uint32_t SIGTTIN  = 21;
+constexpr uint32_t SIGTTOU  = 22;
+constexpr uint32_t SIGURG   = 23;
+constexpr uint32_t SIGWINCH = 28;
+constexpr uint32_t NSIG     = 64; // highest valid signal number
+
+// User handler sentinels (match musl SIG_DFL / SIG_IGN)
+constexpr uintptr_t SIG_DFL = 0;
+constexpr uintptr_t SIG_IGN = 1;
+
+// sigaction flags (musl ABI subset the kernel interprets)
+constexpr uint64_t SA_SIGINFO   = 0x00000004;
+constexpr uint64_t SA_RESTORER  = 0x04000000;
+constexpr uint64_t SA_ONSTACK   = 0x08000000;
+constexpr uint64_t SA_RESTART   = 0x10000000;
+constexpr uint64_t SA_NODEFER   = 0x40000000;
+constexpr uint64_t SA_RESETHAND = 0x80000000;
+
+// Bitmask of signals 1..64: bit (N-1) represents signal N
+using sig_set_t = uint64_t;
+
+constexpr sig_set_t sig_bit(uint32_t sig) {
+    return 1ULL << (sig - 1);
+}
+
+constexpr bool sig_valid(uint32_t sig) {
+    return sig >= 1 && sig <= NSIG;
+}
+
+// POSIX: SIGKILL and SIGSTOP can never be blocked, caught, or ignored
+constexpr sig_set_t UNBLOCKABLE_MASK = sig_bit(SIGKILL) | sig_bit(SIGSTOP);
+
+// Kernel-side layout matches the musl k_sigaction struct
+// passed to rt_sigaction (handler, flags, restorer, 64-bit mask).
+struct k_sigaction {
+    uintptr_t handler;
+    uint64_t  flags;
+    uintptr_t restorer;
+    sig_set_t mask;
+};
+
+static_assert(sizeof(k_sigaction) == 32, "k_sigaction must match musl rt_sigaction layout");
+
+// Per-task signal state. pending is set by senders,
+// blocked is written only by the owning task.
+struct task_signals {
+    sig_set_t blocked;
+    sig_set_t pending;
+};
+
+// Per-process signal state shared by all threads in a thread group.
+struct group_signals {
+    sync::spinlock lock; // guards actions
+    sig_set_t shared_pending;
+    k_sigaction actions[NSIG];
+};
+
+} // namespace signals
+
+#endif // STELLUX_SIGNALS_SIGNAL_TYPES_H

--- a/kernel/tests/signals/signal_types.test.cpp
+++ b/kernel/tests/signals/signal_types.test.cpp
@@ -1,0 +1,24 @@
+#define STLX_TEST_TIER TIER_UTIL
+
+#include "stlx_unit_test.h"
+#include "signals/signal_types.h"
+
+TEST_SUITE(signal_types);
+
+TEST(signal_types, sig_bit_maps_signal_to_bitmask) {
+    EXPECT_EQ(signals::sig_bit(1), 1ULL);
+    EXPECT_EQ(signals::sig_bit(signals::SIGKILL), 1ULL << 8);
+    EXPECT_EQ(signals::sig_bit(64), 1ULL << 63);
+}
+
+TEST(signal_types, sig_valid_bounds) {
+    EXPECT_FALSE(signals::sig_valid(0));
+    EXPECT_TRUE(signals::sig_valid(1));
+    EXPECT_TRUE(signals::sig_valid(64));
+    EXPECT_FALSE(signals::sig_valid(65));
+}
+
+TEST(signal_types, unblockable_mask_is_kill_and_stop) {
+    EXPECT_EQ(signals::UNBLOCKABLE_MASK,
+              signals::sig_bit(signals::SIGKILL) | signals::sig_bit(signals::SIGSTOP));
+}


### PR DESCRIPTION
## Summary
- POSIX signals need per-thread blocked/pending sets and a per-process action table before any send or delivery machinery can exist.
- Adds the signals data model: 64-bit signal sets with helpers, a k_sigaction record byte-matched to the musl rt_sigaction ABI (static_asserted), task and thread_group state fields with initialization at every task creation site, and POSIX mask inheritance for new threads.
- First of a stacked series: state operations, the syscall surface, and process identity land separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-model and initialization only—no delivery or syscalls yet; `task.exec` remains at offset 0 for assembly.
> 
> **Overview**
> Introduces the **POSIX signal data model** ahead of send/delivery syscalls: musl-aligned signal numbers, 64-bit `sig_set_t` helpers, `k_sigaction` (32-byte layout asserted against musl), plus per-thread `task_signals` (blocked/pending) and per-process `group_signals` (shared pending, action table, lock).
> 
> **`task`** and **`thread_group`** now carry those fields; **`thread_group::pid`** is set to the leader’s `tid` at user process creation. Every task creation path zero-initializes `sig`, and **new user threads inherit the creator’s blocked mask** via an atomic load. Small unit tests cover `sig_bit`, `sig_valid`, and `UNBLOCKABLE_MASK`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf60c124e12204f4be36f8ba6e0bee8cd040931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->