### PR TITLE
feat(syscall): implemented signal management syscalls

### DIFF
--- a/kernel/arch/aarch64/syscall/linux_syscalls.h
+++ b/kernel/arch/aarch64/syscall/linux_syscalls.h
@@ -39,6 +39,7 @@ constexpr uint64_t CLOCK_GETTIME    = 113;
 constexpr uint64_t CLOCK_GETRES     = 114;
 constexpr uint64_t RT_SIGACTION     = 134;
 constexpr uint64_t RT_SIGPROCMASK   = 135;
+constexpr uint64_t RT_SIGPENDING    = 136;
 constexpr uint64_t UNAME            = 160;
 constexpr uint64_t GETTIMEOFDAY     = 169;
 constexpr uint64_t GETPID           = 172;

--- a/kernel/arch/x86_64/syscall/linux_syscalls.h
+++ b/kernel/arch/x86_64/syscall/linux_syscalls.h
@@ -60,6 +60,7 @@ constexpr uint64_t GETUID           = 102;
 constexpr uint64_t GETGID           = 104;
 constexpr uint64_t GETEUID          = 107;
 constexpr uint64_t GETEGID          = 108;
+constexpr uint64_t RT_SIGPENDING    = 127;
 constexpr uint64_t ARCH_PRCTL       = 158;
 constexpr uint64_t GETDENTS64       = 217;
 constexpr uint64_t SET_TID_ADDRESS  = 218;

--- a/kernel/syscall/handlers/sys_signal.cpp
+++ b/kernel/syscall/handlers/sys_signal.cpp
@@ -1,19 +1,103 @@
 #include "syscall/handlers/sys_signal.h"
+#include "signals/signal.h"
+#include "sched/sched.h"
+#include "sched/task.h"
+#include "mm/uaccess.h"
 
-// No-op stub: Stellux does not deliver signals yet
+// musl passes sigsetsize = _NSIG/8 = 8 (64-bit sigset)
+static constexpr uint64_t SIGSET_SIZE = 8;
+
 DEFINE_SYSCALL4(rt_sigaction, signum, u_act, u_oldact, sigsetsize) {
-    (void)signum;
-    (void)u_act;
-    (void)u_oldact;
-    (void)sigsetsize;
+    if (sigsetsize != SIGSET_SIZE) {
+        return syscall::EINVAL;
+    }
+
+    sched::task* t = sched::current();
+    if (!t || !t->group) {
+        return syscall::EINVAL;
+    }
+
+    signals::k_sigaction kact;
+    if (u_act != 0) {
+        if (mm::uaccess::copy_from_user(
+                &kact, reinterpret_cast<const void*>(u_act),
+                sizeof(kact)) != mm::uaccess::OK) {
+            return syscall::EFAULT;
+        }
+    }
+
+    signals::k_sigaction kold;
+    int32_t rc = signals::set_action(
+        t->group, static_cast<uint32_t>(signum),
+        u_act != 0 ? &kact : nullptr,
+        u_oldact != 0 ? &kold : nullptr);
+    if (rc != signals::OK) {
+        return syscall::EINVAL;
+    }
+
+    if (u_oldact != 0) {
+        if (mm::uaccess::copy_to_user(
+                reinterpret_cast<void*>(u_oldact), &kold,
+                sizeof(kold)) != mm::uaccess::OK) {
+            return syscall::EFAULT;
+        }
+    }
     return 0;
 }
 
-// No-op stub: signal mask manipulation has no effect without signal delivery
 DEFINE_SYSCALL4(rt_sigprocmask, how, u_set, u_oldset, sigsetsize) {
-    (void)how;
-    (void)u_set;
-    (void)u_oldset;
-    (void)sigsetsize;
+    if (sigsetsize != SIGSET_SIZE) {
+        return syscall::EINVAL;
+    }
+
+    sched::task* t = sched::current();
+    if (!t) {
+        return syscall::EINVAL;
+    }
+
+    signals::sig_set_t kset = 0;
+    if (u_set != 0) {
+        if (mm::uaccess::copy_from_user(
+                &kset, reinterpret_cast<const void*>(u_set),
+                sizeof(kset)) != mm::uaccess::OK) {
+            return syscall::EFAULT;
+        }
+    }
+
+    signals::sig_set_t kold = 0;
+    int32_t rc = signals::set_blocked(
+        t, static_cast<uint32_t>(how),
+        u_set != 0 ? &kset : nullptr,
+        u_oldset != 0 ? &kold : nullptr);
+    if (rc != signals::OK) {
+        return syscall::EINVAL;
+    }
+
+    if (u_oldset != 0) {
+        if (mm::uaccess::copy_to_user(
+                reinterpret_cast<void*>(u_oldset), &kold,
+                sizeof(kold)) != mm::uaccess::OK) {
+            return syscall::EFAULT;
+        }
+    }
+    return 0;
+}
+
+DEFINE_SYSCALL2(rt_sigpending, u_set, sigsetsize) {
+    if (sigsetsize != SIGSET_SIZE) {
+        return syscall::EINVAL;
+    }
+
+    sched::task* t = sched::current();
+    if (!t) {
+        return syscall::EINVAL;
+    }
+
+    signals::sig_set_t pending = signals::pending_blocked_set(t);
+    if (mm::uaccess::copy_to_user(
+            reinterpret_cast<void*>(u_set), &pending,
+            sizeof(pending)) != mm::uaccess::OK) {
+        return syscall::EFAULT;
+    }
     return 0;
 }

