### PR TITLE
fix(signals): reported EINTR from interrupted blocking waits

### DIFF
--- a/kernel/common/ring_buffer.cpp
+++ b/kernel/common/ring_buffer.cpp
@@ -86,8 +86,11 @@ __PRIVILEGED_CODE ssize_t ring_buffer_read(ring_buffer* rb, uint8_t* buf, size_t
 
     size_t avail = readable_bytes(rb);
     if (avail == 0) {
+        // A closed writer is genuine EOF, an interrupted wait is not
+        bool intr = !rb->writer_closed
+                  && signals::interrupt_pending(sched::current());
         sync::spin_unlock_irqrestore(rb->lock, irq);
-        return 0; // EOF
+        return intr ? RB_ERR_INTR : 0;
     }
 
     size_t to_read = avail < len ? avail : len;
@@ -130,9 +133,13 @@ __PRIVILEGED_CODE ssize_t ring_buffer_write(ring_buffer* rb, const uint8_t* buf,
         }
     }
 
-    if (rb->reader_closed || signals::interrupt_pending(sched::current())) {
+    if (rb->reader_closed) {
         sync::spin_unlock_irqrestore(rb->lock, irq);
         return RB_ERR_PIPE;
+    }
+    if (signals::interrupt_pending(sched::current())) {
+        sync::spin_unlock_irqrestore(rb->lock, irq);
+        return RB_ERR_INTR;
     }
 
     size_t space = writable_bytes(rb);
@@ -184,9 +191,13 @@ __PRIVILEGED_CODE ssize_t ring_buffer_write_all(ring_buffer* rb, const uint8_t* 
         }
     }
 
