### PR TITLE
feat(syscall): made getpid process-scoped and added gettid

### DIFF
--- a/kernel/arch/aarch64/syscall/linux_syscalls.h
+++ b/kernel/arch/aarch64/syscall/linux_syscalls.h
@@ -47,6 +47,7 @@ constexpr uint64_t GETUID           = 174;
 constexpr uint64_t GETEUID          = 175;
 constexpr uint64_t GETGID           = 176;
 constexpr uint64_t GETEGID          = 177;
+constexpr uint64_t GETTID           = 178;
 constexpr uint64_t SOCKET           = 198;
 constexpr uint64_t SOCKETPAIR       = 199;
 constexpr uint64_t BIND             = 200;

--- a/kernel/arch/x86_64/syscall/linux_syscalls.h
+++ b/kernel/arch/x86_64/syscall/linux_syscalls.h
@@ -62,6 +62,7 @@ constexpr uint64_t GETEUID          = 107;
 constexpr uint64_t GETEGID          = 108;
 constexpr uint64_t RT_SIGPENDING    = 127;
 constexpr uint64_t ARCH_PRCTL       = 158;
+constexpr uint64_t GETTID           = 186;
 constexpr uint64_t GETDENTS64       = 217;
 constexpr uint64_t SET_TID_ADDRESS  = 218;
 constexpr uint64_t CLOCK_GETTIME    = 228;

--- a/kernel/syscall/handlers/sys_task.cpp
+++ b/kernel/syscall/handlers/sys_task.cpp
@@ -4,6 +4,11 @@
 #include "mm/uaccess.h"
 
 DEFINE_SYSCALL0(getpid) {
+    sched::task* t = sched::current();
+    return static_cast<int64_t>(t->group ? t->group->pid : t->tid);
+}
+
+DEFINE_SYSCALL0(gettid) {
     return static_cast<int64_t>(sched::current()->tid);
 }
 

--- a/kernel/syscall/handlers/sys_task.h
+++ b/kernel/syscall/handlers/sys_task.h
@@ -4,6 +4,7 @@
 #include "syscall/syscall_table.h"
 
 DECLARE_SYSCALL(getpid);
+DECLARE_SYSCALL(gettid);
 DECLARE_SYSCALL(getuid);
 DECLARE_SYSCALL(geteuid);
 DECLARE_SYSCALL(getgid);

--- a/kernel/syscall/syscall_table.cpp
+++ b/kernel/syscall/syscall_table.cpp
@@ -58,6 +58,7 @@ __PRIVILEGED_CODE void init_syscall_table() {
     REGISTER_SYSCALL(linux_nr::RT_SIGACTION,    rt_sigaction);
     REGISTER_SYSCALL(linux_nr::RT_SIGPROCMASK,  rt_sigprocmask);
     REGISTER_SYSCALL(linux_nr::RT_SIGPENDING,   rt_sigpending);
+    REGISTER_SYSCALL(linux_nr::GETTID,          gettid);
     REGISTER_SYSCALL(linux_nr::MPROTECT,        mprotect);
     REGISTER_SYSCALL(linux_nr::MUNMAP,          munmap);
     REGISTER_SYSCALL(linux_nr::EXIT,            exit);


### PR DESCRIPTION
## Summary
- getpid returned the calling task's tid, giving each thread of a process a different pid and leaving process-directed operations like kill(getpid()) unable to name the process.
- getpid now returns the thread group leader's tid per POSIX, with the task tid as the fallback for group-less kernel tasks.
- gettid lands alongside it since musl implements thread-directed calls such as raise() via tkill(gettid()).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> getpid semantics change for threaded userland; incorrect group/pid handling could break signals or process targeting, though the change corrects prior non-POSIX behavior.
> 
> **Overview**
> **`getpid`** no longer returns the calling thread’s `tid`; it now returns the thread group leader’s `pid` when the task has a `thread_group`, and falls back to `tid` for group-less kernel tasks. That aligns process-wide identity with POSIX/Linux expectations (e.g. `kill(getpid())` naming the whole process).
> 
> A new **`gettid`** syscall is wired on aarch64 (178) and x86_64 (186), registered in the syscall table, and implemented to return the current task’s `tid`—supporting libc patterns like `tkill(gettid())` for thread-directed signals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693bd72d036ebff4266368987667f07d446ae4cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->