### PR TITLE
feat(signals): made blocking waits interruptible by fatal signals

### DIFF
--- a/kernel/common/ring_buffer.cpp
+++ b/kernel/common/ring_buffer.cpp
@@ -4,6 +4,7 @@
 #include "mm/heap.h"
 #include "common/string.h"
 #include "sched/sched.h"
+#include "signals/signal.h"
 
 static inline size_t readable_bytes(const ring_buffer* rb) {
     return (rb->head - rb->tail) & (rb->capacity - 1);
@@ -78,7 +79,7 @@ __PRIVILEGED_CODE ssize_t ring_buffer_read(ring_buffer* rb, uint8_t* buf, size_t
             sync::spin_unlock_irqrestore(rb->lock, irq);
             return RB_ERR_AGAIN;
         }
-        while (readable_bytes(rb) == 0 && !rb->writer_closed && !sched::is_kill_pending()) {
+        while (readable_bytes(rb) == 0 && !rb->writer_closed && !signals::interrupt_pending(sched::current())) {
             irq = sync::wait(rb->read_wq, rb->lock, irq);
         }
     }
@@ -124,12 +125,12 @@ __PRIVILEGED_CODE ssize_t ring_buffer_write(ring_buffer* rb, const uint8_t* buf,
             sync::spin_unlock_irqrestore(rb->lock, irq);
             return RB_ERR_AGAIN;
         }
-        while (writable_bytes(rb) == 0 && !rb->reader_closed && !sched::is_kill_pending()) {
+        while (writable_bytes(rb) == 0 && !rb->reader_closed && !signals::interrupt_pending(sched::current())) {
             irq = sync::wait(rb->write_wq, rb->lock, irq);
         }
     }
 
-    if (rb->reader_closed || sched::is_kill_pending()) {
+    if (rb->reader_closed || signals::interrupt_pending(sched::current())) {
         sync::spin_unlock_irqrestore(rb->lock, irq);
         return RB_ERR_PIPE;
     }
@@ -178,12 +179,12 @@ __PRIVILEGED_CODE ssize_t ring_buffer_write_all(ring_buffer* rb, const uint8_t* 
             sync::spin_unlock_irqrestore(rb->lock, irq);
             return RB_ERR_AGAIN;
         }
-        while (writable_bytes(rb) < len && !rb->reader_closed && !sched::is_kill_pending()) {
+        while (writable_bytes(rb) < len && !rb->reader_closed && !signals::interrupt_pending(sched::current())) {
             irq = sync::wait(rb->write_wq, rb->lock, irq);
         }
     }
 
-    if (rb->reader_closed || sched::is_kill_pending()) {
+    if (rb->reader_closed || signals::interrupt_pending(sched::current())) {
         sync::spin_unlock_irqrestore(rb->lock, irq);
         return RB_ERR_PIPE;
     }

--- a/kernel/net/tcp.cpp
+++ b/kernel/net/tcp.cpp
@@ -14,6 +14,7 @@
 #include "fs/fstypes.h"
 #include "sched/sched.h"
 #include "sched/task.h"
+#include "signals/signal.h"
 #include "dynpriv/dynpriv.h"
 
 namespace net {
@@ -398,10 +399,10 @@ __PRIVILEGED_CODE static int32_t tcp_accept(
     }
     while (sock->accept_queue.empty()
            && sock->state == tcp_state::LISTEN
-           && !__atomic_load_n(&task->kill_pending, __ATOMIC_ACQUIRE)) {
+           && !signals::interrupt_pending(task)) {
         irq = sync::wait(sock->accept_wq, sock->lock, irq);
     }
-    if (__atomic_load_n(&task->kill_pending, __ATOMIC_ACQUIRE)) {
+    if (signals::interrupt_pending(task)) {
         sync::spin_unlock_irqrestore(sock->lock, irq);
         return resource::ERR_INTR;
     }
@@ -647,14 +648,14 @@ __PRIVILEGED_CODE static int32_t tcp_connect(
     // Block until state changes from SYN_SENT
     irq = sync::spin_lock_irqsave(sock->lock);
     while (sock->state == tcp_state::SYN_SENT
-           && !__atomic_load_n(&task->kill_pending, __ATOMIC_ACQUIRE)) {
+           && !signals::interrupt_pending(task)) {
         irq = sync::wait(sock->accept_wq, sock->lock, irq);
     }
 
     tcp_state final_state = sock->state;
     sync::spin_unlock_irqrestore(sock->lock, irq);
 
-    if (__atomic_load_n(&task->kill_pending, __ATOMIC_ACQUIRE)) {
+    if (signals::interrupt_pending(task)) {
         return resource::ERR_INTR;
     }
     if (final_state == tcp_state::ESTABLISHED) {

--- a/kernel/sched/sched.cpp
+++ b/kernel/sched/sched.cpp
@@ -5,6 +5,7 @@
 #include "sched/sched_policy.h"
 #include "sched/runqueue.h"
 #include "sched/fpu.h"
+#include "signals/signal.h"
 #include "dynpriv/dynpriv.h"
 #include "percpu/percpu.h"
 #include "mm/heap.h"
@@ -187,8 +188,8 @@ bool is_kill_pending() {
 __PRIVILEGED_CODE void force_wake_for_kill(task* t) {
     __atomic_store_n(&t->kill_pending, 1, __ATOMIC_RELEASE);
 
-    // Pairs with block_task_interrupted_by_kill: the wake below sees BLOCKED,
-    // or the blocker's kill check sees kill_pending. Never neither.
+    // Pairs with block_task_interrupted: the wake below sees BLOCKED,
+    // or the blocker's interrupt check sees kill_pending. Never neither.
     __atomic_thread_fence(__ATOMIC_SEQ_CST);
     timer::cancel_sleep(t);
     wake(t);
@@ -204,10 +205,10 @@ __PRIVILEGED_CODE void prepare_to_block_task() {
 /**
  * @note Privilege: **required**
  */
-__PRIVILEGED_CODE bool block_task_interrupted_by_kill() {
-    // Fence pairs with the one in force_wake_for_kill.
+__PRIVILEGED_CODE bool block_task_interrupted() {
+    // Fence pairs with force_wake_for_kill and signals wake_for_signal.
     __atomic_thread_fence(__ATOMIC_SEQ_CST);
-    return __atomic_load_n(&current()->kill_pending, __ATOMIC_ACQUIRE);
+    return signals::interrupt_pending(current());
 }
 
 /**
@@ -400,15 +401,15 @@ __PRIVILEGED_CODE void wake(task* t) {
 /**
  * @note Privilege: **required**
  */
-__PRIVILEGED_CODE void sleep_ns(uint64_t ns) {
+__PRIVILEGED_CODE uint64_t sleep_ns(uint64_t ns) {
     if (ns == 0) {
         yield();
-        return;
+        return 0;
     }
 
     task* self = current();
     if (self->exec.flags & TASK_FLAG_IDLE) {
-        return;
+        return 0;
     }
 
     uint64_t deadline = clock::now_ns() + ns;
@@ -416,14 +417,16 @@ __PRIVILEGED_CODE void sleep_ns(uint64_t ns) {
     prepare_to_block_task();
     timer::schedule_sleep(self, deadline);
 
-    if (block_task_interrupted_by_kill()) {
-        // Killed before or during sleep entry: do not serve the sleep.
+    if (block_task_interrupted()) {
+        // Interrupted before or during sleep entry: do not serve the sleep.
         timer::cancel_sleep(self);
         cancel_block_task();
-        return;
+    } else {
+        yield();
     }
 
-    yield();
+    uint64_t now = clock::now_ns();
+    return deadline > now ? deadline - now : 0;
 }
 
 __PRIVILEGED_CODE void sleep_us(uint64_t us) {

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -125,17 +125,17 @@ __PRIVILEGED_CODE void force_wake_for_kill(task* t);
 
 /**
  * @brief Publish intent to block: moves the current task to BLOCKED.
- * Pair with block_task_interrupted_by_kill before yielding.
+ * Pair with block_task_interrupted before yielding.
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE void prepare_to_block_task();
 
 /**
- * @brief True if a kill arrived since prepare_to_block_task.
+ * @brief True if a kill or fatal signal arrived since prepare_to_block_task.
  * On true, the caller must unwind its wait entry and call cancel_block_task.
  * @note Privilege: **required**
  */
-__PRIVILEGED_CODE bool block_task_interrupted_by_kill();
+__PRIVILEGED_CODE bool block_task_interrupted();
 
 /**
  * @brief Revert an unfinished block after the caller unwound its entry.
@@ -174,9 +174,11 @@ task* current();
  * timer interrupt when the deadline expires.
  * Must not be called from the idle task.
  * @param ns Duration in nanoseconds. If 0, yields without blocking.
+ * @return Nanoseconds left if interrupted by a kill or fatal signal,
+ *   0 if the full duration elapsed.
  * @note Privilege: **required**
  */
-__PRIVILEGED_CODE void sleep_ns(uint64_t ns);
+__PRIVILEGED_CODE uint64_t sleep_ns(uint64_t ns);
 
 /**
  * @note Privilege: **required**

--- a/kernel/signals/signal.cpp
+++ b/kernel/signals/signal.cpp
@@ -74,6 +74,7 @@ __PRIVILEGED_CODE int32_t set_blocked(sched::task* t, uint32_t how,
     if (old) {
         *old = cur;
     }
+
     if (!set) {
         return OK;
     }
@@ -85,6 +86,7 @@ __PRIVILEGED_CODE int32_t set_blocked(sched::task* t, uint32_t how,
         case SIG_SETMASK: next = *set;        break;
         default:          return ERR_INVAL;
     }
+
     next &= ~UNBLOCKABLE_MASK;
     __atomic_store_n(&t->sig.blocked, next, __ATOMIC_RELEASE);
     return OK;
@@ -113,6 +115,7 @@ __PRIVILEGED_CODE static send_verdict classify_send(sched::thread_group* tg,
     if (handler == SIG_IGN) {
         return send_verdict::IGNORABLE;
     }
+
     switch (dfl_action(sig)) {
         case default_action::TERM:
             return send_verdict::FATAL;
@@ -140,6 +143,7 @@ __PRIVILEGED_CODE int32_t send_to_task(sched::task* t, uint32_t sig) {
     if (!t || !sig_valid(sig)) {
         return ERR_INVAL;
     }
+
     if ((t->exec.flags & (sched::TASK_FLAG_KERNEL | sched::TASK_FLAG_IDLE)) || !t->group) {
         return ERR_PERM;
     }
@@ -150,9 +154,11 @@ __PRIVILEGED_CODE int32_t send_to_task(sched::task* t, uint32_t sig) {
         sched::thread_group* tg = t->group;
         __atomic_fetch_or(&tg->sig.shared_pending, sig_bit(SIGKILL), __ATOMIC_ACQ_REL);
         sync::irq_state irq = sync::spin_lock_irqsave(tg->lock);
+
         if (tg->leader && tg->leader != t) {
             sched::force_wake_for_kill(tg->leader);
         }
+
         sync::spin_unlock_irqrestore(tg->lock, irq);
         sched::force_wake_for_kill(t);
         return OK;
@@ -183,9 +189,11 @@ __PRIVILEGED_CODE int32_t send_to_group(sched::thread_group* tg, uint32_t sig) {
     if (sig == SIGKILL) {
         __atomic_fetch_or(&tg->sig.shared_pending, sig_bit(SIGKILL), __ATOMIC_ACQ_REL);
         sync::irq_state irq = sync::spin_lock_irqsave(tg->lock);
+
         if (tg->leader) {
             sched::force_wake_for_kill(tg->leader); // leader exit reaps the group
         }
+
         sync::spin_unlock_irqrestore(tg->lock, irq);
         return OK;
     }
@@ -202,12 +210,14 @@ __PRIVILEGED_CODE int32_t send_to_group(sched::thread_group* tg, uint32_t sig) {
             (__atomic_load_n(&tg->leader->sig.blocked, __ATOMIC_ACQUIRE) & bit)) {
             blocked_somewhere = true;
         }
+
         for (sched::task& thread : tg->threads) {
             if (__atomic_load_n(&thread.sig.blocked, __ATOMIC_ACQUIRE) & bit) {
                 blocked_somewhere = true;
                 break;
             }
         }
+
         if (blocked_somewhere) {
             __atomic_fetch_or(&tg->sig.shared_pending, bit, __ATOMIC_ACQ_REL);
         }
@@ -238,6 +248,49 @@ __PRIVILEGED_CODE int32_t send_to_group(sched::thread_group* tg, uint32_t sig) {
 
     sync::spin_unlock_irqrestore(tg->lock, irq);
     return OK;
+}
+
+__PRIVILEGED_CODE uint32_t fatal_pending(sched::task* t) {
+    if (__atomic_load_n(&t->kill_pending, __ATOMIC_ACQUIRE)) {
+        return SIGKILL;
+    }
+
+    if (!t->group) {
+        return 0;
+    }
+
+    sig_set_t deliverable =
+        (__atomic_load_n(&t->sig.pending, __ATOMIC_ACQUIRE) |
+         __atomic_load_n(&t->group->sig.shared_pending, __ATOMIC_ACQUIRE)) &
+        ~__atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE);
+    if (!deliverable) {
+        return 0;
+    }
+
+    // SIGKILL outranks every other pending signal
+    if (deliverable & sig_bit(SIGKILL)) {
+        return SIGKILL;
+    }
+
+    sync::irq_state irq = sync::spin_lock_irqsave(t->group->sig.lock);
+    uint32_t fatal_sig = 0;
+    while (deliverable) {
+        uint32_t sig = static_cast<uint32_t>(__builtin_ctzll(deliverable)) + 1;
+        deliverable &= deliverable - 1;
+
+        uintptr_t handler = t->group->sig.actions[sig - 1].handler;
+        if (handler == SIG_DFL && dfl_action(sig) == default_action::TERM) {
+            fatal_sig = sig;
+            break;
+        }
+    }
+
+    sync::spin_unlock_irqrestore(t->group->sig.lock, irq);
+    return fatal_sig;
+}
+
+__PRIVILEGED_CODE bool interrupt_pending(sched::task* t) {
+    return t && fatal_pending(t) != 0;
 }
 
 } // namespace signals

--- a/kernel/signals/signal.h
+++ b/kernel/signals/signal.h
@@ -69,6 +69,22 @@ __PRIVILEGED_CODE int32_t send_to_task(sched::task* t, uint32_t sig);
  */
 __PRIVILEGED_CODE int32_t send_to_group(sched::thread_group* tg, uint32_t sig);
 
+/**
+ * @brief Fatal signal the task must die from, or 0.
+ * A set kill flag reports SIGKILL. Otherwise the lowest pending
+ * unblocked signal whose action resolves to default-terminate, with
+ * SIGKILL outranking every other pending signal.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE uint32_t fatal_pending(sched::task* t);
+
+/**
+ * @brief True if a blocking wait must unwind and return EINTR.
+ * Covers kills and fatal signals (handler delivery extends this later).
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE bool interrupt_pending(sched::task* t);
+
 } // namespace signals
 
 #endif // STELLUX_SIGNALS_SIGNAL_H

--- a/kernel/socket/unix_socket.cpp
+++ b/kernel/socket/unix_socket.cpp
@@ -11,6 +11,7 @@
 #include "hw/barrier.h"
 #include "sched/sched.h"
 #include "sched/task.h"
+#include "signals/signal.h"
 
 namespace socket {
 
@@ -262,10 +263,10 @@ __PRIVILEGED_CODE static int32_t unix_accept(
         }
     }
     while (ls->accept_queue.empty() && !ls->closed
-           && !__atomic_load_n(&task->kill_pending, __ATOMIC_ACQUIRE)) {
+           && !signals::interrupt_pending(task)) {
         irq = sync::wait(ls->accept_wq, ls->lock, irq);
     }
-    if (__atomic_load_n(&task->kill_pending, __ATOMIC_ACQUIRE)) {
+    if (signals::interrupt_pending(task)) {
         sync::spin_unlock_irqrestore(ls->lock, irq);
         return resource::ERR_INTR;
     }

--- a/kernel/sync/futex.cpp
+++ b/kernel/sync/futex.cpp
@@ -2,6 +2,7 @@
 #include "sync/spinlock.h"
 #include "sched/sched.h"
 #include "sched/task.h"
+#include "signals/signal.h"
 #include "mm/uaccess.h"
 #include "mm/vma.h"
 #include "common/hash.h"
@@ -83,8 +84,8 @@ __PRIVILEGED_CODE int32_t futex_wait(uintptr_t uaddr, uint32_t expected,
 
     spin_unlock_irqrestore(bucket->lock, irq);
 
-    if (sched::block_task_interrupted_by_kill()) {
-        // Killed during futex entry: unwind waiter and timer, don't block.
+    if (sched::block_task_interrupted()) {
+        // Interrupted during futex entry: unwind waiter and timer, don't block.
         timer::cancel_sleep(self);
         irq = spin_lock_irqsave(bucket->lock);
         if (waiter.link.is_linked()) {
@@ -100,7 +101,7 @@ __PRIVILEGED_CODE int32_t futex_wait(uintptr_t uaddr, uint32_t expected,
     // blocking operations if we were woken by futex_wake before timeout.
     timer::cancel_sleep(self);
 
-    // Remove self from bucket if still linked (timeout or kill wakeup).
+    // Remove self from bucket if still linked (timeout or interrupt wakeup).
     bool was_linked = false;
     irq = spin_lock_irqsave(bucket->lock);
     if (waiter.link.is_linked()) {
@@ -109,7 +110,7 @@ __PRIVILEGED_CODE int32_t futex_wait(uintptr_t uaddr, uint32_t expected,
     }
     spin_unlock_irqrestore(bucket->lock, irq);
 
-    if (sched::is_kill_pending()) return -4; // EINTR
+    if (signals::interrupt_pending(self)) return -4; // EINTR
     if (was_linked) return -110; // ETIMEDOUT
     return 0;
 }

--- a/kernel/sync/poll.cpp
+++ b/kernel/sync/poll.cpp
@@ -2,6 +2,7 @@
 #include "sync/wait_queue.h"
 #include "sched/sched.h"
 #include "sched/task.h"
+#include "signals/signal.h"
 #include "clock/clock.h"
 #include "timer/timer.h"
 #include "mm/heap.h"
@@ -37,19 +38,19 @@ __PRIVILEGED_CODE bool poll_wait(poll_table& pt, uint64_t timeout_ns) {
     }
 
     sched::task* self = pt.task;
-    if (__atomic_load_n(&self->kill_pending, __ATOMIC_ACQUIRE)) {
+    if (signals::interrupt_pending(self)) {
         return false;
     }
 
     sched::prepare_to_block_task();
 
-    if (sched::block_task_interrupted_by_kill()) {
+    if (sched::block_task_interrupted()) {
         sched::cancel_block_task();
         return false;
     }
 
-    // The kill check's fence also orders this re-check against the BLOCKED
-    // store, closing the race where a source fires during the transition.
+    // The interrupt check's fence also orders this re-check against the
+    // BLOCKED store, closing the race where a source fires during the transition.
     if (__atomic_load_n(&pt.triggered, __ATOMIC_ACQUIRE)) {
         sched::cancel_block_task();
         return true;

--- a/kernel/sync/poll.h
+++ b/kernel/sync/poll.h
@@ -55,7 +55,7 @@ __PRIVILEGED_CODE void poll_subscribe(poll_table& pt, wait_queue& wq);
  * Block until any subscribed source fires or timeout expires.
  * @param timeout_ns 0 = infinite wait (no timeout).
  * @return true if triggered by a source, false on timeout.
- * Caller must check sched::is_kill_pending() after return.
+ * Caller must check signals::interrupt_pending() after return.
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE bool poll_wait(poll_table& pt, uint64_t timeout_ns);

--- a/kernel/sync/wait_queue.cpp
+++ b/kernel/sync/wait_queue.cpp
@@ -56,8 +56,8 @@ __PRIVILEGED_CODE static void notify_observers_and_unlock(
 }
 
 /**
- * Not kill-interruptible on its own: a force-woken waiter re-blocks unless
- * the caller loops on sched::is_kill_pending().
+ * Not interruptible on its own: a force-woken waiter re-blocks unless
+ * the caller loops on signals::interrupt_pending().
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE

--- a/kernel/syscall/handlers/sys_proc.cpp
+++ b/kernel/syscall/handlers/sys_proc.cpp
@@ -6,6 +6,7 @@
 #include "sched/sched.h"
 #include "sched/task.h"
 #include "sched/task_registry.h"
+#include "signals/signal.h"
 #include "dynpriv/dynpriv.h"
 #include "exec/elf.h"
 #include "mm/uaccess.h"
@@ -285,10 +286,10 @@ DEFINE_SYSCALL2(proc_wait, u_handle, u_exit_code_ptr) {
         resource::resource_release(obj);
         return syscall::EINVAL;
     }
-    while (!pr->exited && !__atomic_load_n(&caller->kill_pending, __ATOMIC_ACQUIRE)) {
+    while (!pr->exited && !signals::interrupt_pending(caller)) {
         irq = sync::wait(pr->wait_queue, pr->lock, irq);
     }
-    if (__atomic_load_n(&caller->kill_pending, __ATOMIC_ACQUIRE)) {
+    if (!pr->exited) {
         sync::spin_unlock_irqrestore(pr->lock, irq);
         resource::resource_release(obj);
         return syscall::EINTR;

--- a/kernel/syscall/handlers/sys_task.cpp
+++ b/kernel/syscall/handlers/sys_task.cpp
@@ -32,8 +32,6 @@ DEFINE_SYSCALL1(exit_group, status) {
 }
 
 DEFINE_SYSCALL2(nanosleep, u_req, u_rem) {
-    (void)u_rem;
-
     struct kernel_timespec {
         int64_t tv_sec;
         int64_t tv_nsec;
@@ -56,6 +54,20 @@ DEFINE_SYSCALL2(nanosleep, u_req, u_rem) {
 
     uint64_t ns = static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL
                 + static_cast<uint64_t>(ts.tv_nsec);
-    sched::sleep_ns(ns);
-    return 0;
+    uint64_t rem_ns = sched::sleep_ns(ns);
+    if (rem_ns == 0) {
+        return 0;
+    }
+
+    if (u_rem != 0) {
+        kernel_timespec rem = {
+            static_cast<int64_t>(rem_ns / 1000000000ULL),
+            static_cast<int64_t>(rem_ns % 1000000000ULL),
+        };
+        if (mm::uaccess::copy_to_user(
+                reinterpret_cast<void*>(u_rem), &rem, sizeof(rem)) != mm::uaccess::OK) {
+            return syscall::EFAULT;
+        }
+    }
+    return syscall::EINTR;
 }

--- a/kernel/tests/signals/signal_interrupt.test.cpp
+++ b/kernel/tests/signals/signal_interrupt.test.cpp
@@ -1,0 +1,122 @@
+#define STLX_TEST_TIER TIER_MM_ALLOC
+
+#include "stlx_unit_test.h"
+#include "signals/signal.h"
+#include "sched/task.h"
+#include "mm/heap.h"
+#include "dynpriv/dynpriv.h"
+
+TEST_SUITE(signal_interrupt);
+
+// Hand-built process: a thread group with a leader and one thread.
+static sched::thread_group* g_tg;
+static sched::task* g_leader;
+static sched::task* g_thread;
+
+static int32_t setup_group() {
+    RUN_ELEVATED({
+        g_leader = heap::kalloc_new<sched::task>();
+        g_thread = heap::kalloc_new<sched::task>();
+        g_tg     = heap::kalloc_new<sched::thread_group>();
+    });
+    if (!g_leader || !g_thread || !g_tg) {
+        return -1;
+    }
+
+    g_tg->lock = sync::SPINLOCK_INIT;
+    g_tg->leader = g_leader;
+    g_tg->pid = 1;
+    g_tg->threads.init();
+    g_tg->thread_count = 1;
+    g_leader->group = g_tg;
+    g_thread->group = g_tg;
+    g_tg->threads.push_back(g_thread);
+    return 0;
+}
+
+static int32_t teardown_group() {
+    RUN_ELEVATED({
+        if (g_tg)     heap::kfree_delete(g_tg);
+        if (g_leader) heap::kfree_delete(g_leader);
+        if (g_thread) heap::kfree_delete(g_thread);
+    });
+    g_tg = nullptr;
+    g_leader = nullptr;
+    g_thread = nullptr;
+    return 0;
+}
+
+BEFORE_EACH(signal_interrupt, setup_group);
+AFTER_EACH(signal_interrupt, teardown_group);
+
+TEST(signal_interrupt, kill_flag_reports_sigkill) {
+    uint32_t fatal = 0;
+    g_leader->kill_pending = 1;
+    g_leader->sig.pending = signals::sig_bit(signals::SIGTERM);
+    RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
+    EXPECT_EQ(fatal, signals::SIGKILL);
+}
+
+TEST(signal_interrupt, lowest_fatal_signal_wins) {
+    uint32_t fatal = 0;
+    g_leader->sig.pending = signals::sig_bit(signals::SIGTERM)
+                          | signals::sig_bit(signals::SIGINT);
+    RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
+    EXPECT_EQ(fatal, signals::SIGINT);
+}
+
+TEST(signal_interrupt, pending_sigkill_outranks_lower_signals) {
+    uint32_t fatal = 0;
+    g_leader->sig.pending = signals::sig_bit(signals::SIGINT);
+    g_tg->sig.shared_pending = signals::sig_bit(signals::SIGKILL);
+    RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
+    EXPECT_EQ(fatal, signals::SIGKILL);
+}
+
+TEST(signal_interrupt, blocked_signals_are_not_fatal) {
+    uint32_t fatal = 1;
+    g_leader->sig.pending = signals::sig_bit(signals::SIGTERM);
+    g_leader->sig.blocked = signals::sig_bit(signals::SIGTERM);
+    RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
+    EXPECT_EQ(fatal, 0U);
+}
+
+TEST(signal_interrupt, handled_signals_are_not_fatal) {
+    signals::k_sigaction act = {};
+    act.handler = 0x400000;
+    uint32_t fatal = 1;
+    RUN_ELEVATED({
+        signals::set_action(g_tg, signals::SIGTERM, &act, nullptr);
+    });
+    g_leader->sig.pending = signals::sig_bit(signals::SIGTERM);
+    RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
+    EXPECT_EQ(fatal, 0U);
+}
+
+TEST(signal_interrupt, default_ignore_pending_is_not_fatal) {
+    uint32_t fatal = 1;
+    g_leader->sig.pending = signals::sig_bit(signals::SIGCHLD);
+    RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
+    EXPECT_EQ(fatal, 0U);
+}
+
+TEST(signal_interrupt, shared_pending_is_visible_to_every_thread) {
+    uint32_t fatal = 0;
+    g_tg->sig.shared_pending = signals::sig_bit(signals::SIGTERM);
+    RUN_ELEVATED({ fatal = signals::fatal_pending(g_thread); });
+    EXPECT_EQ(fatal, signals::SIGTERM);
+}
+
+TEST(signal_interrupt, interrupt_pending_truth) {
+    bool intr = true;
+    RUN_ELEVATED({ intr = signals::interrupt_pending(g_leader); });
+    EXPECT_FALSE(intr);
+
+    g_leader->sig.pending = signals::sig_bit(signals::SIGTERM);
+    RUN_ELEVATED({ intr = signals::interrupt_pending(g_leader); });
+    EXPECT_TRUE(intr);
+
+    intr = true;
+    RUN_ELEVATED({ intr = signals::interrupt_pending(nullptr); });
+    EXPECT_FALSE(intr);
+}


### PR DESCRIPTION
## Summary
- Blocking waits re-checked only the kill flag, so a task with a pending fatal signal could stay blocked in sleeps, buffers, sockets, poll, futexes, or process waits until an unrelated wakeup.
- fatal_pending and interrupt_pending answer "must this task die" with SIGKILL outranking all, and every blocking wait plus the scheduler's post-block re-check now unwinds on them, completing the sender-side wake fence contract.
- sleep_ns reports the time remaining when interrupted and nanosleep surfaces it with EINTR per POSIX.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the contract for every blocking syscall path and scheduler sleep/interrupt handling; incorrect fatal-signal selection or races could cause stuck tasks or premature EINTR.
> 
> **Overview**
> Blocking kernel waits previously bailed out only on **`kill_pending`**, so a task with a pending **default-terminate** signal (e.g. SIGTERM) could stay asleep in ring buffers, TCP/UNIX sockets, futexes, poll, or **`proc_wait`** until some unrelated wakeup.
> 
> This PR adds **`signals::fatal_pending`** / **`signals::interrupt_pending`** (kill flag → SIGKILL; otherwise lowest unblocked pending signal whose disposition is default-terminate, with SIGKILL outranking others) and routes wait loops and post-block checks through them. **`block_task_interrupted_by_kill`** is renamed **`block_task_interrupted`** and delegates to that helper, pairing with existing **`wake_for_signal`** / **`force_wake_for_kill`** fences.
> 
> **`sleep_ns`** now returns **remaining nanoseconds** when interrupted; **`nanosleep`** writes **`rem`** and returns **EINTR**. **`proc_wait`** returns **EINTR** whenever the wait ends without the child having exited (including signal interrupt), not only on kill. Unit tests cover **`fatal_pending`** / **`interrupt_pending`** selection rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 362ebdb7e33d6c63c0c09218fd6e7d6703806355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->