--- a/kernel/syscall/handlers/sys_signal.h
+++ b/kernel/syscall/handlers/sys_signal.h
@@ -5,5 +5,6 @@
 
 DECLARE_SYSCALL(rt_sigaction);
 DECLARE_SYSCALL(rt_sigprocmask);
+DECLARE_SYSCALL(rt_sigpending);
 
 #endif // STELLUX_SYSCALL_HANDLERS_SYS_SIGNAL_H

--- a/kernel/syscall/syscall_table.cpp
+++ b/kernel/syscall/syscall_table.cpp
@@ -57,6 +57,7 @@ __PRIVILEGED_CODE void init_syscall_table() {
     REGISTER_SYSCALL(linux_nr::MMAP,            mmap);
     REGISTER_SYSCALL(linux_nr::RT_SIGACTION,    rt_sigaction);
     REGISTER_SYSCALL(linux_nr::RT_SIGPROCMASK,  rt_sigprocmask);
+    REGISTER_SYSCALL(linux_nr::RT_SIGPENDING,   rt_sigpending);
     REGISTER_SYSCALL(linux_nr::MPROTECT,        mprotect);
     REGISTER_SYSCALL(linux_nr::MUNMAP,          munmap);
     REGISTER_SYSCALL(linux_nr::EXIT,            exit);

--- a/kernel/tests/signals/signal_syscalls.test.cpp
+++ b/kernel/tests/signals/signal_syscalls.test.cpp
@@ -1,0 +1,29 @@
+#define STLX_TEST_TIER TIER_SCHED
+
+#include "stlx_unit_test.h"
+#include "signals/signal.h"
+#include "syscall/handlers/sys_signal.h"
+#include "dynpriv/dynpriv.h"
+
+TEST_SUITE(signal_syscalls);
+
+// musl always passes sigsetsize 8, anything else must be rejected
+TEST(signal_syscalls, rejects_wrong_sigsetsize) {
+    int64_t rc = 0;
+
+    RUN_ELEVATED({ rc = sys_rt_sigaction(signals::SIGINT, 0, 0, 4, 0, 0); });
+    EXPECT_EQ(rc, syscall::EINVAL);
+
+    RUN_ELEVATED({ rc = sys_rt_sigprocmask(signals::SIG_BLOCK, 0, 0, 16, 0, 0); });
+    EXPECT_EQ(rc, syscall::EINVAL);
+
+    RUN_ELEVATED({ rc = sys_rt_sigpending(0, 4, 0, 0, 0, 0); });
+    EXPECT_EQ(rc, syscall::EINVAL);
+}
+
+// Kernel tasks have no thread group, so no action table to modify
+TEST(signal_syscalls, sigaction_requires_a_process) {
+    int64_t rc = 0;
+    RUN_ELEVATED({ rc = sys_rt_sigaction(signals::SIGINT, 0, 0, 8, 0, 0); });
+    EXPECT_EQ(rc, syscall::EINVAL);
+}


### PR DESCRIPTION
## Summary
- rt_sigaction and rt_sigprocmask were silent no-op stubs: musl programs installed signal handlers and masks the kernel discarded.
- The handlers validate scalar arguments, copy user structures in and out with uaccess before any lock is held, and delegate every semantic rule to the signal state operations, keeping policy out of the syscall boundary.
- rt_sigpending lands alongside them with its musl syscall numbers registered on both architectures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Signal mask and handler state now affect user processes via user-memory copies; incorrect validation or uaccess could corrupt task signal state, though logic is delegated to existing signal layer.
> 
> **Overview**
> **Replaces no-op signal syscall stubs** with handlers that validate musl’s 8-byte `sigsetsize`, copy `k_sigaction` / sigset buffers via `uaccess`, and delegate semantics to `signals::set_action`, `set_blocked`, and `pending_blocked_set`.
> 
> **Adds `rt_sigpending`**, wired with `RT_SIGPENDING` on aarch64 (136) and x86_64 (127) and registered in the syscall table. **`rt_sigaction`** now requires a current task with a thread group (kernel tasks without a process get `EINVAL`).
> 
> Unit tests cover wrong `sigsetsize` rejection and the process requirement for `sigaction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43d6f9525dc89797aae44cc44f2c89d49d6bf324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->