### PR TITLE
feat(signals): unified task death behind fatal signal state

### DIFF
--- a/kernel/arch/aarch64/sched/sched.cpp
+++ b/kernel/arch/aarch64/sched/sched.cpp
@@ -2,6 +2,7 @@
 #include "sched/task.h"
 #include "sched/sched.h"
 #include "sched/sched_internal.h"
+#include "signals/signal.h"
 #include "sched/fpu.h"
 #include "dynpriv/dynpriv.h"
 #include "syscall/syscall.h"
@@ -154,10 +155,11 @@ __PRIVILEGED_CODE void on_yield(aarch64::trap_frame* tf) {
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();
 
-    if (__atomic_load_n(&prev->kill_pending, __ATOMIC_ACQUIRE)
-        && !(prev->exec.flags & TASK_FLAG_KERNEL)
-        && prev->state != TASK_STATE_DEAD) {
-        sched::exit(sched::TASK_KILL_STATUS);
+    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state != TASK_STATE_DEAD) {
+        uint32_t fsig = signals::fatal_pending(prev);
+        if (fsig) {
+            signals::die_from_signal(fsig);
+        }
     }
 
     task* next = pick_next_and_switch(prev);
@@ -196,10 +198,11 @@ __PRIVILEGED_CODE void on_tick(aarch64::trap_frame* tf) {
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();
 
-    if (__atomic_load_n(&prev->kill_pending, __ATOMIC_ACQUIRE)
-        && !(prev->exec.flags & TASK_FLAG_KERNEL)
-        && prev->state != TASK_STATE_DEAD) {
-        sched::exit(sched::TASK_KILL_STATUS);
+    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state != TASK_STATE_DEAD) {
+        uint32_t fsig = signals::fatal_pending(prev);
+        if (fsig) {
+            signals::die_from_signal(fsig);
+        }
     }
 
     task* next = pick_next_and_switch(prev);

--- a/kernel/arch/aarch64/trap/trap.cpp
+++ b/kernel/arch/aarch64/trap/trap.cpp
@@ -13,6 +13,7 @@
 #include "timer/timer.h"
 #include "sched/sched.h"
 #include "sched/task.h"
+#include "signals/signal.h"
 #include "mm/mm.h"
 
 // Forward declaration of syscall dispatch
@@ -118,9 +119,7 @@ void stlx_aarch64_el0_sync_handler(aarch64::trap_frame* tf) {
         ec == aarch64::EC_FP_A64           ||
         ec == aarch64::EC_BRK_A64)
     ) {
-        int sig = ec_to_signal(ec);
-        __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
-        sched::exit(sig);
+        signals::die_from_signal(static_cast<uint32_t>(ec_to_signal(ec)));
     }
 
     trap_fatal("el0 sync", tf);

--- a/kernel/arch/x86_64/sched/sched.cpp
+++ b/kernel/arch/x86_64/sched/sched.cpp
@@ -2,6 +2,7 @@
 #include "sched/task.h"
 #include "sched/sched.h"
 #include "sched/sched_internal.h"
+#include "signals/signal.h"
 #include "sched/fpu.h"
 #include "dynpriv/dynpriv.h"
 #include "trap/trap_frame.h"
@@ -128,10 +129,11 @@ __PRIVILEGED_CODE void on_yield(x86::trap_frame* tf) {
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();
 
-    if (__atomic_load_n(&prev->kill_pending, __ATOMIC_ACQUIRE)
-        && !(prev->exec.flags & TASK_FLAG_KERNEL)
-        && prev->state != TASK_STATE_DEAD) {
-        sched::exit(sched::TASK_KILL_STATUS);
+    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state != TASK_STATE_DEAD) {
+        uint32_t fsig = signals::fatal_pending(prev);
+        if (fsig) {
+            signals::die_from_signal(fsig);
+        }
     }
 
     task* next = pick_next_and_switch(prev);
@@ -169,10 +171,11 @@ __PRIVILEGED_CODE void on_tick(x86::trap_frame* tf) {
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();
 
-    if (__atomic_load_n(&prev->kill_pending, __ATOMIC_ACQUIRE)
-        && !(prev->exec.flags & TASK_FLAG_KERNEL)
-        && prev->state != TASK_STATE_DEAD) {
-        sched::exit(sched::TASK_KILL_STATUS);
+    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state != TASK_STATE_DEAD) {
+        uint32_t fsig = signals::fatal_pending(prev);
+        if (fsig) {
+            signals::die_from_signal(fsig);
+        }
     }
 
     task* next = pick_next_and_switch(prev);

--- a/kernel/arch/x86_64/trap/trap.cpp
+++ b/kernel/arch/x86_64/trap/trap.cpp
@@ -10,6 +10,7 @@
 #include "msi/msi.h"
 #include "sched/sched.h"
 #include "sched/task.h"
+#include "signals/signal.h"
 #include "mm/mm.h"
 
 namespace sched {
@@ -118,9 +119,7 @@ extern "C" __PRIVILEGED_CODE void stlx_x86_64_trap_handler(x86::trap_frame* tf) 
         tf->vector == x86::EXC_STACK_FAULT ||
         tf->vector == x86::EXC_ALIGNMENT_CHECK)
     ) {
-        int sig = vector_to_signal(tf->vector);
-        __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
-        sched::exit(sig); // POSIX-compatible SIGSEGV
+        signals::die_from_signal(static_cast<uint32_t>(vector_to_signal(tf->vector)));
     }
 
     panic::on_trap(tf);

--- a/kernel/sched/sched.cpp
+++ b/kernel/sched/sched.cpp
@@ -453,6 +453,15 @@ __PRIVILEGED_CODE void sleep_ms(uint64_t ms) {
             thread_group* tg = task->group;
 
             if (tg->leader == task) {
+                // Reaped never-started threads report the recorded group
+                // exit signal so every member exposes the same death cause
+                int32_t reap_status = TASK_KILL_STATUS;
+                uint32_t es = __atomic_load_n(&tg->sig.exit_signal,
+                                              __ATOMIC_ACQUIRE);
+                if (es != 0) {
+                    reap_status = static_cast<int32_t>(es) & 0x7F;
+                }
+
                 sync::irq_state irq = sync::spin_lock_irqsave(tg->lock);
                 auto it = tg->threads.begin();
                 auto end = tg->threads.end();
@@ -468,7 +477,7 @@ __PRIVILEGED_CODE void sleep_ms(uint64_t ms) {
                         if (thread.proc_res) {
                             auto* pr = thread.proc_res;
                             sync::irq_state pr_irq = sync::spin_lock_irqsave(pr->lock);
-                            pr->wait_status = TASK_KILL_STATUS;
+                            pr->wait_status = reap_status;
                             pr->exited = true;
                             pr->child = nullptr;
                             sync::wake_all(pr->wait_queue);

--- a/kernel/sched/sched.cpp
+++ b/kernel/sched/sched.cpp
@@ -180,16 +180,23 @@ task* current() {
     return this_cpu(current_task);
 }
 
+// A pending SIGKILL bit is the task's "must terminate" marker
+static inline bool task_kill_bit_set(const task* t) {
+    return (__atomic_load_n(&t->sig.pending, __ATOMIC_ACQUIRE)
+            & signals::sig_bit(signals::SIGKILL)) != 0;
+}
+
 bool is_kill_pending() {
     task* t = current();
-    return t && __atomic_load_n(&t->kill_pending, __ATOMIC_ACQUIRE);
+    return t && task_kill_bit_set(t);
 }
 
 __PRIVILEGED_CODE void force_wake_for_kill(task* t) {
-    __atomic_store_n(&t->kill_pending, 1, __ATOMIC_RELEASE);
+    __atomic_fetch_or(&t->sig.pending, signals::sig_bit(signals::SIGKILL),
+                      __ATOMIC_ACQ_REL);
 
     // Pairs with block_task_interrupted: the wake below sees BLOCKED,
-    // or the blocker's interrupt check sees kill_pending. Never neither.
+    // or the blocker's interrupt check sees the SIGKILL bit. Never neither.
     __atomic_thread_fence(__ATOMIC_SEQ_CST);
     timer::cancel_sleep(t);
     wake(t);
@@ -491,7 +498,7 @@ __PRIVILEGED_CODE void sleep_ms(uint64_t ms) {
             auto* pr = task->proc_res;
             sync::irq_state irq = sync::spin_lock_irqsave(pr->lock);
             if (!pr->detached) {
-                if (__atomic_load_n(&task->kill_pending, __ATOMIC_ACQUIRE)) {
+                if (task_kill_bit_set(task)) {
                     pr->wait_status = exit_code & 0x7F;
                 } else {
                     pr->wait_status = (exit_code & 0xFF) << 8;
@@ -590,7 +597,6 @@ __PRIVILEGED_CODE task* create_kernel_task(
     resource::init_task_handles(t);
     t->proc_res = nullptr;
     t->cwd = nullptr;
-    t->kill_pending = 0;
     t->sig = {};
     t->group = nullptr;
     t->group_link = {};
@@ -849,7 +855,6 @@ __PRIVILEGED_CODE task* create_user_task(
     resource::init_task_handles(t);
     t->proc_res = nullptr;
     t->cwd = nullptr;
-    t->kill_pending = 0;
     t->sig = {};
 
     auto* tg = heap::kalloc_new<thread_group>();
@@ -941,7 +946,6 @@ __PRIVILEGED_CODE task* create_user_thread(
     t->state = TASK_STATE_CREATED;
     t->exit_code = 0;
     t->cleanup_stage = TASK_CLEANUP_STAGE_ACTIVE;
-    t->kill_pending = 0;
     t->sig = {};
     t->sig.blocked = __atomic_load_n(&creator->sig.blocked, __ATOMIC_ACQUIRE);
     string::memcpy(t->name, name, string::strnlen(name, TASK_NAME_MAX - 1)); 

--- a/kernel/sched/task.h
+++ b/kernel/sched/task.h
@@ -62,13 +62,13 @@ struct task {
     int32_t        exit_code;
     uint32_t       state;
     uint32_t       cleanup_stage;
-    uint32_t       kill_pending;
 
     // Stacks
     uintptr_t      task_stack_base;
     uintptr_t      sys_stack_base;
 
-    // Signals (per-thread blocked mask and pending set)
+    // Signals (per-thread blocked mask and pending set). A
+    // pending SIGKILL bit is the task's "kill pending" marker.
     signals::task_signals sig;
 
     // Scheduler state

--- a/kernel/signals/signal.cpp
+++ b/kernel/signals/signal.cpp
@@ -251,25 +251,26 @@ __PRIVILEGED_CODE int32_t send_to_group(sched::thread_group* tg, uint32_t sig) {
 }
 
 __PRIVILEGED_CODE uint32_t fatal_pending(sched::task* t) {
-    if (__atomic_load_n(&t->kill_pending, __ATOMIC_ACQUIRE)) {
-        return SIGKILL;
+    sig_set_t pending = __atomic_load_n(&t->sig.pending, __ATOMIC_ACQUIRE);
+    sig_set_t shared = t->group
+        ? __atomic_load_n(&t->group->sig.shared_pending, __ATOMIC_ACQUIRE) : 0;
+
+    // A pending SIGKILL is the "must terminate" marker and outranks all.
+    // Report the signal that began group termination if one was recorded.
+    if ((pending | shared) & sig_bit(SIGKILL)) {
+        uint32_t es = t->group
+            ? __atomic_load_n(&t->group->sig.exit_signal, __ATOMIC_ACQUIRE) : 0;
+        return es ? es : SIGKILL;
     }
 
     if (!t->group) {
         return 0;
     }
 
-    sig_set_t deliverable =
-        (__atomic_load_n(&t->sig.pending, __ATOMIC_ACQUIRE) |
-         __atomic_load_n(&t->group->sig.shared_pending, __ATOMIC_ACQUIRE)) &
-        ~__atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE);
+    sig_set_t deliverable = (pending | shared)
+        & ~__atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE);
     if (!deliverable) {
         return 0;
-    }
-
-    // SIGKILL outranks every other pending signal
-    if (deliverable & sig_bit(SIGKILL)) {
-        return SIGKILL;
     }
 
     sync::irq_state irq = sync::spin_lock_irqsave(t->group->sig.lock);
@@ -291,6 +292,40 @@ __PRIVILEGED_CODE uint32_t fatal_pending(sched::task* t) {
 
 __PRIVILEGED_CODE bool interrupt_pending(sched::task* t) {
     return t && fatal_pending(t) != 0;
+}
+
+__PRIVILEGED_CODE void die_from_signal(uint32_t sig) {
+    sched::task* self = sched::current();
+    sched::thread_group* tg = self->group;
+
+    // Native kills (proc_kill, proc_kill_tid) stay thread-scoped: the
+    // SIGKILL bit is set without recording a group exit signal
+    bool native_kill =
+        (__atomic_load_n(&self->sig.pending, __ATOMIC_ACQUIRE) & sig_bit(SIGKILL)) &&
+        (!tg || __atomic_load_n(&tg->sig.exit_signal, __ATOMIC_ACQUIRE) == 0);
+
+    if (tg && !native_kill) {
+        // First recorded signal wins so every group member reports it,
+        // including this thread if another already recorded one
+        uint32_t expected = 0;
+        if (!__atomic_compare_exchange_n(&tg->sig.exit_signal, &expected, sig,
+                                         false, __ATOMIC_ACQ_REL,
+                                         __ATOMIC_ACQUIRE)) {
+            sig = expected;
+        }
+
+        // A dying non-leader force-kills the leader, whose exit reaps
+        // every remaining thread
+        sync::irq_state irq = sync::spin_lock_irqsave(tg->lock);
+        if (tg->leader && tg->leader != self) {
+            sched::force_wake_for_kill(tg->leader);
+        }
+        sync::spin_unlock_irqrestore(tg->lock, irq);
+    }
+
+    // The SIGKILL bit makes exit() encode a killed-by-signal wait status
+    __atomic_fetch_or(&self->sig.pending, sig_bit(SIGKILL), __ATOMIC_RELEASE);
+    sched::exit(static_cast<int32_t>(sig));
 }
 
 } // namespace signals

--- a/kernel/signals/signal.h
+++ b/kernel/signals/signal.h
@@ -71,9 +71,9 @@ __PRIVILEGED_CODE int32_t send_to_group(sched::thread_group* tg, uint32_t sig);
 
 /**
  * @brief Fatal signal the task must die from, or 0.
- * A set kill flag reports SIGKILL. Otherwise the lowest pending
- * unblocked signal whose action resolves to default-terminate, with
- * SIGKILL outranking every other pending signal.
+ * A set kill flag reports the group's recorded exit signal (SIGKILL if
+ * none). Otherwise the lowest pending unblocked signal whose action
+ * resolves to default-terminate, with SIGKILL outranking all others.
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE uint32_t fatal_pending(sched::task* t);
@@ -84,6 +84,16 @@ __PRIVILEGED_CODE uint32_t fatal_pending(sched::task* t);
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE bool interrupt_pending(sched::task* t);
+
+/**
+ * @brief Terminate the current task because of signal sig.
+ * Fatal signals kill the whole process: a non-leader records sig as the
+ * group exit signal and force-kills the leader so teardown reaps every
+ * thread. Native kills (proc_kill, proc_kill_tid) stay thread-scoped.
+ * The wait status reports death by sig.
+ * @note Privilege: **required**
+ */
+[[noreturn]] __PRIVILEGED_CODE void die_from_signal(uint32_t sig);
 
 } // namespace signals
 

--- a/kernel/signals/signal_types.h
+++ b/kernel/signals/signal_types.h
@@ -77,6 +77,7 @@ struct task_signals {
 struct group_signals {
     sync::spinlock lock; // guards actions
     sig_set_t shared_pending;
+    uint32_t exit_signal; // first fatal signal that began group termination, 0 if none
     k_sigaction actions[NSIG];
 };
 

--- a/kernel/syscall/syscall.cpp
+++ b/kernel/syscall/syscall.cpp
@@ -3,6 +3,7 @@
 #include "sched/task_exec_core.h"
 #include "sched/sched.h"
 #include "sched/task.h"
+#include "signals/signal.h"
 #include "dynpriv/dynpriv.h"
 #include "percpu/percpu.h"
 #include "common/logging.h"
@@ -48,9 +49,11 @@ extern "C" __PRIVILEGED_CODE int64_t stlx_syscall_handler(
     }
 
     sched::task* self = sched::current();
-    if (self && __atomic_load_n(&self->kill_pending, __ATOMIC_ACQUIRE)
-        && !(self->exec.flags & sched::TASK_FLAG_KERNEL)) {
-        sched::exit(sched::TASK_KILL_STATUS);
+    if (self && !(self->exec.flags & sched::TASK_FLAG_KERNEL)) {
+        uint32_t fsig = signals::fatal_pending(self);
+        if (fsig) {
+            signals::die_from_signal(fsig);
+        }
     }
 
     // Return-boundary restore: dynamic runtime elevation follows the selected

--- a/kernel/tests/sched/kill.test.cpp
+++ b/kernel/tests/sched/kill.test.cpp
@@ -4,6 +4,7 @@
 #include "helpers.h"
 #include "sched/sched.h"
 #include "sched/task.h"
+#include "signals/signal_types.h"
 #include "dynpriv/dynpriv.h"
 #include "sync/spinlock.h"
 #include "sync/wait_queue.h"
@@ -42,7 +43,7 @@ static void sleep_kill_fn(void*) {
 
     uint32_t kp = 0;
     RUN_ELEVATED({
-        kp = __atomic_load_n(&sched::current()->kill_pending, __ATOMIC_ACQUIRE);
+        kp = sched::is_kill_pending() ? 1u : 0u;
     });
     __atomic_store_n(&g_sleep_kill_was_pending, kp, __ATOMIC_RELEASE);
     __atomic_store_n(&g_sleep_kill_done, 1, __ATOMIC_RELEASE);
@@ -117,7 +118,7 @@ static void wq_kill_fn(void*) {
 
     uint32_t kp = 0;
     RUN_ELEVATED({
-        kp = __atomic_load_n(&sched::current()->kill_pending, __ATOMIC_ACQUIRE);
+        kp = sched::is_kill_pending() ? 1u : 0u;
     });
     __atomic_store_n(&g_wq_kill_was_pending, kp, __ATOMIC_RELEASE);
     __atomic_store_n(&g_wq_kill_done, 1, __ATOMIC_RELEASE);
@@ -212,7 +213,7 @@ static void double_kill_fn(void*) {
         }
         sync::spin_unlock_irqrestore(g_double_lock, irq);
         __atomic_store_n(&g_double_kp,
-            __atomic_load_n(&sched::current()->kill_pending, __ATOMIC_ACQUIRE),
+            sched::is_kill_pending() ? 1u : 0u,
             __ATOMIC_RELEASE);
     });
     __atomic_store_n(&g_double_done, 1, __ATOMIC_RELEASE);
@@ -292,7 +293,8 @@ TEST(kill, is_kill_pending_accessor) {
     ASSERT_TRUE(spin_wait(&g_ikp_started));
 
     RUN_ELEVATED({
-        __atomic_store_n(&t->kill_pending, 1, __ATOMIC_RELEASE);
+        __atomic_fetch_or(&t->sig.pending,
+                          signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
     });
     __atomic_store_n(&g_ikp_flag_set, 1, __ATOMIC_RELEASE);
 

--- a/kernel/tests/signals/interrupt_results.test.cpp
+++ b/kernel/tests/signals/interrupt_results.test.cpp
@@ -21,7 +21,8 @@ static int32_t setup_rb() {
 }
 
 static int32_t teardown_rb() {
-    __atomic_store_n(&sched::current()->kill_pending, 0, __ATOMIC_RELEASE);
+    __atomic_fetch_and(&sched::current()->sig.pending,
+                       ~signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
     RUN_ELEVATED({
         if (g_rb) ring_buffer_destroy(g_rb);
     });
@@ -35,7 +36,8 @@ AFTER_EACH(interrupt_results, teardown_rb);
 TEST(interrupt_results, interrupted_empty_read_is_not_eof) {
     uint8_t buf[8];
     ssize_t rc = 0;
-    __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
+    __atomic_fetch_or(&sched::current()->sig.pending,
+                      signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
     RUN_ELEVATED({ rc = ring_buffer_read(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, RB_ERR_INTR);
 }
@@ -44,7 +46,8 @@ TEST(interrupt_results, closed_writer_read_stays_eof_when_interrupted) {
     uint8_t buf[8];
     ssize_t rc = -100;
     RUN_ELEVATED({ ring_buffer_close_write(g_rb); });
-    __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
+    __atomic_fetch_or(&sched::current()->sig.pending,
+                      signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
     RUN_ELEVATED({ rc = ring_buffer_read(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, 0LL);
 }
@@ -64,7 +67,8 @@ TEST(interrupt_results, interrupted_full_write_is_not_epipe) {
     uint8_t buf[8];
     ssize_t rc = 0;
     fill_buffer(g_rb);
-    __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
+    __atomic_fetch_or(&sched::current()->sig.pending,
+                      signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
     RUN_ELEVATED({ rc = ring_buffer_write(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, RB_ERR_INTR);
 
@@ -76,7 +80,8 @@ TEST(interrupt_results, interrupted_full_write_is_not_epipe) {
 TEST(interrupt_results, interrupted_write_with_space_still_writes) {
     uint8_t buf[8];
     ssize_t rc = 0;
-    __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
+    __atomic_fetch_or(&sched::current()->sig.pending,
+                      signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
     RUN_ELEVATED({ rc = ring_buffer_write(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, 8LL);
 
@@ -89,7 +94,8 @@ TEST(interrupt_results, closed_reader_write_stays_epipe_when_interrupted) {
     uint8_t buf[8];
     ssize_t rc = 0;
     RUN_ELEVATED({ ring_buffer_close_read(g_rb); });
-    __atomic_store_n(&sched::current()->kill_pending, 1, __ATOMIC_RELEASE);
+    __atomic_fetch_or(&sched::current()->sig.pending,
+                      signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
     RUN_ELEVATED({ rc = ring_buffer_write(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, RB_ERR_PIPE);
 }

--- a/kernel/tests/signals/signal_death.test.cpp
+++ b/kernel/tests/signals/signal_death.test.cpp
@@ -1,0 +1,81 @@
+#define STLX_TEST_TIER TIER_MM_ALLOC
+
+#include "stlx_unit_test.h"
+#include "signals/signal.h"
+#include "sched/task.h"
+#include "mm/heap.h"
+#include "dynpriv/dynpriv.h"
+
+TEST_SUITE(signal_death);
+
+// Hand-built process: a thread group with a leader and one thread.
+static sched::thread_group* g_tg;
+static sched::task* g_leader;
+static sched::task* g_thread;
+
+static int32_t setup_group() {
+    RUN_ELEVATED({
+        g_leader = heap::kalloc_new<sched::task>();
+        g_thread = heap::kalloc_new<sched::task>();
+        g_tg     = heap::kalloc_new<sched::thread_group>();
+    });
+    if (!g_leader || !g_thread || !g_tg) {
+        return -1;
+    }
+
+    g_tg->lock = sync::SPINLOCK_INIT;
+    g_tg->leader = g_leader;
+    g_tg->pid = 1;
+    g_tg->threads.init();
+    g_tg->thread_count = 1;
+    g_leader->group = g_tg;
+    g_thread->group = g_tg;
+    g_tg->threads.push_back(g_thread);
+    return 0;
+}
+
+static int32_t teardown_group() {
+    RUN_ELEVATED({
+        if (g_tg)     heap::kfree_delete(g_tg);
+        if (g_leader) heap::kfree_delete(g_leader);
+        if (g_thread) heap::kfree_delete(g_thread);
+    });
+    g_tg = nullptr;
+    g_leader = nullptr;
+    g_thread = nullptr;
+    return 0;
+}
+
+BEFORE_EACH(signal_death, setup_group);
+AFTER_EACH(signal_death, teardown_group);
+
+TEST(signal_death, killed_member_reports_group_exit_signal) {
+    uint32_t fatal = 0;
+
+    // A killed member of a group dying from SIGSEGV reports SIGSEGV
+    g_leader->sig.pending |= signals::sig_bit(signals::SIGKILL);
+    g_tg->sig.exit_signal = signals::SIGSEGV;
+    RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
+    EXPECT_EQ(fatal, signals::SIGSEGV);
+
+    // Every thread of the group reports the same signal
+    g_thread->sig.pending |= signals::sig_bit(signals::SIGKILL);
+    RUN_ELEVATED({ fatal = signals::fatal_pending(g_thread); });
+    EXPECT_EQ(fatal, signals::SIGSEGV);
+}
+
+TEST(signal_death, kill_without_exit_signal_reports_sigkill) {
+    uint32_t fatal = 0;
+    g_leader->sig.pending |= signals::sig_bit(signals::SIGKILL);
+    RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
+    EXPECT_EQ(fatal, signals::SIGKILL);
+}
+
+TEST(signal_death, exit_signal_alone_reports_nothing) {
+    uint32_t fatal = 0;
+    g_tg->sig.exit_signal = signals::SIGTERM;
+
+    // Without the kill flag the exit signal alone reports nothing
+    RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
+    EXPECT_EQ(fatal, 0U);
+}

--- a/kernel/tests/signals/signal_interrupt.test.cpp
+++ b/kernel/tests/signals/signal_interrupt.test.cpp
@@ -49,10 +49,11 @@ static int32_t teardown_group() {
 BEFORE_EACH(signal_interrupt, setup_group);
 AFTER_EACH(signal_interrupt, teardown_group);
 
-TEST(signal_interrupt, kill_flag_reports_sigkill) {
+TEST(signal_interrupt, pending_sigkill_reports_sigkill) {
     uint32_t fatal = 0;
-    g_leader->kill_pending = 1;
-    g_leader->sig.pending = signals::sig_bit(signals::SIGTERM);
+    // SIGKILL wins over a lower pending signal
+    g_leader->sig.pending = signals::sig_bit(signals::SIGKILL)
+                          | signals::sig_bit(signals::SIGTERM);
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
     EXPECT_EQ(fatal, signals::SIGKILL);
 }

--- a/kernel/tests/signals/signal_send.test.cpp
+++ b/kernel/tests/signals/signal_send.test.cpp
@@ -78,8 +78,8 @@ TEST(signal_send, fatal_send_pends_without_kill_flag) {
     RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGTERM); });
     EXPECT_EQ(rc, signals::OK);
     EXPECT_EQ(g_thread->sig.pending, signals::sig_bit(signals::SIGTERM));
-    EXPECT_EQ(g_thread->kill_pending, 0U);
-    EXPECT_EQ(g_leader->kill_pending, 0U);
+    EXPECT_BITS_CLEAR(g_thread->sig.pending, signals::sig_bit(signals::SIGKILL));
+    EXPECT_BITS_CLEAR(g_leader->sig.pending, signals::sig_bit(signals::SIGKILL));
 }
 
 TEST(signal_send, ignored_unblocked_send_drops) {
@@ -109,7 +109,7 @@ TEST(signal_send, handled_send_pends_only) {
     });
     EXPECT_EQ(rc, signals::OK);
     EXPECT_EQ(g_thread->sig.pending, signals::sig_bit(signals::SIGTERM));
-    EXPECT_EQ(g_thread->kill_pending, 0U);
+    EXPECT_BITS_CLEAR(g_thread->sig.pending, signals::sig_bit(signals::SIGKILL));
 }
 
 TEST(signal_send, sigkill_to_thread_kills_group) {
@@ -118,8 +118,8 @@ TEST(signal_send, sigkill_to_thread_kills_group) {
     EXPECT_EQ(rc, signals::OK);
     // SIGKILL is process-wide: target and leader are marked, and the
     // shared bit makes it fatal for every other thread immediately
-    EXPECT_EQ(g_thread->kill_pending, 1U);
-    EXPECT_EQ(g_leader->kill_pending, 1U);
+    EXPECT_BITS_SET(g_thread->sig.pending, signals::sig_bit(signals::SIGKILL));
+    EXPECT_BITS_SET(g_leader->sig.pending, signals::sig_bit(signals::SIGKILL));
     EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGKILL));
 }
 
@@ -127,7 +127,7 @@ TEST(signal_send, sigkill_to_group_marks_leader) {
     int32_t rc = 0;
     RUN_ELEVATED({ rc = signals::send_to_group(g_tg, signals::SIGKILL); });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_EQ(g_leader->kill_pending, 1U);
+    EXPECT_BITS_SET(g_leader->sig.pending, signals::sig_bit(signals::SIGKILL));
     EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGKILL));
 }
 
@@ -136,7 +136,7 @@ TEST(signal_send, group_fatal_send_sets_shared) {
     RUN_ELEVATED({ rc = signals::send_to_group(g_tg, signals::SIGTERM); });
     EXPECT_EQ(rc, signals::OK);
     EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGTERM));
-    EXPECT_EQ(g_leader->kill_pending, 0U);
+    EXPECT_BITS_CLEAR(g_leader->sig.pending, signals::sig_bit(signals::SIGKILL));
 }
 
 TEST(signal_send, group_ignored_send_drops_unless_blocked) {


### PR DESCRIPTION
## Summary
- `kill_pending` and signal pending bits tracked "must terminate" separately, leaving two exit paths that could disagree on how a task died.
- A pending SIGKILL bit is now the single termination marker; syscall exit, preemption, and fault paths all die through `fatal_pending`/`die_from_signal`.
- Group deaths record the first fatal signal delivered, so every thread and the parent's wait status report the same cause, while native `proc_kill_tid` kills stay thread-scoped.

Made with [Cursor](https://cursor.com)