### PR TITLE
feat(signals): honored SA_RESTART for interrupted syscalls

### DIFF
--- a/kernel/arch/aarch64/signal/delivery.cpp
+++ b/kernel/arch/aarch64/signal/delivery.cpp
@@ -1,5 +1,6 @@
 #include "signal/delivery.h"
 #include "arch/arch_signal.h"
+#include "syscall/syscall_table.h"
 #include "sched/fpu.h"
 #include "sched/sched.h"
 #include "sched/task.h"
@@ -12,6 +13,9 @@ namespace aarch64 {
 // PSTATE condition flags (NZCV). Everything else is forced so a restored
 // context returns to EL0t (mode bits 0) with interrupts unmasked (DAIF 0).
 constexpr uint64_t SPSR_NZCV_MASK = 0xF0000000ULL;
+
+// SVC is four bytes, stepping ELR back re-executes the interrupted call
+constexpr uint64_t SVC_INSN_LEN = 4;
 
 static inline uint64_t align_down(uint64_t v, uint64_t a) {
     return v & ~(a - 1);
@@ -140,11 +144,25 @@ __PRIVILEGED_CODE int64_t restore_signal_frame(trap_frame* tf) {
 } // namespace aarch64
 
 __PRIVILEGED_CODE int64_t arch::deliver_pending_signal(sched::task* self,
-                                                       int64_t result) {
+                                                       int64_t result,
+                                                       uint64_t) {
+    aarch64::trap_frame* tf = aarch64::current_trap_frame();
+
+    // Delivery only when returning to user mode, an elevated task keeps
+    // its signals pending until it lowers
     uint32_t sig = 0;
     signals::k_sigaction act{};
     signals::sig_set_t old_blocked = 0;
-    if (!signals::take_deliverable(self, &sig, &act, &old_blocked)) {
+    bool delivered = !(self->exec.flags & sched::TASK_FLAG_ELEVATED) &&
+        signals::take_deliverable(self, &sig, &act, &old_blocked);
+
+    if (!delivered) {
+        // Interrupted with nothing to run: restart transparently so a raced
+        // or elevated boundary never surfaces EINTR, re-publishing x0's arg
+        if (result == syscall::ERESTARTSYS) {
+            tf->elr -= aarch64::SVC_INSN_LEN;
+            return static_cast<int64_t>(tf->x[0]);
+        }
         return result;
     }
 
@@ -153,8 +171,20 @@ __PRIVILEGED_CODE int64_t arch::deliver_pending_signal(sched::task* self,
         signals::die_from_signal(signals::SIGSEGV);
     }
 
-    if (aarch64::build_signal_frame(aarch64::current_trap_frame(), sig, &act,
-                                    old_blocked, result) != 0) {
+    // SA_RESTART resumes at the SVC insn with x0 restored to the original
+    // argument, x8 still carries the number in the frame
+    int64_t saved_result = result;
+    if (result == syscall::ERESTARTSYS) {
+        if (act.flags & signals::SA_RESTART) {
+            tf->elr -= aarch64::SVC_INSN_LEN;
+            saved_result = static_cast<int64_t>(tf->x[0]);
+        } else {
+            saved_result = syscall::EINTR;
+        }
+    }
+
+    if (aarch64::build_signal_frame(tf, sig, &act, old_blocked,
+                                    saved_result) != 0) {
         signals::die_from_signal(signals::SIGSEGV);
     }
 

--- a/kernel/arch/arch_signal.h
+++ b/kernel/arch/arch_signal.h
@@ -11,14 +11,16 @@ namespace arch {
 
 /**
  * @brief Deliver one pending handler-bound signal at the syscall-return
- * boundary by redirecting the saved user context to the handler.
- * An action without a restorer or an unwritable user stack kills the task
- * with SIGSEGV. Returns the value for the user's result register, so a
- * built frame keeps the handler's first argument intact.
+ * boundary by redirecting the saved user context to the handler, and
+ * resolve an ERESTARTSYS result: rewound for re-execution under SA_RESTART
+ * (or when nothing was delivered), reported as EINTR otherwise. An action
+ * without a restorer or an unwritable user stack kills the task with
+ * SIGSEGV. Returns the value for the user's result register.
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE int64_t deliver_pending_signal(sched::task* self,
-                                                 int64_t result);
+                                                 int64_t result,
+                                                 uint64_t syscall_num);
 
 /**
  * @brief rt_sigreturn core: restore the interrupted context from the user

--- a/kernel/arch/x86_64/signal/delivery.cpp
+++ b/kernel/arch/x86_64/signal/delivery.cpp
@@ -1,5 +1,6 @@
 #include "signal/delivery.h"
 #include "arch/arch_signal.h"
+#include "syscall/syscall_table.h"
 #include "defs/segments.h"
 #include "sched/fpu.h"
 #include "sched/sched.h"
@@ -16,6 +17,9 @@ constexpr uint64_t RED_ZONE = 128;
 // User half of the canonical address space, RIP must stay below it or
 // SYSRET faults with kernel privilege on a non-canonical value.
 constexpr uint64_t USER_ADDR_LIMIT = 0x0000800000000000ULL;
+
+// SYSCALL is two bytes, stepping RIP back re-executes the interrupted call
+constexpr uint64_t SYSCALL_INSN_LEN = 2;
 
 // RFLAGS bits a restored context may carry (arithmetic, direction, trap,
 // AC, ID). IF is forced on and bit 1 is reserved-must-be-one, everything
@@ -183,11 +187,25 @@ __PRIVILEGED_CODE int64_t restore_signal_frame(syscall_frame* ctx) {
 } // namespace x86
 
 __PRIVILEGED_CODE int64_t arch::deliver_pending_signal(sched::task* self,
-                                                       int64_t result) {
+                                                       int64_t result,
+                                                       uint64_t syscall_num) {
+    x86::syscall_frame* ctx = x86::current_syscall_frame();
+
+    // Delivery only when returning to user mode, an elevated task keeps
+    // its signals pending until it lowers
     uint32_t sig = 0;
     signals::k_sigaction act{};
     signals::sig_set_t old_blocked = 0;
-    if (!signals::take_deliverable(self, &sig, &act, &old_blocked)) {
+    bool delivered = !(self->exec.flags & sched::TASK_FLAG_ELEVATED) &&
+        signals::take_deliverable(self, &sig, &act, &old_blocked);
+
+    if (!delivered) {
+        // Interrupted with nothing to run: restart transparently so a raced
+        // or elevated boundary never surfaces a spurious EINTR
+        if (result == syscall::ERESTARTSYS) {
+            ctx->rip -= x86::SYSCALL_INSN_LEN;
+            return static_cast<int64_t>(syscall_num);
+        }
         return result;
     }
 
@@ -197,11 +215,23 @@ __PRIVILEGED_CODE int64_t arch::deliver_pending_signal(sched::task* self,
         signals::die_from_signal(signals::SIGSEGV);
     }
 
-    if (x86::build_signal_frame(x86::current_syscall_frame(), sig, &act,
-                                old_blocked, result) != 0) {
+    // SA_RESTART resumes at the SYSCALL insn with the number back in RAX,
+    // re-executing the interrupted call once the handler returns
+    int64_t saved_result = result;
+    if (result == syscall::ERESTARTSYS) {
+        if (act.flags & signals::SA_RESTART) {
+            ctx->rip -= x86::SYSCALL_INSN_LEN;
+            saved_result = static_cast<int64_t>(syscall_num);
+        } else {
+            saved_result = syscall::EINTR;
+        }
+    }
+
+    if (x86::build_signal_frame(ctx, sig, &act, old_blocked,
+                                saved_result) != 0) {
         signals::die_from_signal(signals::SIGSEGV);
     }
-    return result;
+    return saved_result;
 }
 
 __PRIVILEGED_CODE int64_t arch::restore_signal_context() {

--- a/kernel/signals/signal.cpp
+++ b/kernel/signals/signal.cpp
@@ -139,6 +139,20 @@ __PRIVILEGED_CODE static void wake_for_signal(sched::task* t) {
     sched::wake(t);
 }
 
+/**
+ * True when a signal send may wake t: the signal must be unblocked, and
+ * one bound for a handler needs a target able to run it, so an elevated
+ * task is left waiting (mirrors interrupt_pending).
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static bool wake_eligible(sched::task* t, sig_set_t bit,
+                                            bool needs_handler) {
+    if (__atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE) & bit) {
+        return false;
+    }
+    return !needs_handler || !(t->exec.flags & sched::TASK_FLAG_ELEVATED);
+}
+
 __PRIVILEGED_CODE int32_t send_to_task(sched::task* t, uint32_t sig) {
     if (!t || !sig_valid(sig)) {
         return ERR_INVAL;
@@ -175,7 +189,8 @@ __PRIVILEGED_CODE int32_t send_to_task(sched::task* t, uint32_t sig) {
     }
 
     __atomic_fetch_or(&t->sig.pending, sig_bit(sig), __ATOMIC_ACQ_REL);
-    if (verdict != send_verdict::IGNORABLE && !is_blocked) {
+    if (verdict != send_verdict::IGNORABLE &&
+        wake_eligible(t, sig_bit(sig), verdict == send_verdict::HANDLED)) {
         wake_for_signal(t);
     }
     return OK;
@@ -228,14 +243,14 @@ __PRIVILEGED_CODE int32_t send_to_group(sched::thread_group* tg, uint32_t sig) {
     __atomic_fetch_or(&tg->sig.shared_pending, bit, __ATOMIC_ACQ_REL);
 
     if (verdict != send_verdict::IGNORABLE) {
-        // Wake one thread with the signal unblocked, leader preferred
+        // Wake one thread the signal can act on now, leader preferred
+        bool needs_handler = verdict == send_verdict::HANDLED;
         sched::task* target = nullptr;
-        if (tg->leader &&
-            !(__atomic_load_n(&tg->leader->sig.blocked, __ATOMIC_ACQUIRE) & bit)) {
+        if (tg->leader && wake_eligible(tg->leader, bit, needs_handler)) {
             target = tg->leader;
         } else {
             for (sched::task& thread : tg->threads) {
-                if (!(__atomic_load_n(&thread.sig.blocked, __ATOMIC_ACQUIRE) & bit)) {
+                if (wake_eligible(&thread, bit, needs_handler)) {
                     target = &thread;
                     break;
                 }
@@ -291,7 +306,17 @@ __PRIVILEGED_CODE uint32_t fatal_pending(sched::task* t) {
 }
 
 __PRIVILEGED_CODE bool interrupt_pending(sched::task* t) {
-    return t && (fatal_pending(t) != 0 || next_deliverable(t) != 0);
+    if (!t) {
+        return false;
+    }
+    if (fatal_pending(t) != 0) {
+        return true;
+    }
+
+    // A handler cannot run while elevated, so a deliverable signal only
+    // interrupts waits once the task can return to user mode
+    return !(t->exec.flags & sched::TASK_FLAG_ELEVATED)
+        && next_deliverable(t) != 0;
 }
 
 __PRIVILEGED_CODE uint32_t next_deliverable(sched::task* t) {

--- a/kernel/signals/signal.h
+++ b/kernel/signals/signal.h
@@ -53,6 +53,8 @@ __PRIVILEGED_CODE sig_set_t pending_blocked_set(sched::task* t);
  * SIGKILL terminates the whole process via the kill machinery. Signals
  * resolving to ignore are dropped unless the target blocks them. Fatal
  * and handler-bound signals wake a blocked target so it can act promptly.
+ * A handled signal leaves an elevated target waiting, since delivery
+ * needs a return to user mode.
  * @return OK, ERR_INVAL for a bad signal, ERR_PERM for kernel/idle tasks.
  * @note Privilege: **required**
  */
@@ -79,7 +81,9 @@ __PRIVILEGED_CODE uint32_t fatal_pending(sched::task* t);
 
 /**
  * @brief True if a blocking wait must unwind and return EINTR.
- * Covers kills, fatal signals, and handler-bound deliveries.
+ * Covers kills, fatal signals, and handler-bound deliveries. Handled
+ * signals only interrupt a task that can return to user mode to run the
+ * handler, an elevated task keeps waiting.
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE bool interrupt_pending(sched::task* t);

--- a/kernel/syscall/handlers/sys_fd.cpp
+++ b/kernel/syscall/handlers/sys_fd.cpp
@@ -121,7 +121,7 @@ inline int64_t map_resource_error(int64_t rc) {
         case resource::ERR_PIPE:
             return syscall::EPIPE;
         case resource::ERR_INTR:
-            return syscall::EINTR;
+            return syscall::ERESTARTSYS;
         case resource::ERR_NOTCONN:
             return syscall::ENOTCONN;
         case resource::ERR_CONNREFUSED:

--- a/kernel/syscall/handlers/sys_futex.cpp
+++ b/kernel/syscall/handlers/sys_futex.cpp
@@ -2,10 +2,13 @@
 #include "sync/futex.h"
 
 DEFINE_SYSCALL3(futex_wait, uaddr, expected, timeout_ns) {
-    return sync::futex_wait(
+    int64_t rc = sync::futex_wait(
         static_cast<uintptr_t>(uaddr),
         static_cast<uint32_t>(expected),
         timeout_ns);
+
+    // An interrupted wait restarts safely, re-checking the futex value
+    return rc == syscall::EINTR ? syscall::ERESTARTSYS : rc;
 }
 
 DEFINE_SYSCALL2(futex_wake, uaddr, count) {

--- a/kernel/syscall/handlers/sys_io.cpp
+++ b/kernel/syscall/handlers/sys_io.cpp
@@ -25,7 +25,7 @@ inline int64_t map_resource_error(int64_t rc) {
         case resource::ERR_TABLEFULL: return syscall::EMFILE;
         case resource::ERR_UNSUP:     return syscall::ENOSYS;
         case resource::ERR_PIPE:      return syscall::EPIPE;
-        case resource::ERR_INTR:      return syscall::EINTR;
+        case resource::ERR_INTR:      return syscall::ERESTARTSYS;
         case resource::ERR_AGAIN:     return syscall::EAGAIN;
         case resource::ERR_IO:
         default:                      return syscall::EIO;

--- a/kernel/syscall/handlers/sys_proc.cpp
+++ b/kernel/syscall/handlers/sys_proc.cpp
@@ -292,7 +292,7 @@ DEFINE_SYSCALL2(proc_wait, u_handle, u_exit_code_ptr) {
     if (!pr->exited) {
         sync::spin_unlock_irqrestore(pr->lock, irq);
         resource::resource_release(obj);
-        return syscall::EINTR;
+        return syscall::ERESTARTSYS;
     }
     int32_t child_wait_status = pr->wait_status;
     sync::spin_unlock_irqrestore(pr->lock, irq);

--- a/kernel/syscall/handlers/sys_socket.cpp
+++ b/kernel/syscall/handlers/sys_socket.cpp
@@ -32,7 +32,7 @@ inline int64_t map_socket_op_error(int32_t rc) {
     case resource::ERR_AGAIN:       return syscall::EAGAIN;
     case resource::ERR_NOENT:       return syscall::ENOENT;
     case resource::ERR_NOTDIR:      return syscall::ENOTDIR;
-    case resource::ERR_INTR:        return syscall::EINTR;
+    case resource::ERR_INTR:        return syscall::ERESTARTSYS;
     case resource::ERR_NOPROTOOPT:  return syscall::ENOPROTOOPT;
     default:                        return syscall::EIO;
     }

--- a/kernel/syscall/syscall.cpp
+++ b/kernel/syscall/syscall.cpp
@@ -56,11 +56,9 @@ extern "C" __PRIVILEGED_CODE int64_t stlx_syscall_handler(
             signals::die_from_signal(fsig);
         }
 
-        // Handler delivery only when returning to user mode, an elevated
-        // task keeps its signals pending until it lowers
-        if (!(self->exec.flags & sched::TASK_FLAG_ELEVATED)) {
-            result = arch::deliver_pending_signal(self, result);
-        }
+        // Delivers one pending handled signal and resolves interrupted-wait
+        // restarts, the internal ERESTARTSYS marker never reaches userspace
+        result = arch::deliver_pending_signal(self, result, syscall_num);
     }
 
     // Return-boundary restore: dynamic runtime elevation follows the selected

--- a/kernel/syscall/syscall_table.h
+++ b/kernel/syscall/syscall_table.h
@@ -45,6 +45,10 @@ constexpr int64_t ENOTCONN         = -107;
 constexpr int64_t ETIMEDOUT        = -110;
 constexpr int64_t ECONNREFUSED     = -111;
 
+// Interrupted restartable wait, resolved at the syscall-return boundary
+// (rewind for re-execution or EINTR) and never visible to userspace.
+constexpr int64_t ERESTARTSYS = -512;
+
 extern handler_t g_syscall_table[MAX_SYSCALL_NUM];
 
 /**

--- a/kernel/tests/signals/signal_interrupt.test.cpp
+++ b/kernel/tests/signals/signal_interrupt.test.cpp
@@ -139,3 +139,24 @@ TEST(signal_interrupt, interrupt_pending_covers_handled_signals) {
     RUN_ELEVATED({ intr = signals::interrupt_pending(g_leader); });
     EXPECT_FALSE(intr);
 }
+
+TEST(signal_interrupt, elevated_task_defers_handled_interrupts) {
+    signals::k_sigaction act = {};
+    act.handler = 0x400000;
+    RUN_ELEVATED({
+        signals::set_action(g_tg, signals::SIGUSR1, &act, nullptr);
+    });
+
+    // Undeliverable while elevated, so the wait must not unwind
+    bool intr = true;
+    g_leader->sig.pending = signals::sig_bit(signals::SIGUSR1);
+    g_leader->exec.flags = sched::TASK_FLAG_ELEVATED;
+    RUN_ELEVATED({ intr = signals::interrupt_pending(g_leader); });
+    EXPECT_FALSE(intr);
+
+    // Fatal signals still interrupt an elevated task
+    g_leader->sig.pending |= signals::sig_bit(signals::SIGKILL);
+    RUN_ELEVATED({ intr = signals::interrupt_pending(g_leader); });
+    EXPECT_TRUE(intr);
+    g_leader->exec.flags = 0;
+}

--- a/userland/apps/sigtest/src/sigtest.c
+++ b/userland/apps/sigtest/src/sigtest.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <poll.h>
 #include <sys/mman.h>
 #include <stlx/proc.h>
 
@@ -187,6 +188,120 @@ static void test_read_eintr(void) {
     close(fds[1]);
 }
 
+static volatile sig_atomic_t restart_handler_ran = 0;
+static int g_restart_wfd;
+
+static void restart_handler(int sig) {
+    (void)sig;
+    restart_handler_ran = 1;
+}
+
+static void restart_helper(void* arg) {
+    (void)arg;
+
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR1);
+    sigprocmask(SIG_BLOCK, &set, NULL);
+
+    usleep(150 * 1000);
+    kill(getpid(), SIGUSR1);      /* interrupts the read, restart re-blocks */
+    usleep(150 * 1000);
+    char b = 'r';
+    write(g_restart_wfd, &b, 1);  /* completes the restarted read */
+    _exit(0);
+}
+
+static void test_read_restart(void) {
+    /* signal() installs with SA_RESTART, the read must complete instead
+     * of failing with EINTR */
+    if (signal(SIGUSR1, restart_handler) == SIG_ERR) {
+        printf("  SKIP: signal unavailable\n");
+        return;
+    }
+
+    int fds[2];
+    if (pipe(fds) != 0) {
+        printf("  SKIP: pipe unavailable\n");
+        return;
+    }
+    g_restart_wfd = fds[1];
+
+    void* stk = mmap(NULL, HELPER_STACK_SIZE, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+    if (stk == MAP_FAILED) {
+        printf("  SKIP: helper stack unavailable\n");
+        close(fds[0]);
+        close(fds[1]);
+        return;
+    }
+    int h = proc_create_thread(restart_helper, NULL,
+                               (char*)stk + HELPER_STACK_SIZE, "sig_helper");
+    if (h < 0) {
+        printf("  SKIP: thread creation unavailable\n");
+        munmap(stk, HELPER_STACK_SIZE);
+        close(fds[0]);
+        close(fds[1]);
+        return;
+    }
+    proc_thread_start(h);
+
+    char byte = 0;
+    ssize_t n = read(fds[0], &byte, 1);
+
+    proc_thread_join(h, NULL);
+
+    check("restarted read completed", n == 1 && byte == 'r');
+    check("handler ran during restart", restart_handler_ran == 1);
+
+    munmap(stk, HELPER_STACK_SIZE);
+    close(fds[0]);
+    close(fds[1]);
+}
+
+static void test_poll_eintr_despite_restart(void) {
+    /* poll is never restarted, SA_RESTART or not (as on Linux) */
+    signal(SIGUSR1, restart_handler);
+
+    int fds[2];
+    if (pipe(fds) != 0) {
+        printf("  SKIP: pipe unavailable\n");
+        return;
+    }
+
+    void* stk = mmap(NULL, HELPER_STACK_SIZE, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+    if (stk == MAP_FAILED) {
+        printf("  SKIP: helper stack unavailable\n");
+        close(fds[0]);
+        close(fds[1]);
+        return;
+    }
+    int h = proc_create_thread(eintr_helper, NULL,
+                               (char*)stk + HELPER_STACK_SIZE, "sig_helper");
+    if (h < 0) {
+        printf("  SKIP: thread creation unavailable\n");
+        munmap(stk, HELPER_STACK_SIZE);
+        close(fds[0]);
+        close(fds[1]);
+        return;
+    }
+    proc_thread_start(h);
+
+    struct pollfd pfd = { .fd = fds[0], .events = POLLIN, .revents = 0 };
+    int ret = poll(&pfd, 1, -1);
+    int saved_errno = errno;
+
+    proc_thread_join(h, NULL);
+
+    check("poll interrupted despite SA_RESTART", ret == -1);
+    check("poll errno is EINTR", saved_errno == EINTR);
+
+    munmap(stk, HELPER_STACK_SIZE);
+    close(fds[0]);
+    close(fds[1]);
+}
+
 int main(void) {
     setvbuf(stdout, NULL, _IONBF, 0);
     printf("sigtest: running signal delivery tests\n");
@@ -196,6 +311,8 @@ int main(void) {
     test_deferred_reentry();
     test_unblock_delivers();
     test_read_eintr();
+    test_read_restart();
+    test_poll_eintr_despite_restart();
 
     printf("sigtest: %d passed, %d failed\n", passed, failed);
     return failed > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary
- Handlers installed through musl's signal() set SA_RESTART, but interrupted blocking calls always surfaced EINTR, breaking ported programs that never expect it.
- Restartable waits (read/write, sockets, futex, proc_wait) return an internal ERESTARTSYS that the delivery boundary rewinds for re-execution under SA_RESTART, converts to EINTR otherwise, or restarts transparently when no handler ran; poll/select and nanosleep keep EINTR, matching Linux.
- Handled signals no longer interrupt or wake elevated tasks, which cannot run a handler, closing a restart livelock and spurious poll/futex results.

Made with [Cursor](https://cursor.com)