### PR TITLE
feat(userland): migrated kill to POSIX signals and retired proc_kill_tid

### DIFF
--- a/kernel/signals/signal.cpp
+++ b/kernel/signals/signal.cpp
@@ -298,8 +298,8 @@ __PRIVILEGED_CODE void die_from_signal(uint32_t sig) {
     sched::task* self = sched::current();
     sched::thread_group* tg = self->group;
 
-    // Native kills (proc_kill, proc_kill_tid) stay thread-scoped: the
-    // SIGKILL bit is set without recording a group exit signal
+    // Native kills (proc_kill) stay thread-scoped: the SIGKILL bit
+    // is set without recording a group exit signal
     bool native_kill =
         (__atomic_load_n(&self->sig.pending, __ATOMIC_ACQUIRE) & sig_bit(SIGKILL)) &&
         (!tg || __atomic_load_n(&tg->sig.exit_signal, __ATOMIC_ACQUIRE) == 0);

--- a/kernel/signals/signal.h
+++ b/kernel/signals/signal.h
@@ -89,7 +89,7 @@ __PRIVILEGED_CODE bool interrupt_pending(sched::task* t);
  * @brief Terminate the current task because of signal sig.
  * Fatal signals kill the whole process: a non-leader records sig as the
  * group exit signal and force-kills the leader so teardown reaps every
- * thread. Native kills (proc_kill, proc_kill_tid) stay thread-scoped.
+ * thread. Native kills (proc_kill) stay thread-scoped.
  * The wait status reports death by sig.
  * @note Privilege: **required**
  */

--- a/kernel/syscall/handlers/sys_proc.cpp
+++ b/kernel/syscall/handlers/sys_proc.cpp
@@ -537,34 +537,3 @@ DEFINE_SYSCALL4(proc_create_thread, u_entry, u_arg, u_stack_top, u_name) {
     resource::resource_release(obj);
     return static_cast<int64_t>(handle);
 }
-
-DEFINE_SYSCALL1(proc_kill_tid, u_tid) {
-    uint32_t tid = static_cast<uint32_t>(u_tid);
-
-    sched::task* self = sched::current();
-    if (!self) {
-        return syscall::EIO;
-    }
-
-    if (self->tid == tid || tid == 0) {
-        return syscall::EINVAL;
-    }
-
-    int64_t result = 0;
-    RUN_ELEVATED({
-        sync::irq_state irq = sched::g_task_registry.lock();
-        sched::task* target = sched::g_task_registry.find_locked(tid);
-
-        if (!target) {
-            result = syscall::ESRCH;
-        } else if (target->exec.flags & (sched::TASK_FLAG_IDLE | sched::TASK_FLAG_KERNEL)) {
-            result = syscall::EPERM;
-        } else {
-            sched::force_wake_for_kill(target);
-        }
-
-        sched::g_task_registry.unlock(irq);
-    });
-
-    return result;
-}

--- a/kernel/syscall/handlers/sys_proc.h
+++ b/kernel/syscall/handlers/sys_proc.h
@@ -10,7 +10,6 @@ DECLARE_SYSCALL(proc_detach);
 DECLARE_SYSCALL(proc_info);
 DECLARE_SYSCALL(proc_set_handle);
 DECLARE_SYSCALL(proc_kill);
-DECLARE_SYSCALL(proc_kill_tid);
 DECLARE_SYSCALL(proc_create_thread);
 
 #endif // STELLUX_SYSCALL_HANDLERS_SYS_PROC_H

--- a/kernel/syscall/syscall.h
+++ b/kernel/syscall/syscall.h
@@ -21,7 +21,6 @@ constexpr uint64_t SYS_PROC_INFO            = 1014;
 constexpr uint64_t SYS_PROC_SET_HANDLE      = 1015;
 constexpr uint64_t SYS_PROC_KILL            = 1016;
 constexpr uint64_t SYS_PROC_THREAD_CREATE   = 1017;
-constexpr uint64_t SYS_PROC_KILL_TID        = 1018;
 
 // PTY
 constexpr uint64_t SYS_PTY_CREATE = 1020;

--- a/kernel/syscall/syscall_table.cpp
+++ b/kernel/syscall/syscall_table.cpp
@@ -126,8 +126,6 @@ __PRIVILEGED_CODE void init_syscall_table() {
     REGISTER_SYSCALL(SYS_PROC_SET_HANDLE, proc_set_handle);
     REGISTER_SYSCALL(SYS_PROC_KILL, proc_kill);
     REGISTER_SYSCALL(SYS_PROC_THREAD_CREATE, proc_create_thread);
-    REGISTER_SYSCALL(SYS_PROC_KILL_TID, proc_kill_tid);
-
     REGISTER_SYSCALL(SYS_PTY_CREATE, pty_create);
 
     REGISTER_SYSCALL(SYS_FUTEX_WAIT,     futex_wait);

--- a/userland/apps/kill/src/kill.c
+++ b/userland/apps/kill/src/kill.c
@@ -1,24 +1,80 @@
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdio.h>
 #include <stdlib.h>
-#include <stlx/proc.h>
+#include <string.h>
+#include <signal.h>
+#include <errno.h>
+#include <sys/types.h>
+
+// Common signal names accepted after a dash, with or without a SIG prefix
+static const struct {
+    const char* name;
+    int         sig;
+} signal_names[] = {
+    { "HUP",  SIGHUP  }, { "INT",  SIGINT  }, { "QUIT", SIGQUIT },
+    { "KILL", SIGKILL }, { "TERM", SIGTERM },
+    { "USR1", SIGUSR1 }, { "USR2", SIGUSR2 },
+};
+
+static int parse_signal(const char* spec) {
+    if (spec[0] >= '0' && spec[0] <= '9') {
+        char* end = NULL;
+        long sig = strtol(spec, &end, 10);
+        if (*end != '\0' || sig < 0 || sig > 64) {
+            return -1;
+        }
+        return (int)sig;
+    }
+
+    if (strncmp(spec, "SIG", 3) == 0) {
+        spec += 3;
+    }
+    for (size_t i = 0; i < sizeof(signal_names) / sizeof(signal_names[0]); i++) {
+        if (strcmp(spec, signal_names[i].name) == 0) {
+            return signal_names[i].sig;
+        }
+    }
+    return -1;
+}
 
 int main(int argc, char* argv[]) {
-    if (argc < 2) {
-        fprintf(stderr, "usage: kill <tid>\n");
+    int sig = SIGTERM;
+    int argi = 1;
+
+    if (argi < argc && argv[argi][0] == '-' && strcmp(argv[argi], "--") != 0) {
+        sig = parse_signal(argv[argi] + 1);
+        if (sig < 0) {
+            fprintf(stderr, "kill: invalid signal: %s\n", argv[argi]);
+            return 1;
+        }
+        argi++;
+    }
+
+    // A -- terminator lets negative process-group pids follow
+    if (argi < argc && strcmp(argv[argi], "--") == 0) {
+        argi++;
+    }
+
+    if (argi >= argc) {
+        fprintf(stderr, "usage: kill [-SIGNAL] [--] pid...\n");
         return 1;
     }
 
-    int tid = atoi(argv[1]);
-    if (tid <= 0) {
-        fprintf(stderr, "kill: invalid tid: %s\n", argv[1]);
-        return 1;
-    }
+    int status = 0;
+    for (; argi < argc; argi++) {
+        char* end = NULL;
+        long pid = strtol(argv[argi], &end, 10);
+        if (argv[argi][0] == '\0' || *end != '\0' || pid == 0) {
+            fprintf(stderr, "kill: invalid pid: %s\n", argv[argi]);
+            status = 1;
+            continue;
+        }
 
-    int rc = proc_kill_tid(tid);
-    if (rc < 0) {
-        fprintf(stderr, "kill: failed to kill tid %d (error %d)\n", tid, rc);
-        return 1;
+        if (kill((pid_t)pid, sig) != 0) {
+            fprintf(stderr, "kill: (%ld): %s\n", pid, strerror(errno));
+            status = 1;
+        }
     }
-
-    return 0;
+    return status;
 }

--- a/userland/lib/libstlx/include/stlx/proc.h
+++ b/userland/lib/libstlx/include/stlx/proc.h
@@ -81,13 +81,6 @@ int proc_set_handle(int proc_handle, int slot, int resource_handle);
 int proc_kill(int handle);
 
 /**
- * Kill a task by its thread ID. Only userland tasks can be targeted,
- * kernel and idle tasks return EPERM. Returns 0 on success, negative
- * errno on failure (ESRCH if not found, EINVAL for self or TID 0).
- */
-int proc_kill_tid(int tid);
-
-/**
  * Create a thread in the caller's address space. The thread shares the
  * caller's mm_context and gets a copy of the caller's handle table and cwd.
  * Returns a handle in CREATED state; call proc_thread_start() to schedule.

--- a/userland/lib/libstlx/include/stlx/syscall_nums.h
+++ b/userland/lib/libstlx/include/stlx/syscall_nums.h
@@ -9,7 +9,6 @@
 #define SYS_PROC_SET_HANDLE     1015
 #define SYS_PROC_KILL           1016
 #define SYS_PROC_THREAD_CREATE  1017
-#define SYS_PROC_KILL_TID       1018
 #define SYS_PTY_CREATE          1020
 
 #define SYS_FUTEX_WAIT          1030

--- a/userland/lib/libstlx/src/proc.c
+++ b/userland/lib/libstlx/src/proc.c
@@ -49,10 +49,6 @@ int proc_kill(int handle) {
     return (int)syscall(SYS_PROC_KILL, handle);
 }
 
-int proc_kill_tid(int tid) {
-    return (int)syscall(SYS_PROC_KILL_TID, tid);
-}
-
 int proc_create_thread(void (*entry)(void*), void* arg,
                        void* stack_top, const char* name) {
     return (int)syscall(SYS_PROC_THREAD_CREATE, entry, arg, stack_top, name);


### PR DESCRIPTION
## Summary
- The `kill` utility hard-killed raw tids via the native `proc_kill_tid` syscall, bypassing signal semantics; it now speaks POSIX — `kill [-SIGNAL] [--] pid...` with a graceful `SIGTERM` default and process-group targeting.
- `proc_kill_tid` had no remaining consumers and no unique capability (`proc_kill` on a thread handle covers surgical thread kills), so the syscall, its libstlx wrapper, and the 1018 slot are removed.

Made with [Cursor](https://cursor.com)