-    if (rb->reader_closed || signals::interrupt_pending(sched::current())) {
+    if (rb->reader_closed) {
         sync::spin_unlock_irqrestore(rb->lock, irq);
         return RB_ERR_PIPE;
+    }
+    if (signals::interrupt_pending(sched::current())) {
+        sync::spin_unlock_irqrestore(rb->lock, irq);
+        return RB_ERR_INTR;
     }
 
     size_t space = writable_bytes(rb);

--- a/kernel/common/ring_buffer.cpp
+++ b/kernel/common/ring_buffer.cpp
@@ -137,12 +137,15 @@ __PRIVILEGED_CODE ssize_t ring_buffer_write(ring_buffer* rb, const uint8_t* buf,
         sync::spin_unlock_irqrestore(rb->lock, irq);
         return RB_ERR_PIPE;
     }
-    if (signals::interrupt_pending(sched::current())) {
+
+    // Progress wins over interruption: only a waited-out interruption
+    // leaves no space here while the reader is still open
+    size_t space = writable_bytes(rb);
+    if (space == 0) {
         sync::spin_unlock_irqrestore(rb->lock, irq);
         return RB_ERR_INTR;
     }
 
-    size_t space = writable_bytes(rb);
     size_t to_write = space < len ? space : len;
     size_t head_idx = rb->head & (rb->capacity - 1);
     size_t first = rb->capacity - head_idx;
@@ -195,15 +198,13 @@ __PRIVILEGED_CODE ssize_t ring_buffer_write_all(ring_buffer* rb, const uint8_t* 
         sync::spin_unlock_irqrestore(rb->lock, irq);
         return RB_ERR_PIPE;
     }
-    if (signals::interrupt_pending(sched::current())) {
-        sync::spin_unlock_irqrestore(rb->lock, irq);
-        return RB_ERR_INTR;
-    }
 
+    // Progress wins over interruption, AGAIN covers spurious exits
     size_t space = writable_bytes(rb);
     if (space < len) {
+        bool intr = signals::interrupt_pending(sched::current());
         sync::spin_unlock_irqrestore(rb->lock, irq);
-        return RB_ERR_AGAIN;
+        return intr ? RB_ERR_INTR : RB_ERR_AGAIN;
     }
 
     size_t head_idx = rb->head & (rb->capacity - 1);

--- a/kernel/common/ring_buffer.h
+++ b/kernel/common/ring_buffer.h
@@ -7,9 +7,11 @@
 
 constexpr size_t RING_BUFFER_DEFAULT_CAPACITY = 8192;
 
+// Values mirror the resource layer error codes and flow untranslated
 constexpr ssize_t RB_ERR_INVAL = -1;
 constexpr ssize_t RB_ERR_AGAIN = -16;
 constexpr ssize_t RB_ERR_PIPE  = -11;
+constexpr ssize_t RB_ERR_INTR  = -18;
 
 struct ring_buffer {
     uint8_t* data;

--- a/kernel/syscall/handlers/sys_fd.cpp
+++ b/kernel/syscall/handlers/sys_fd.cpp
@@ -120,6 +120,8 @@ inline int64_t map_resource_error(int64_t rc) {
             return syscall::ENOSYS;
         case resource::ERR_PIPE:
             return syscall::EPIPE;
+        case resource::ERR_INTR:
+            return syscall::EINTR;
         case resource::ERR_NOTCONN:
             return syscall::ENOTCONN;
         case resource::ERR_CONNREFUSED:

--- a/kernel/syscall/handlers/sys_io.cpp
+++ b/kernel/syscall/handlers/sys_io.cpp
@@ -25,6 +25,7 @@ inline int64_t map_resource_error(int64_t rc) {
         case resource::ERR_TABLEFULL: return syscall::EMFILE;
         case resource::ERR_UNSUP:     return syscall::ENOSYS;
         case resource::ERR_PIPE:      return syscall::EPIPE;
+        case resource::ERR_INTR:      return syscall::EINTR;
         case resource::ERR_AGAIN:     return syscall::EAGAIN;
         case resource::ERR_IO:
         default:                      return syscall::EIO;

--- a/kernel/syscall/handlers/sys_poll.cpp
+++ b/kernel/syscall/handlers/sys_poll.cpp
@@ -4,6 +4,7 @@
 #include "resource/resource.h"
 #include "sched/sched.h"
 #include "sched/task.h"
+#include "signals/signal.h"
 #include "mm/uaccess.h"
 #include "mm/heap.h"
 
@@ -96,6 +97,11 @@ __PRIVILEGED_CODE static int64_t do_poll(
     }
 
     sync::poll_cleanup(pt);
+
+    // An interrupted wait with nothing ready is EINTR, not a timeout
+    if (ready == 0 && signals::interrupt_pending(task)) {
+        return syscall::EINTR;
+    }
     return ready;
 }
 

--- a/kernel/syscall/handlers/sys_select.cpp
+++ b/kernel/syscall/handlers/sys_select.cpp
@@ -4,6 +4,7 @@
 #include "resource/resource.h"
 #include "sched/sched.h"
 #include "sched/task.h"
+#include "signals/signal.h"
 #include "mm/uaccess.h"
 #include "mm/heap.h"
 
@@ -37,7 +38,7 @@ __PRIVILEGED_CODE static int64_t do_select(
         pt.init(task);
         sync::poll_wait(pt, timeout_ns);
         sync::poll_cleanup(pt);
-        return 0;
+        return signals::interrupt_pending(task) ? syscall::EINTR : 0;
     }
 
     size_t nwords = (static_cast<size_t>(nfds) + BITS_PER_LONG - 1) / BITS_PER_LONG;
@@ -158,6 +159,12 @@ __PRIVILEGED_CODE static int64_t do_select(
 
     heap::kfree(fdmap);
     heap::kfree(pollfds);
+
+    // An interrupted wait with nothing ready is EINTR, not a timeout.
+    // Zero-timeout probes never slept and keep reporting 0.
+    if (ready == 0 && !immediate && signals::interrupt_pending(task)) {
+        return syscall::EINTR;
+    }
     return ready;
 }
 

--- a/kernel/tests/signals/interrupt_results.test.cpp
+++ b/kernel/tests/signals/interrupt_results.test.cpp
@@ -1,0 +1,77 @@
+#define STLX_TEST_TIER TIER_SCHED
+
+#include "stlx_unit_test.h"
+#include "common/ring_buffer.h"
+#include "resource/resource.h"
+#include "signals/signal.h"
+#include "sched/sched.h"
+#include "sched/task.h"
+#include "dynpriv/dynpriv.h"
+
+TEST_SUITE(interrupt_results);
+
+// The kill flag drives the same interruption logic as fatal signals
+// and is safe to toggle on the running kernel test task.
+
+static ring_buffer* g_rb;
+
+static int32_t setup_rb() {
+    RUN_ELEVATED({ g_rb = ring_buffer_create(64); });
+    return g_rb ? 0 : -1;
+}
+
+static int32_t teardown_rb() {
+    __atomic_store_n(&sched::current()->kill_pending, 0, __ATOMIC_RELEASE);
+    RUN_ELEVATED({
+        if (g_rb) ring_buffer_destroy(g_rb);
+    });
+    g_rb = nullptr;
+    return 0;
+}
+
+BEFORE_EACH(interrupt_results, setup_rb);
+AFTER_EACH(interrupt_results, teardown_rb);
+
+TEST(interrupt_results, interrupted_empty_read_is_not_eof) {
+    uint8_t buf[8];
+    ssize_t rc = 0;
+    __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
+    RUN_ELEVATED({ rc = ring_buffer_read(g_rb, buf, sizeof(buf), false); });
+    EXPECT_EQ(rc, RB_ERR_INTR);
+}
+
+TEST(interrupt_results, closed_writer_read_stays_eof_when_interrupted) {
+    uint8_t buf[8];
+    ssize_t rc = -100;
+    RUN_ELEVATED({ ring_buffer_close_write(g_rb); });
+    __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
+    RUN_ELEVATED({ rc = ring_buffer_read(g_rb, buf, sizeof(buf), false); });
+    EXPECT_EQ(rc, 0LL);
+}
+
+TEST(interrupt_results, interrupted_full_write_is_not_epipe) {
+    uint8_t big[64];
+    ssize_t rc = 0;
+    RUN_ELEVATED({ ring_buffer_write(g_rb, big, 63, true); }); // fill it
+    __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
+    RUN_ELEVATED({ rc = ring_buffer_write(g_rb, big, 8, false); });
+    EXPECT_EQ(rc, RB_ERR_INTR);
+
+    rc = 0;
+    RUN_ELEVATED({ rc = ring_buffer_write_all(g_rb, big, 8, false); });
+    EXPECT_EQ(rc, RB_ERR_INTR);
+}
+
+TEST(interrupt_results, closed_reader_write_stays_epipe_when_interrupted) {
+    uint8_t buf[8];
+    ssize_t rc = 0;
+    RUN_ELEVATED({ ring_buffer_close_read(g_rb); });
+    __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
+    RUN_ELEVATED({ rc = ring_buffer_write(g_rb, buf, sizeof(buf), false); });
+    EXPECT_EQ(rc, RB_ERR_PIPE);
+}
+
+TEST(interrupt_results, rb_intr_matches_resource_code) {
+    EXPECT_EQ(RB_ERR_INTR, static_cast<ssize_t>(resource::ERR_INTR));
+    EXPECT_EQ(RB_ERR_PIPE, static_cast<ssize_t>(resource::ERR_PIPE));
+}

--- a/kernel/tests/signals/interrupt_results.test.cpp
+++ b/kernel/tests/signals/interrupt_results.test.cpp
@@ -49,17 +49,40 @@ TEST(interrupt_results, closed_writer_read_stays_eof_when_interrupted) {
     EXPECT_EQ(rc, 0LL);
 }
 
+// Fill regardless of how create rounds the requested capacity up
+static void fill_buffer(ring_buffer* rb) {
+    uint8_t byte = 0;
+    ssize_t rc = 1;
+    RUN_ELEVATED({
+        while (rc == 1) {
+            rc = ring_buffer_write(rb, &byte, 1, true);
+        }
+    });
+}
+
 TEST(interrupt_results, interrupted_full_write_is_not_epipe) {
-    uint8_t big[64];
+    uint8_t buf[8];
     ssize_t rc = 0;
-    RUN_ELEVATED({ ring_buffer_write(g_rb, big, 63, true); }); // fill it
+    fill_buffer(g_rb);
     __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
-    RUN_ELEVATED({ rc = ring_buffer_write(g_rb, big, 8, false); });
+    RUN_ELEVATED({ rc = ring_buffer_write(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, RB_ERR_INTR);
 
     rc = 0;
-    RUN_ELEVATED({ rc = ring_buffer_write_all(g_rb, big, 8, false); });
+    RUN_ELEVATED({ rc = ring_buffer_write_all(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, RB_ERR_INTR);
+}
+
+TEST(interrupt_results, interrupted_write_with_space_still_writes) {
+    uint8_t buf[8];
+    ssize_t rc = 0;
+    __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
+    RUN_ELEVATED({ rc = ring_buffer_write(g_rb, buf, sizeof(buf), false); });
+    EXPECT_EQ(rc, 8LL);
+
+    rc = 0;
+    RUN_ELEVATED({ rc = ring_buffer_write_all(g_rb, buf, sizeof(buf), false); });
+    EXPECT_EQ(rc, 8LL);
 }
 
 TEST(interrupt_results, closed_reader_write_stays_epipe_when_interrupted) {


### PR DESCRIPTION
## Summary
- A wait interrupted by a kill or fatal signal returned misleading results: buffer reads reported end-of-stream, writes reported a closed pipe, and poll/select looked like a timeout.
- The buffer layer gains a distinct interrupted result (value aligned with the resource layer so it flows untranslated), with closed-writer and closed-reader conditions keeping precedence, and both io syscall error tables map it to EINTR.
- poll, ppoll, select, and pselect6 report EINTR when an actual wait was interrupted, while zero-timeout probes keep reporting 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core syscall and ring-buffer wait paths where misclassification could break userland retry semantics, but behavior is narrowly scoped to interruption vs EOF/pipe/timeout with added tests.
> 
> **Overview**
> Blocking waits interrupted by signals no longer masquerade as EOF, `EPIPE`, timeouts, or `EAGAIN` where that was wrong.
> 
> **Ring buffer** adds `RB_ERR_INTR` (aligned with `resource::ERR_INTR`) and separates interruption from genuine EOF/pipe closure: empty reads after an interrupted wait return interrupt instead of `0`; full writes return interrupt instead of treating interruption like a closed reader. If space or data is available after wake, I/O still proceeds (“progress wins”). **`sys_fd` / `sys_io`** map `ERR_INTR` to **`EINTR`**.
> 
> **`poll` / `ppoll` / `select` / `pselect6`** return **`EINTR`** when a real timed wait ends with nothing ready and a signal is pending; zero-timeout probes still return `0`.
> 
> New **`interrupt_results`** unit tests cover ring-buffer and error-code behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4f19abb8ec37a3980e92223a28ba5242f10c2d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->