### PR TITLE
fix(signals): enforced POSIX invariants when installing actions

### DIFF
--- a/kernel/signals/signal.cpp
+++ b/kernel/signals/signal.cpp
@@ -35,11 +35,18 @@ __PRIVILEGED_CODE int32_t set_action(sched::thread_group* tg, uint32_t sig,
         *old = tg->sig.actions[sig - 1];
     }
     if (act) {
-        tg->sig.actions[sig - 1] = *act;
-        // Discard while holding sig.lock so a concurrent sigaction cannot
-        // install a handler between the install and the flush. Nests
-        // tg->lock inside sig.lock, no path takes them in reverse order.
-        if (act->handler == SIG_IGN) {
+        k_sigaction stored = *act;
+
+        // POSIX: the handler mask can never block SIGKILL/SIGSTOP
+        stored.mask &= ~UNBLOCKABLE_MASK;
+        tg->sig.actions[sig - 1] = stored;
+
+        // POSIX: an ignoring disposition discards pending instances. Doing
+        // it under sig.lock keeps install and flush atomic (nests tg->lock).
+        bool ignores = stored.handler == SIG_IGN ||
+            (stored.handler == SIG_DFL && dfl_action(sig) == default_action::IGNORE);
+
+        if (ignores) {
             discard_pending(tg, sig);
         }
     }

--- a/kernel/signals/signal_types.h
+++ b/kernel/signals/signal_types.h
@@ -58,6 +58,31 @@ constexpr bool sig_valid(uint32_t sig) {
 // POSIX: SIGKILL and SIGSTOP can never be blocked, caught, or ignored
 constexpr sig_set_t UNBLOCKABLE_MASK = sig_bit(SIGKILL) | sig_bit(SIGSTOP);
 
+// What SIG_DFL means for each signal. Stop-class defaults are not
+// implemented, so callers pick their own fallback where one is needed.
+enum class default_action : uint8_t {
+    TERM,
+    IGNORE,
+    STOP,
+};
+
+constexpr default_action dfl_action(uint32_t sig) {
+    switch (sig) {
+        case SIGCHLD:
+        case SIGCONT:
+        case SIGURG:
+        case SIGWINCH:
+            return default_action::IGNORE;
+        case SIGSTOP:
+        case SIGTSTP:
+        case SIGTTIN:
+        case SIGTTOU:
+            return default_action::STOP;
+        default:
+            return default_action::TERM;
+    }
+}
+
 // Kernel-side layout matches the musl k_sigaction struct
 // passed to rt_sigaction (handler, flags, restorer, 64-bit mask).
 struct k_sigaction {

--- a/kernel/tests/signals/signal_state.test.cpp
+++ b/kernel/tests/signals/signal_state.test.cpp
@@ -170,6 +170,61 @@ TEST(signal_state, set_action_allows_query_of_kill) {
     EXPECT_EQ(old.handler, signals::SIG_DFL);
 }
 
+TEST(signal_state, dfl_action_classification) {
+    EXPECT_TRUE(signals::dfl_action(signals::SIGTERM) == signals::default_action::TERM);
+    EXPECT_TRUE(signals::dfl_action(signals::SIGKILL) == signals::default_action::TERM);
+    EXPECT_TRUE(signals::dfl_action(signals::SIGSEGV) == signals::default_action::TERM);
+    EXPECT_TRUE(signals::dfl_action(signals::SIGCHLD) == signals::default_action::IGNORE);
+    EXPECT_TRUE(signals::dfl_action(signals::SIGCONT) == signals::default_action::IGNORE);
+    EXPECT_TRUE(signals::dfl_action(signals::SIGURG) == signals::default_action::IGNORE);
+    EXPECT_TRUE(signals::dfl_action(signals::SIGWINCH) == signals::default_action::IGNORE);
+    EXPECT_TRUE(signals::dfl_action(signals::SIGSTOP) == signals::default_action::STOP);
+    EXPECT_TRUE(signals::dfl_action(signals::SIGTSTP) == signals::default_action::STOP);
+    EXPECT_TRUE(signals::dfl_action(64) == signals::default_action::TERM);
+}
+
+TEST(signal_state, set_action_strips_unblockables_from_mask) {
+    signals::k_sigaction act = {};
+    act.handler = 0x400000;
+    act.mask = signals::sig_bit(signals::SIGUSR1) | signals::UNBLOCKABLE_MASK;
+
+    int32_t rc = 0;
+    RUN_ELEVATED({
+        rc = signals::set_action(g_tg, signals::SIGINT, &act, nullptr);
+    });
+    EXPECT_EQ(rc, signals::OK);
+
+    signals::k_sigaction old = {};
+    RUN_ELEVATED({
+        rc = signals::set_action(g_tg, signals::SIGINT, nullptr, &old);
+    });
+    EXPECT_EQ(rc, signals::OK);
+    EXPECT_EQ(old.mask, signals::sig_bit(signals::SIGUSR1));
+}
+
+TEST(signal_state, dfl_on_default_ignore_signal_discards_pending) {
+    const signals::sig_set_t sigchld = signals::sig_bit(signals::SIGCHLD);
+    const signals::sig_set_t sigtstp = signals::sig_bit(signals::SIGTSTP);
+
+    g_tg->sig.shared_pending = sigchld | sigtstp;
+    g_leader->sig.pending    = sigchld | sigtstp;
+
+    signals::k_sigaction act = {};
+    act.handler = signals::SIG_DFL;
+    int32_t rc = 0;
+    RUN_ELEVATED({
+        rc = signals::set_action(g_tg, signals::SIGCHLD, &act, nullptr);
+        if (rc == signals::OK) {
+            rc = signals::set_action(g_tg, signals::SIGTSTP, &act, nullptr);
+        }
+    });
+    EXPECT_EQ(rc, signals::OK);
+
+    // Default-ignore SIGCHLD is discarded, stop-class SIGTSTP is not
+    EXPECT_EQ(g_tg->sig.shared_pending, sigtstp);
+    EXPECT_EQ(g_leader->sig.pending, sigtstp);
+}
+
 TEST(signal_state, sig_ign_discards_pending) {
     const signals::sig_set_t sigusr1 = signals::sig_bit(signals::SIGUSR1);
     const signals::sig_set_t sigterm = signals::sig_bit(signals::SIGTERM);


### PR DESCRIPTION
## Summary
- set_action stored handler masks verbatim, so SIGKILL/SIGSTOP bits could persist and later hide a pending SIGKILL once delivery masking consumes sa_mask, and pending instances were only discarded for SIG_IGN.
- Stored masks are stripped of unblockable bits, and the discard now covers both POSIX ignore paths: SIG_IGN and SIG_DFL on default-ignore signals (SIGCHLD, SIGCONT, SIGURG, SIGWINCH), while stop-class defaults are preserved.
- The default-action classification table joins the signal types, with tests pinning the classification, the mask stripping, and the discard distinction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core signal disposition and pending-queue behavior on the rt_sigaction path; incorrect classification or discard logic could drop or mishandle signals process-wide.
> 
> **Overview**
> **`set_action`** now enforces POSIX rules when installing signal handlers: stored **`sa_mask`** bits for **SIGKILL** and **SIGSTOP** are stripped so delivery masking cannot hide unblockable signals, and pending instances are flushed not only for **`SIG_IGN`** but also for **`SIG_DFL`** on signals whose default is ignore (**SIGCHLD**, **SIGCONT**, **SIGURG**, **SIGWINCH**). Stop-class defaults (**SIGTSTP**, etc.) still do not trigger discard.
> 
> A **`dfl_action()`** / **`default_action`** table in **`signal_types.h`** centralizes per-signal default behavior. New unit tests cover classification, mask stripping, and the ignore-vs-stop discard distinction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d1566c9ab82c4e1ea42316253cb2433ce9b17d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->