### PR TITLE
feat(signals): added signal sending

### DIFF
--- a/kernel/signals/signal.cpp
+++ b/kernel/signals/signal.cpp
@@ -1,7 +1,17 @@
 #include "signals/signal.h"
+#include "sched/sched.h"
 #include "sched/task.h"
+#include "timer/timer.h"
+#include "common/logging.h"
 
 namespace signals {
+
+// What a send must do for sig, given the process's installed action
+enum class send_verdict : uint8_t {
+    FATAL,     // default-terminate, wake the target so it can die
+    IGNORABLE, // droppable unless the target blocks it
+    HANDLED,   // a user handler is installed, leave it pending
+};
 
 /**
  * Clear pending instances of sig from the shared set and every thread.
@@ -86,6 +96,148 @@ __PRIVILEGED_CODE sig_set_t pending_blocked_set(sched::task* t) {
         pend |= __atomic_load_n(&t->group->sig.shared_pending, __ATOMIC_ACQUIRE);
     }
     return pend & __atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE);
+}
+
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static send_verdict classify_send(sched::thread_group* tg,
+                                                    uint32_t sig) {
+    sync::irq_state irq = sync::spin_lock_irqsave(tg->sig.lock);
+    uintptr_t handler = tg->sig.actions[sig - 1].handler;
+    sync::spin_unlock_irqrestore(tg->sig.lock, irq);
+
+    if (handler != SIG_DFL && handler != SIG_IGN) {
+        return send_verdict::HANDLED;
+    }
+    if (handler == SIG_IGN) {
+        return send_verdict::IGNORABLE;
+    }
+    switch (dfl_action(sig)) {
+        case default_action::TERM:
+            return send_verdict::FATAL;
+        case default_action::STOP:
+            log::warn("signals: stop/continue unsupported, ignoring signal %u", sig);
+            return send_verdict::IGNORABLE;
+        case default_action::IGNORE:
+        default:
+            return send_verdict::IGNORABLE;
+    }
+}
+
+/**
+ * Wake a blocked task so it observes a newly pending signal. The fence
+ * pairs with the interruption re-check after prepare_to_block_task.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static void wake_for_signal(sched::task* t) {
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    timer::cancel_sleep(t);
+    sched::wake(t);
+}
+
+__PRIVILEGED_CODE int32_t send_to_task(sched::task* t, uint32_t sig) {
+    if (!t || !sig_valid(sig)) {
+        return ERR_INVAL;
+    }
+    if ((t->exec.flags & (sched::TASK_FLAG_KERNEL | sched::TASK_FLAG_IDLE)) || !t->group) {
+        return ERR_PERM;
+    }
+
+    if (sig == SIGKILL) {
+        // SIGKILL is process-wide: the shared bit is fatal for every thread
+        // at its next kernel crossing, not only after leader teardown
+        sched::thread_group* tg = t->group;
+        __atomic_fetch_or(&tg->sig.shared_pending, sig_bit(SIGKILL), __ATOMIC_ACQ_REL);
+        sync::irq_state irq = sync::spin_lock_irqsave(tg->lock);
+        if (tg->leader && tg->leader != t) {
+            sched::force_wake_for_kill(tg->leader);
+        }
+        sync::spin_unlock_irqrestore(tg->lock, irq);
+        sched::force_wake_for_kill(t);
+        return OK;
+    }
+
+    send_verdict verdict = classify_send(t->group, sig);
+    sig_set_t blocked = __atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE);
+    bool is_blocked = (blocked & sig_bit(sig)) != 0;
+
+    // Ignored signals are dropped unless blocked (the action may change
+    // before the target unblocks them)
+    if (verdict == send_verdict::IGNORABLE && !is_blocked) {
+        return OK;
+    }
+
+    __atomic_fetch_or(&t->sig.pending, sig_bit(sig), __ATOMIC_ACQ_REL);
+    if (verdict == send_verdict::FATAL && !is_blocked) {
+        wake_for_signal(t);
+    }
+    return OK;
+}
+
+__PRIVILEGED_CODE int32_t send_to_group(sched::thread_group* tg, uint32_t sig) {
+    if (!tg || !sig_valid(sig)) {
+        return ERR_INVAL;
+    }
+
+    if (sig == SIGKILL) {
+        __atomic_fetch_or(&tg->sig.shared_pending, sig_bit(SIGKILL), __ATOMIC_ACQ_REL);
+        sync::irq_state irq = sync::spin_lock_irqsave(tg->lock);
+        if (tg->leader) {
+            sched::force_wake_for_kill(tg->leader); // leader exit reaps the group
+        }
+        sync::spin_unlock_irqrestore(tg->lock, irq);
+        return OK;
+    }
+
+    send_verdict verdict = classify_send(tg, sig);
+    const sig_set_t bit = sig_bit(sig);
+
+    sync::irq_state irq = sync::spin_lock_irqsave(tg->lock);
+
+    if (verdict == send_verdict::IGNORABLE) {
+        // Droppable only if no thread has it blocked
+        bool blocked_somewhere = false;
+        if (tg->leader &&
+            (__atomic_load_n(&tg->leader->sig.blocked, __ATOMIC_ACQUIRE) & bit)) {
+            blocked_somewhere = true;
+        }
+        for (sched::task& thread : tg->threads) {
+            if (__atomic_load_n(&thread.sig.blocked, __ATOMIC_ACQUIRE) & bit) {
+                blocked_somewhere = true;
+                break;
+            }
+        }
+        if (blocked_somewhere) {
+            __atomic_fetch_or(&tg->sig.shared_pending, bit, __ATOMIC_ACQ_REL);
+        }
+        sync::spin_unlock_irqrestore(tg->lock, irq);
+        return OK;
+    }
+
+    __atomic_fetch_or(&tg->sig.shared_pending, bit, __ATOMIC_ACQ_REL);
+
+    if (verdict == send_verdict::FATAL) {
+        // Wake one thread with the signal unblocked, leader preferred
+        sched::task* target = nullptr;
+        if (tg->leader &&
+            !(__atomic_load_n(&tg->leader->sig.blocked, __ATOMIC_ACQUIRE) & bit)) {
+            target = tg->leader;
+        } else {
+            for (sched::task& thread : tg->threads) {
+                if (!(__atomic_load_n(&thread.sig.blocked, __ATOMIC_ACQUIRE) & bit)) {
+                    target = &thread;
+                    break;
+                }
+            }
+        }
+        if (target) {
+            wake_for_signal(target);
+        }
+    }
+
+    sync::spin_unlock_irqrestore(tg->lock, irq);
+    return OK;
 }
 
 } // namespace signals

--- a/kernel/signals/signal.h
+++ b/kernel/signals/signal.h
@@ -12,6 +12,7 @@ namespace signals {
 
 constexpr int32_t OK        = 0;
 constexpr int32_t ERR_INVAL = -1;
+constexpr int32_t ERR_PERM  = -2;
 
 // rt_sigprocmask how values (musl ABI)
 constexpr uint32_t SIG_BLOCK   = 0;
@@ -46,6 +47,27 @@ __PRIVILEGED_CODE int32_t set_blocked(sched::task* t, uint32_t how,
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE sig_set_t pending_blocked_set(sched::task* t);
+
+/**
+ * @brief Send a thread-directed signal (tkill semantics).
+ * SIGKILL terminates the whole process via the kill machinery. Signals
+ * resolving to ignore are dropped unless the target blocks them. Fatal
+ * signals wake a blocked target so it can act promptly. Signals with a
+ * handler installed are left pending for delivery.
+ * @return OK, ERR_INVAL for a bad signal, ERR_PERM for kernel/idle tasks.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE int32_t send_to_task(sched::task* t, uint32_t sig);
+
+/**
+ * @brief Send a process-directed signal (kill semantics).
+ * Same drop, pend, and wake rules as send_to_task applied group-wide:
+ * the signal lands in the shared pending set and one thread with it
+ * unblocked is woken (leader preferred).
+ * @return OK or ERR_INVAL.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE int32_t send_to_group(sched::thread_group* tg, uint32_t sig);
 
 } // namespace signals
 

--- a/kernel/signals/signal_types.h
+++ b/kernel/signals/signal_types.h
@@ -47,17 +47,6 @@ constexpr uint64_t SA_RESETHAND = 0x80000000;
 // Bitmask of signals 1..64: bit (N-1) represents signal N
 using sig_set_t = uint64_t;
 
-constexpr sig_set_t sig_bit(uint32_t sig) {
-    return 1ULL << (sig - 1);
-}
-
-constexpr bool sig_valid(uint32_t sig) {
-    return sig >= 1 && sig <= NSIG;
-}
-
-// POSIX: SIGKILL and SIGSTOP can never be blocked, caught, or ignored
-constexpr sig_set_t UNBLOCKABLE_MASK = sig_bit(SIGKILL) | sig_bit(SIGSTOP);
-
 // What SIG_DFL means for each signal. Stop-class defaults are not
 // implemented, so callers pick their own fallback where one is needed.
 enum class default_action : uint8_t {
@@ -65,23 +54,6 @@ enum class default_action : uint8_t {
     IGNORE,
     STOP,
 };
-
-constexpr default_action dfl_action(uint32_t sig) {
-    switch (sig) {
-        case SIGCHLD:
-        case SIGCONT:
-        case SIGURG:
-        case SIGWINCH:
-            return default_action::IGNORE;
-        case SIGSTOP:
-        case SIGTSTP:
-        case SIGTTIN:
-        case SIGTTOU:
-            return default_action::STOP;
-        default:
-            return default_action::TERM;
-    }
-}
 
 // Kernel-side layout matches the musl k_sigaction struct
 // passed to rt_sigaction (handler, flags, restorer, 64-bit mask).
@@ -107,6 +79,34 @@ struct group_signals {
     sig_set_t shared_pending;
     k_sigaction actions[NSIG];
 };
+
+constexpr sig_set_t sig_bit(uint32_t sig) {
+    return 1ULL << (sig - 1);
+}
+
+constexpr bool sig_valid(uint32_t sig) {
+    return sig >= 1 && sig <= NSIG;
+}
+
+// POSIX: SIGKILL and SIGSTOP can never be blocked, caught, or ignored
+constexpr sig_set_t UNBLOCKABLE_MASK = sig_bit(SIGKILL) | sig_bit(SIGSTOP);
+
+constexpr default_action dfl_action(uint32_t sig) {
+    switch (sig) {
+        case SIGCHLD:
+        case SIGCONT:
+        case SIGURG:
+        case SIGWINCH:
+            return default_action::IGNORE;
+        case SIGSTOP:
+        case SIGTSTP:
+        case SIGTTIN:
+        case SIGTTOU:
+            return default_action::STOP;
+        default:
+            return default_action::TERM;
+    }
+}
 
 } // namespace signals
 

--- a/kernel/tests/signals/signal_send.test.cpp
+++ b/kernel/tests/signals/signal_send.test.cpp
@@ -1,0 +1,160 @@
+#define STLX_TEST_TIER TIER_MM_ALLOC
+
+#include "stlx_unit_test.h"
+#include "signals/signal.h"
+#include "sched/task.h"
+#include "mm/heap.h"
+#include "dynpriv/dynpriv.h"
+
+TEST_SUITE(signal_send);
+
+// Minimal process fixture: a thread group with a leader and one thread.
+static sched::thread_group* g_tg;
+static sched::task* g_leader;
+static sched::task* g_thread;
+
+static int32_t setup_group() {
+    RUN_ELEVATED({
+        g_leader = heap::kalloc_new<sched::task>();
+        g_thread = heap::kalloc_new<sched::task>();
+        g_tg     = heap::kalloc_new<sched::thread_group>();
+    });
+    if (!g_leader || !g_thread || !g_tg) {
+        return -1;
+    }
+
+    g_tg->lock = sync::SPINLOCK_INIT;
+    g_tg->leader = g_leader;
+    g_tg->pid = 1;
+    g_tg->threads.init();
+    g_tg->thread_count = 1;
+    g_leader->group = g_tg;
+    g_thread->group = g_tg;
+    g_tg->threads.push_back(g_thread);
+    return 0;
+}
+
+static int32_t teardown_group() {
+    RUN_ELEVATED({
+        if (g_tg)     heap::kfree_delete(g_tg);
+        if (g_leader) heap::kfree_delete(g_leader);
+        if (g_thread) heap::kfree_delete(g_thread);
+    });
+    g_tg = nullptr;
+    g_leader = nullptr;
+    g_thread = nullptr;
+    return 0;
+}
+
+BEFORE_EACH(signal_send, setup_group);
+AFTER_EACH(signal_send, teardown_group);
+
+TEST(signal_send, rejects_invalid_signals) {
+    int32_t rc = 0;
+    RUN_ELEVATED({ rc = signals::send_to_task(g_thread, 0); });
+    EXPECT_EQ(rc, signals::ERR_INVAL);
+    RUN_ELEVATED({ rc = signals::send_to_task(g_thread, 65); });
+    EXPECT_EQ(rc, signals::ERR_INVAL);
+    RUN_ELEVATED({ rc = signals::send_to_task(nullptr, signals::SIGTERM); });
+    EXPECT_EQ(rc, signals::ERR_INVAL);
+    RUN_ELEVATED({ rc = signals::send_to_group(nullptr, signals::SIGTERM); });
+    EXPECT_EQ(rc, signals::ERR_INVAL);
+}
+
+TEST(signal_send, rejects_kernel_and_idle_targets) {
+    int32_t rc = 0;
+    g_thread->exec.flags = sched::TASK_FLAG_KERNEL;
+    RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGTERM); });
+    EXPECT_EQ(rc, signals::ERR_PERM);
+
+    g_thread->exec.flags = sched::TASK_FLAG_IDLE;
+    RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGTERM); });
+    EXPECT_EQ(rc, signals::ERR_PERM);
+    g_thread->exec.flags = 0;
+}
+
+TEST(signal_send, fatal_send_pends_without_kill_flag) {
+    int32_t rc = 0;
+    RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGTERM); });
+    EXPECT_EQ(rc, signals::OK);
+    EXPECT_EQ(g_thread->sig.pending, signals::sig_bit(signals::SIGTERM));
+    EXPECT_EQ(g_thread->kill_pending, 0U);
+    EXPECT_EQ(g_leader->kill_pending, 0U);
+}
+
+TEST(signal_send, ignored_unblocked_send_drops) {
+    int32_t rc = 0;
+    RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGCHLD); });
+    EXPECT_EQ(rc, signals::OK);
+    EXPECT_EQ(g_thread->sig.pending, 0ULL);
+}
+
+TEST(signal_send, ignored_blocked_send_pends) {
+    g_thread->sig.blocked = signals::sig_bit(signals::SIGCHLD);
+    int32_t rc = 0;
+    RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGCHLD); });
+    EXPECT_EQ(rc, signals::OK);
+    EXPECT_EQ(g_thread->sig.pending, signals::sig_bit(signals::SIGCHLD));
+}
+
+TEST(signal_send, handled_send_pends_only) {
+    signals::k_sigaction act = {};
+    act.handler = 0x400000;
+    int32_t rc = 0;
+    RUN_ELEVATED({
+        rc = signals::set_action(g_tg, signals::SIGTERM, &act, nullptr);
+        if (rc == signals::OK) {
+            rc = signals::send_to_task(g_thread, signals::SIGTERM);
+        }
+    });
+    EXPECT_EQ(rc, signals::OK);
+    EXPECT_EQ(g_thread->sig.pending, signals::sig_bit(signals::SIGTERM));
+    EXPECT_EQ(g_thread->kill_pending, 0U);
+}
+
+TEST(signal_send, sigkill_to_thread_kills_group) {
+    int32_t rc = 0;
+    RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGKILL); });
+    EXPECT_EQ(rc, signals::OK);
+    // SIGKILL is process-wide: target and leader are marked, and the
+    // shared bit makes it fatal for every other thread immediately
+    EXPECT_EQ(g_thread->kill_pending, 1U);
+    EXPECT_EQ(g_leader->kill_pending, 1U);
+    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGKILL));
+}
+
+TEST(signal_send, sigkill_to_group_marks_leader) {
+    int32_t rc = 0;
+    RUN_ELEVATED({ rc = signals::send_to_group(g_tg, signals::SIGKILL); });
+    EXPECT_EQ(rc, signals::OK);
+    EXPECT_EQ(g_leader->kill_pending, 1U);
+    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGKILL));
+}
+
+TEST(signal_send, group_fatal_send_sets_shared) {
+    int32_t rc = 0;
+    RUN_ELEVATED({ rc = signals::send_to_group(g_tg, signals::SIGTERM); });
+    EXPECT_EQ(rc, signals::OK);
+    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGTERM));
+    EXPECT_EQ(g_leader->kill_pending, 0U);
+}
+
+TEST(signal_send, group_ignored_send_drops_unless_blocked) {
+    int32_t rc = 0;
+    RUN_ELEVATED({ rc = signals::send_to_group(g_tg, signals::SIGCHLD); });
+    EXPECT_EQ(rc, signals::OK);
+    EXPECT_EQ(g_tg->sig.shared_pending, 0ULL);
+
+    // One thread blocking the signal keeps it pending
+    g_thread->sig.blocked = signals::sig_bit(signals::SIGCHLD);
+    RUN_ELEVATED({ rc = signals::send_to_group(g_tg, signals::SIGCHLD); });
+    EXPECT_EQ(rc, signals::OK);
+    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGCHLD));
+}
+
+TEST(signal_send, stop_class_send_is_ignored) {
+    int32_t rc = 0;
+    RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGTSTP); });
+    EXPECT_EQ(rc, signals::OK);
+    EXPECT_EQ(g_thread->sig.pending, 0ULL);
+}


### PR DESCRIPTION
## Summary
- The signal state layer had no senders: nothing could mark a signal pending or wake a target.
- send_to_task and send_to_group classify each signal by its installed action, dropping ignored signals unless the target blocks them, leaving handler-bound signals pending for delivery, and waking one unblocked target for default-terminate signals.
- SIGKILL bypasses classification: a shared pending bit makes it fatal for every thread at its next kernel crossing while the existing kill machinery wakes the process, and kernel or idle tasks are never signalable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches process termination, scheduler wake paths, and atomic pending state; incorrect behavior could miss kills or wake the wrong tasks, though coverage is added in unit tests.
> 
> **Overview**
> Adds **`send_to_task`** (tkill) and **`send_to_group`** (kill) so the kernel can mark signals pending and wake targets. Each send is classified via installed actions: ignored signals are dropped unless blocked, custom handlers only set pending, and default-terminate signals pend and **wake** an unblocked thread (`wake_for_signal` cancels sleep and calls `sched::wake`).
> 
> **SIGKILL** bypasses classification: it sets **shared pending**, uses existing **`force_wake_for_kill`** machinery, and is treated as process-wide. Kernel/idle tasks get **`ERR_PERM`**. Stop-class defaults are logged and treated as ignorable. **`signal_types.h`** only reorders constexpr helpers; **`signal_send.test.cpp`** covers validation, drop/pend rules, and SIGKILL behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b77d4dfdbda15cb4b758c02e5accbfe76f51b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->