### PR TITLE
feat(signals): delivered signals to compute-bound tasks

### DIFF
--- a/kernel/arch/aarch64/sched/sched.cpp
+++ b/kernel/arch/aarch64/sched/sched.cpp
@@ -2,6 +2,7 @@
 #include "sched/task.h"
 #include "sched/sched.h"
 #include "sched/sched_internal.h"
+#include "signal/delivery.h"
 #include "signals/signal.h"
 #include "sched/fpu.h"
 #include "dynpriv/dynpriv.h"
@@ -35,6 +36,8 @@ static task_exec_core g_boot_exec = {
     .mm_ctx = nullptr,
     .fpu_ctx = {},
     .tls_base = 0,
+    .iret_pending = 0,
+    .iret_ctx = {},
 };
 
 /**
@@ -152,6 +155,11 @@ __PRIVILEGED_CODE void on_yield(aarch64::trap_frame* tf) {
     advance_cpu_tlb_sync_epoch();
     // Publish prior switched-out task as off-CPU before we start a new scheduling decision.
     finalize_pending_off_cpu();
+
+    // The yield fast path skips the syscall boundary, deliver here so a
+    // yielding task still sees its handled signals promptly
+    aarch64::deliver_async_signal(prev, tf);
+
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();
 
@@ -194,6 +202,10 @@ __PRIVILEGED_CODE void on_tick(aarch64::trap_frame* tf) {
     if (!(prev->exec.flags & TASK_FLAG_PREEMPTIBLE)) {
         return;
     }
+
+    // Handler delivery for compute-bound tasks: redirect before the
+    // context save so both resume paths carry it
+    aarch64::deliver_async_signal(prev, tf);
 
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();

--- a/kernel/arch/aarch64/signal/delivery.cpp
+++ b/kernel/arch/aarch64/signal/delivery.cpp
@@ -112,6 +112,45 @@ __PRIVILEGED_CODE int32_t build_signal_frame(trap_frame* tf, uint32_t sig,
     return 0;
 }
 
+/**
+ * Frame write for delivery outside a syscall. Never blocks or pages in,
+ * the caller defers the signal when the stack is not resident. The ERET
+ * exit already rebuilds every register, no special restore is needed.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static int32_t build_signal_frame_async(
+    trap_frame* tf, uint32_t sig, const signals::k_sigaction* act,
+    signals::sig_set_t old_blocked) {
+    uint64_t frame_addr = align_down(tf->sp - sizeof(rt_sigframe), 16);
+
+    rt_sigframe* frame = heap::kalloc_new<rt_sigframe>();
+    if (!frame) {
+        return mm::uaccess::ERR_RETRY;
+    }
+    sched::fpu_state fp;
+    fpu::save(&fp);
+
+    // x0 still holds the interrupted value, there is no syscall result
+    pack_sigframe(frame, tf, static_cast<int64_t>(tf->x[0]), sig,
+                  old_blocked, &fp);
+
+    int32_t rc = mm::uaccess::copy_to_user_resident(
+        reinterpret_cast<void*>(frame_addr), frame, sizeof(*frame));
+    heap::kfree_delete(frame);
+
+    if (rc != mm::uaccess::OK) {
+        return rc;
+    }
+
+    tf->sp = frame_addr;
+    tf->elr = act->handler;
+    tf->x[0] = sig;
+    tf->x[1] = frame_addr + __builtin_offsetof(rt_sigframe, info);
+    tf->x[2] = frame_addr + __builtin_offsetof(rt_sigframe, uc);
+    tf->x[30] = act->restorer; // LR, the handler returns into the restorer
+    return 0;
+}
+
 __PRIVILEGED_CODE int64_t restore_signal_frame(trap_frame* tf) {
     uint64_t frame_addr = tf->sp;
 
@@ -139,6 +178,48 @@ __PRIVILEGED_CODE int64_t restore_signal_frame(trap_frame* tf) {
     heap::kfree_delete(frame);
 
     return resume;
+}
+
+__PRIVILEGED_CODE void deliver_async_signal(sched::task* self,
+                                            trap_frame* tf) {
+    if (!from_user(tf)) {
+        return;
+    }
+
+    // An elevated task keeps its signals pending until it lowers, the
+    // same rule every other delivery site applies
+    if (!self || !self->group ||
+        (self->exec.flags & sched::TASK_FLAG_ELEVATED) ||
+        self->state == sched::TASK_STATE_DEAD) {
+        return;
+    }
+
+    // A fatal signal takes the death path at this same boundary
+    if (signals::fatal_pending(self)) {
+        return;
+    }
+
+    uint32_t sig = 0;
+    signals::k_sigaction act{};
+    signals::sig_set_t old_blocked = 0;
+    if (!signals::take_deliverable(self, &sig, &act, &old_blocked)) {
+        return;
+    }
+
+    // Same restorer contract as x86_64, the bundled musl always passes one
+    if (!(act.flags & signals::SA_RESTORER) || !act.restorer) {
+        signals::die_from_signal(signals::SIGSEGV);
+    }
+
+    int32_t rc = build_signal_frame_async(tf, sig, &act, old_blocked);
+    if (rc == mm::uaccess::ERR_RETRY) {
+        // Not deliverable right now, a later boundary picks it up
+        signals::untake_deliverable(self, sig, &act, old_blocked);
+        return;
+    }
+    if (rc != 0) {
+        signals::die_from_signal(signals::SIGSEGV);
+    }
 }
 
 } // namespace aarch64

--- a/kernel/arch/aarch64/signal/delivery.cpp
+++ b/kernel/arch/aarch64/signal/delivery.cpp
@@ -113,8 +113,8 @@ __PRIVILEGED_CODE int32_t build_signal_frame(trap_frame* tf, uint32_t sig,
 }
 
 /**
- * Frame write for delivery outside a syscall. Never blocks or pages in,
- * the caller defers the signal when the stack is not resident. The ERET
+ * Frame write for delivery outside a syscall. Never blocks, the caller
+ * defers the signal when the address-space lock is contended. The ERET
  * exit already rebuilds every register, no special restore is needed.
  * @note Privilege: **required**
  */
@@ -134,7 +134,7 @@ __PRIVILEGED_CODE static int32_t build_signal_frame_async(
     pack_sigframe(frame, tf, static_cast<int64_t>(tf->x[0]), sig,
                   old_blocked, &fp);
 
-    int32_t rc = mm::uaccess::copy_to_user_resident(
+    int32_t rc = mm::uaccess::copy_to_user_nonblock(
         reinterpret_cast<void*>(frame_addr), frame, sizeof(*frame));
     heap::kfree_delete(frame);
 

--- a/kernel/arch/aarch64/signal/delivery.h
+++ b/kernel/arch/aarch64/signal/delivery.h
@@ -52,8 +52,8 @@ __PRIVILEGED_CODE int64_t restore_signal_frame(trap_frame* tf);
 /**
  * @brief Deliver one pending handler-bound signal to a task interrupted
  * in user mode, redirecting the trap frame to the handler. The frame
- * write never blocks or pages in: when the user stack is not resident
- * the signal is returned to the pending set for a later boundary.
+ * write never blocks: when the address-space lock is contended the
+ * signal is returned to the pending set for a later boundary.
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE void deliver_async_signal(sched::task* self,

--- a/kernel/arch/aarch64/signal/delivery.h
+++ b/kernel/arch/aarch64/signal/delivery.h
@@ -6,6 +6,8 @@
 #include "sched/fpu_state.h"
 #include "signals/signal_types.h"
 
+namespace sched { struct task; }
+
 namespace aarch64 {
 
 /**
@@ -46,6 +48,16 @@ __PRIVILEGED_CODE int32_t build_signal_frame(trap_frame* tf, uint32_t sig,
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE int64_t restore_signal_frame(trap_frame* tf);
+
+/**
+ * @brief Deliver one pending handler-bound signal to a task interrupted
+ * in user mode, redirecting the trap frame to the handler. The frame
+ * write never blocks or pages in: when the user stack is not resident
+ * the signal is returned to the pending set for a later boundary.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE void deliver_async_signal(sched::task* self,
+                                            trap_frame* tf);
 
 } // namespace aarch64
 

--- a/kernel/arch/x86_64/sched/sched.cpp
+++ b/kernel/arch/x86_64/sched/sched.cpp
@@ -2,6 +2,7 @@
 #include "sched/task.h"
 #include "sched/sched.h"
 #include "sched/sched_internal.h"
+#include "signal/delivery.h"
 #include "signals/signal.h"
 #include "sched/fpu.h"
 #include "dynpriv/dynpriv.h"
@@ -34,6 +35,8 @@ static task_exec_core g_boot_exec = {
     .mm_ctx = nullptr,
     .fpu_ctx = {},
     .tls_base = 0,
+    .iret_pending = 0,
+    .iret_ctx = {},
 };
 
 /**
@@ -126,6 +129,11 @@ __PRIVILEGED_CODE void on_yield(x86::trap_frame* tf) {
     advance_cpu_tlb_sync_epoch();
     // Publish prior switched-out task as off-CPU before we start a new scheduling decision.
     finalize_pending_off_cpu();
+
+    // The yield gate is reachable from user mode and skips the syscall
+    // boundary, deliver here so a yielding task sees signals promptly
+    x86::deliver_async_signal(prev, tf);
+
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();
 
@@ -167,6 +175,10 @@ __PRIVILEGED_CODE void on_tick(x86::trap_frame* tf) {
     if (!(prev->exec.flags & TASK_FLAG_PREEMPTIBLE)) {
         return;
     }
+
+    // Handler delivery for compute-bound tasks: redirect before the
+    // context save so both resume paths carry it
+    x86::deliver_async_signal(prev, tf);
 
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();

--- a/kernel/arch/x86_64/signal/delivery.cpp
+++ b/kernel/arch/x86_64/signal/delivery.cpp
@@ -271,8 +271,8 @@ constexpr uint64_t RFLAGS_DF = 1ULL << 10;
 constexpr uint64_t RFLAGS_TF = 1ULL << 8;
 
 /**
- * Frame write for delivery outside a syscall. Never blocks or pages in,
- * the caller defers the signal when the stack is not resident.
+ * Frame write for delivery outside a syscall. Never blocks, the caller
+ * defers the signal when the address-space lock is contended.
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE static int32_t build_signal_frame_async(
@@ -299,10 +299,10 @@ __PRIVILEGED_CODE static int32_t build_signal_frame_async(
     sched::fpu_state fp;
     fpu::save(&fp);
 
-    int32_t rc = mm::uaccess::copy_to_user_resident(
+    int32_t rc = mm::uaccess::copy_to_user_nonblock(
         reinterpret_cast<void*>(frame_addr), frame, sizeof(*frame));
     if (rc == mm::uaccess::OK) {
-        rc = mm::uaccess::copy_to_user_resident(
+        rc = mm::uaccess::copy_to_user_nonblock(
             reinterpret_cast<void*>(fpstate), &fp, sizeof(fp));
     }
     heap::kfree_delete(frame);

--- a/kernel/arch/x86_64/signal/delivery.cpp
+++ b/kernel/arch/x86_64/signal/delivery.cpp
@@ -155,8 +155,14 @@ __PRIVILEGED_CODE int64_t restore_signal_frame(syscall_frame* ctx) {
     bool ok = mm::uaccess::copy_from_user(
         frame, reinterpret_cast<void*>(frame_addr), sizeof(*frame)) == mm::uaccess::OK;
 
+    // A context captured outside a syscall restores every register through
+    // the IRET exit, the frame-based SYSRET path cannot rebuild it
+    bool full = ok && (frame->uc.uc_flags & UC_FULL_RESTORE) != 0;
+    sched::task_exec_core* exec = this_cpu(current_task_exec);
+
     if (ok) {
-        ok = unpack_sigframe(frame, ctx, &mask);
+        ok = full ? unpack_sigframe_full(frame, &exec->iret_ctx, &mask)
+                  : unpack_sigframe(frame, ctx, &mask);
     }
 
     if (!ok) {
@@ -167,7 +173,8 @@ __PRIVILEGED_CODE int64_t restore_signal_frame(syscall_frame* ctx) {
     signals::set_blocked(sched::current(), signals::SIG_SETMASK, &mask, nullptr);
 
     uint64_t fpstate = frame->uc.uc_mcontext.fpstate;
-    int64_t resume = static_cast<int64_t>(frame->uc.uc_mcontext.rax);
+    int64_t resume = full ? 0
+        : static_cast<int64_t>(frame->uc.uc_mcontext.rax);
     if (fpstate) {
         // A bad FXSAVE pointer is a corrupt frame, kill like the other paths
         sched::fpu_state fp;
@@ -180,8 +187,181 @@ __PRIVILEGED_CODE int64_t restore_signal_frame(syscall_frame* ctx) {
         fpu::restore(&fp);
     }
 
+    if (full) {
+        // Publish only after the context is fully staged, the syscall
+        // exit consumes it as soon as this handler returns
+        __atomic_store_n(&exec->iret_pending, 1u, __ATOMIC_RELEASE);
+    }
+
     heap::kfree_delete(frame);
     return resume;
+}
+
+__PRIVILEGED_CODE void pack_sigframe_full(rt_sigframe* frame,
+                                          const trap_frame* tf, uint32_t sig,
+                                          signals::sig_set_t old_blocked,
+                                          uint64_t user_fpstate) {
+    sigcontext& sc = frame->uc.uc_mcontext;
+    sc.r8  = tf->r8;
+    sc.r9  = tf->r9;
+    sc.r10 = tf->r10;
+    sc.r11 = tf->r11;
+    sc.r12 = tf->r12;
+    sc.r13 = tf->r13;
+    sc.r14 = tf->r14;
+    sc.r15 = tf->r15;
+    sc.rdi = tf->rdi;
+    sc.rsi = tf->rsi;
+    sc.rbp = tf->rbp;
+    sc.rbx = tf->rbx;
+    sc.rdx = tf->rdx;
+    sc.rax = tf->rax;
+    sc.rcx = tf->rcx;
+    sc.rsp = tf->rsp;
+    sc.rip = tf->rip;
+    sc.eflags = tf->rflags;
+    sc.cs = USER_CS;
+    sc.ss = USER_DS;
+    sc.fpstate = user_fpstate;
+
+    frame->uc.uc_flags = UC_FULL_RESTORE;
+    frame->uc.uc_sigmask = old_blocked;
+    frame->info.si_signo = static_cast<int32_t>(sig);
+    frame->info.si_code = SI_USER;
+}
+
+__PRIVILEGED_CODE bool unpack_sigframe_full(const rt_sigframe* frame,
+                                            sched::thread_cpu_context* out,
+                                            signals::sig_set_t* mask) {
+    const sigcontext& sc = frame->uc.uc_mcontext;
+    if (sc.rip >= USER_ADDR_LIMIT) {
+        return false;
+    }
+
+    out->rax = sc.rax;
+    out->rbx = sc.rbx;
+    out->rcx = sc.rcx;
+    out->rdx = sc.rdx;
+    out->rsi = sc.rsi;
+    out->rdi = sc.rdi;
+    out->rbp = sc.rbp;
+    out->rsp = sc.rsp;
+    out->r8  = sc.r8;
+    out->r9  = sc.r9;
+    out->r10 = sc.r10;
+    out->r11 = sc.r11;
+    out->r12 = sc.r12;
+    out->r13 = sc.r13;
+    out->r14 = sc.r14;
+    out->r15 = sc.r15;
+    out->rip = sc.rip;
+    out->rflags = (sc.eflags & RFLAGS_USER_MASK) | RFLAGS_IF | RFLAGS_MB1;
+
+    // Forged segments must never reach the IRET exit
+    out->cs = USER_CS;
+    out->ss = USER_DS;
+
+    *mask = frame->uc.uc_sigmask;
+    return true;
+}
+
+// Direction and trap flags a handler must not inherit from the
+// interrupted instruction stream
+constexpr uint64_t RFLAGS_DF = 1ULL << 10;
+constexpr uint64_t RFLAGS_TF = 1ULL << 8;
+
+/**
+ * Frame write for delivery outside a syscall. Never blocks or pages in,
+ * the caller defers the signal when the stack is not resident.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static int32_t build_signal_frame_async(
+    trap_frame* tf, uint32_t sig, const signals::k_sigaction* act,
+    signals::sig_set_t old_blocked) {
+    // SYSRET is not involved here, but the same user-half bound keeps a
+    // kernel-half handler from ever running with user state
+    if (act->handler >= USER_ADDR_LIMIT) {
+        return -1;
+    }
+
+    uint64_t sp = tf->rsp - RED_ZONE;
+    uint64_t fpstate = align_down(sp - sizeof(sched::fpu_state), 16);
+    uint64_t frame_addr = align_down(fpstate - sizeof(rt_sigframe), 16) - 8;
+
+    rt_sigframe* frame = heap::kalloc_new<rt_sigframe>();
+    if (!frame) {
+        return mm::uaccess::ERR_RETRY;
+    }
+
+    pack_sigframe_full(frame, tf, sig, old_blocked, fpstate);
+    frame->pretcode = act->restorer;
+
+    sched::fpu_state fp;
+    fpu::save(&fp);
+
+    int32_t rc = mm::uaccess::copy_to_user_resident(
+        reinterpret_cast<void*>(frame_addr), frame, sizeof(*frame));
+    if (rc == mm::uaccess::OK) {
+        rc = mm::uaccess::copy_to_user_resident(
+            reinterpret_cast<void*>(fpstate), &fp, sizeof(fp));
+    }
+    heap::kfree_delete(frame);
+
+    if (rc != mm::uaccess::OK) {
+        return rc;
+    }
+
+    tf->rip = act->handler;
+    tf->rsp = frame_addr;
+    tf->rdi = sig;
+    tf->rsi = frame_addr + __builtin_offsetof(rt_sigframe, info);
+    tf->rdx = frame_addr + __builtin_offsetof(rt_sigframe, uc);
+    tf->rflags = (tf->rflags & RFLAGS_USER_MASK & ~(RFLAGS_DF | RFLAGS_TF))
+        | RFLAGS_IF | RFLAGS_MB1;
+    return 0;
+}
+
+__PRIVILEGED_CODE void deliver_async_signal(sched::task* self,
+                                            trap_frame* tf) {
+    if (!from_user(tf)) {
+        return;
+    }
+
+    // An elevated task keeps its signals pending until it lowers, the
+    // same rule every other delivery site applies
+    if (!self || !self->group ||
+        (self->exec.flags & sched::TASK_FLAG_ELEVATED) ||
+        self->state == sched::TASK_STATE_DEAD) {
+        return;
+    }
+
+    // A fatal signal takes the death path at this same boundary
+    if (signals::fatal_pending(self)) {
+        return;
+    }
+
+    uint32_t sig = 0;
+    signals::k_sigaction act{};
+    signals::sig_set_t old_blocked = 0;
+    if (!signals::take_deliverable(self, &sig, &act, &old_blocked)) {
+        return;
+    }
+
+    // The handler returns through the restorer's rt_sigreturn,
+    // an action installed without one is undeliverable.
+    if (!(act.flags & signals::SA_RESTORER) || !act.restorer) {
+        signals::die_from_signal(signals::SIGSEGV);
+    }
+
+    int32_t rc = build_signal_frame_async(tf, sig, &act, old_blocked);
+    if (rc == mm::uaccess::ERR_RETRY) {
+        // Not deliverable right now, a later boundary picks it up
+        signals::untake_deliverable(self, sig, &act, old_blocked);
+        return;
+    }
+    if (rc != 0) {
+        signals::die_from_signal(signals::SIGSEGV);
+    }
 }
 
 } // namespace x86
@@ -189,6 +369,12 @@ __PRIVILEGED_CODE int64_t restore_signal_frame(syscall_frame* ctx) {
 __PRIVILEGED_CODE int64_t arch::deliver_pending_signal(sched::task* self,
                                                        int64_t result,
                                                        uint64_t syscall_num) {
+    // A staged full-register return supersedes the frame, so it no longer
+    // describes the resume context, delivery waits for a later boundary
+    if (__atomic_load_n(&self->exec.iret_pending, __ATOMIC_ACQUIRE)) {
+        return result;
+    }
+
     x86::syscall_frame* ctx = x86::current_syscall_frame();
 
     // Delivery only when returning to user mode, an elevated task keeps

--- a/kernel/arch/x86_64/signal/delivery.h
+++ b/kernel/arch/x86_64/signal/delivery.h
@@ -79,8 +79,8 @@ __PRIVILEGED_CODE bool unpack_sigframe_full(const rt_sigframe* frame,
 /**
  * @brief Deliver one pending handler-bound signal to a task interrupted
  * in user mode, redirecting the trap frame to the handler. The frame
- * write never blocks or pages in: when the user stack is not resident
- * the signal is returned to the pending set for a later boundary.
+ * write never blocks: when the address-space lock is contended the
+ * signal is returned to the pending set for a later boundary.
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE void deliver_async_signal(sched::task* self,

--- a/kernel/arch/x86_64/signal/delivery.h
+++ b/kernel/arch/x86_64/signal/delivery.h
@@ -3,7 +3,10 @@
 
 #include "signal/sigframe.h"
 #include "syscall/syscall_frame.h"
+#include "trap/trap_frame.h"
 #include "signals/signal_types.h"
+
+namespace sched { struct task; }
 
 namespace x86 {
 
@@ -45,9 +48,43 @@ __PRIVILEGED_CODE int32_t build_signal_frame(syscall_frame* ctx, uint32_t sig,
 /**
  * @brief Restore interrupted state from the user signal frame and return
  * the value to resume in RAX. Kills the task with SIGSEGV on a bad frame.
+ * A frame marked UC_FULL_RESTORE is staged for the IRET exit instead of
+ * being applied to ctx.
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE int64_t restore_signal_frame(syscall_frame* ctx);
+
+/**
+ * @brief Fill a zeroed kernel-local signal frame from a trap frame, for
+ * delivery outside a syscall. Every register including RCX/R11/RAX is
+ * captured and the frame is marked UC_FULL_RESTORE. Pure, unit-testable.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE void pack_sigframe_full(rt_sigframe* frame,
+                                          const trap_frame* tf, uint32_t sig,
+                                          signals::sig_set_t old_blocked,
+                                          uint64_t user_fpstate);
+
+/**
+ * @brief Recover a full register context from a UC_FULL_RESTORE frame.
+ * Sanitizes RFLAGS, forces user segments, and rejects a non-canonical
+ * RIP so the IRET exit can never fault back into the kernel. Returns
+ * false and leaves out untouched on a bad frame. Pure, unit-testable.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE bool unpack_sigframe_full(const rt_sigframe* frame,
+                                            sched::thread_cpu_context* out,
+                                            signals::sig_set_t* mask);
+
+/**
+ * @brief Deliver one pending handler-bound signal to a task interrupted
+ * in user mode, redirecting the trap frame to the handler. The frame
+ * write never blocks or pages in: when the user stack is not resident
+ * the signal is returned to the pending set for a later boundary.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE void deliver_async_signal(sched::task* self,
+                                            trap_frame* tf);
 
 } // namespace x86
 

--- a/kernel/arch/x86_64/signal/sigframe.h
+++ b/kernel/arch/x86_64/signal/sigframe.h
@@ -8,6 +8,11 @@ namespace x86 {
 
 constexpr int32_t SI_USER = 0;
 
+// uc_flags bit: the saved context carries live RCX/R11/RAX from an
+// interrupted instruction stream, so the return must rebuild every
+// register through an IRET exit (SYSRET consumes RCX and R11).
+constexpr uint64_t UC_FULL_RESTORE = 1;
+
 // Delivered to SA_SIGINFO handlers. Only si_signo and si_code are filled,
 // sender identity stays zero because standard signals carry no queue.
 struct siginfo {

--- a/kernel/arch/x86_64/syscall/syscall_entry.S
+++ b/kernel/arch/x86_64/syscall/syscall_entry.S
@@ -33,9 +33,33 @@
 .extern stlx_syscall_handler
 .extern current_task_exec
 
-.set TASK_FLAGS_OFFSET,     0x00
-.set TASK_SYS_STACK_OFFSET, 0x10
-.set TASK_FLAG_ELEVATED,    (1 << 0)
+.set TASK_FLAGS_OFFSET,        0x00
+.set TASK_SYS_STACK_OFFSET,    0x10
+.set TASK_IRET_PENDING_OFFSET, 0x2E8
+.set TASK_IRET_CTX_OFFSET,     0x2F0
+.set TASK_FLAG_ELEVATED,       (1 << 0)
+
+/* thread_cpu_context offsets (sched/thread_cpu_context.h) */
+.set CTX_RAX,    0x00
+.set CTX_RBX,    0x08
+.set CTX_RCX,    0x10
+.set CTX_RDX,    0x18
+.set CTX_RSI,    0x20
+.set CTX_RDI,    0x28
+.set CTX_RBP,    0x30
+.set CTX_RSP,    0x38
+.set CTX_R8,     0x40
+.set CTX_R9,     0x48
+.set CTX_R10,    0x50
+.set CTX_R11,    0x58
+.set CTX_R12,    0x60
+.set CTX_R13,    0x68
+.set CTX_R14,    0x70
+.set CTX_R15,    0x78
+.set CTX_RIP,    0x80
+.set CTX_RFLAGS, 0x88
+.set CTX_CS,     0x90
+.set CTX_SS,     0x98
 
 .globl stlx_x86_syscall_entry
 .type stlx_x86_syscall_entry, @function
@@ -114,6 +138,17 @@ stlx_x86_syscall_entry:
     /* Clean up arg6. */
     add rsp, 8
 
+    /*
+     * A staged full-register context (rt_sigreturn of a frame captured
+     * outside a syscall) replaces the frame-based return entirely:
+     * SYSRET consumes RCX/R11, only IRET can rebuild every register.
+     */
+    push rax
+    this_cpu_read rax, current_task_exec
+    cmp dword ptr [rax + TASK_IRET_PENDING_OFFSET], 0
+    pop rax
+    jne .Lsyscall_iret_exit
+
     /* Restore user argument registers. */
     pop rdi
     pop rsi
@@ -155,5 +190,42 @@ stlx_x86_syscall_entry:
     popfq
     push rcx
     ret
+
+.Lsyscall_iret_exit:
+    /*
+     * Full-register return: the staged context was sanitized by the
+     * rt_sigreturn path (user segments forced, RFLAGS masked, RIP
+     * bounded), so IRET always lands back in user mode.
+     */
+    this_cpu_read rax, current_task_exec
+    mov dword ptr [rax + TASK_IRET_PENDING_OFFSET], 0
+    lea rax, [rax + TASK_IRET_CTX_OFFSET]
+
+    /* Hardware return frame from the staged context. */
+    push qword ptr [rax + CTX_SS]
+    push qword ptr [rax + CTX_RSP]
+    push qword ptr [rax + CTX_RFLAGS]
+    push qword ptr [rax + CTX_CS]
+    push qword ptr [rax + CTX_RIP]
+
+    /* Every general register from the staged context, RAX last. */
+    mov rbx, [rax + CTX_RBX]
+    mov rcx, [rax + CTX_RCX]
+    mov rdx, [rax + CTX_RDX]
+    mov rsi, [rax + CTX_RSI]
+    mov rdi, [rax + CTX_RDI]
+    mov rbp, [rax + CTX_RBP]
+    mov r8,  [rax + CTX_R8]
+    mov r9,  [rax + CTX_R9]
+    mov r10, [rax + CTX_R10]
+    mov r11, [rax + CTX_R11]
+    mov r12, [rax + CTX_R12]
+    mov r13, [rax + CTX_R13]
+    mov r14, [rax + CTX_R14]
+    mov r15, [rax + CTX_R15]
+    mov rax, [rax + CTX_RAX]
+
+    swapgs
+    iretq
 
 .size stlx_x86_syscall_entry, . - stlx_x86_syscall_entry

--- a/kernel/mm/mm.cpp
+++ b/kernel/mm/mm.cpp
@@ -82,6 +82,21 @@ bool handle_user_pf(
         return false;
     }
 
+    sync::mutex_lock(mm_ctx->lock);
+    bool resolved = handle_user_pf_locked(mm_ctx, fault_address, pf_flags);
+    sync::mutex_unlock(mm_ctx->lock);
+    return resolved;
+}
+
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE
+bool handle_user_pf_locked(
+    mm_context* mm_ctx,
+    uintptr_t fault_address,
+    uint64_t pf_flags
+) {
     /**
      * For now, on-demand paging is not yet fully complete, so
      * the only operation that's supported is lazy stack growing.
@@ -92,27 +107,22 @@ bool handle_user_pf(
 
     uintptr_t page_addr = fault_address & ~(pmm::PAGE_SIZE - 1);
 
-    sync::mutex_lock(mm_ctx->lock);
-
     // Get the virtual memory area for this page
     vma* vm = vma_find_locked(mm_ctx, page_addr);
 
     // Ensure that on-demand paging is supported for this page type
     if (!vm || !(vm->flags & VMA_FLAG_STACK)) {
-        sync::mutex_unlock(mm_ctx->lock);
         return false;
     }
 
     // Concurrent page fault on same page won by another CPU, retry
     if (paging::get_physical(page_addr, mm_ctx->pt_root) != 0) {
-        sync::mutex_unlock(mm_ctx->lock);
         return true;
     }
 
     // Allocate a new physical page to back the memory
     pmm::phys_addr_t phys = pmm::alloc_page();
     if (phys == 0) {
-        sync::mutex_unlock(mm_ctx->lock);
         return false; // OOM - my favorite thing
     }
 
@@ -123,11 +133,9 @@ bool handle_user_pf(
     paging::page_flags_t pagefl = prot_to_page_flags(vm->prot);
     if (paging::map_page(page_addr, phys, pagefl, mm_ctx->pt_root) != paging::OK) {
         pmm::free_page(phys);
-        sync::mutex_unlock(mm_ctx->lock);
         return false;
     }
 
-    sync::mutex_unlock(mm_ctx->lock);
     log::info("Lazily loading stack page: %p\n", page_addr);
     return true;
 }

--- a/kernel/mm/mm.h
+++ b/kernel/mm/mm.h
@@ -53,6 +53,17 @@ __PRIVILEGED_CODE bool handle_user_pf(
 );
 
 /**
+ * @brief handle_user_pf with mm_ctx->lock already held by the caller.
+ * Never blocks, so it is safe from interrupt context.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE bool handle_user_pf_locked(
+    mm_context* mm_ctx,
+    uintptr_t fault_address,
+    uint64_t pf_flags
+);
+
+/**
  * @brief Create a user address-space context with a new user page-table root.
  * @return New mm_context on success, nullptr on failure.
  * @note Privilege: **required**

--- a/kernel/mm/uaccess.cpp
+++ b/kernel/mm/uaccess.cpp
@@ -135,7 +135,7 @@ __PRIVILEGED_CODE int32_t copy_to_user(
 /**
  * @note Privilege: **required**
  */
-__PRIVILEGED_CODE int32_t copy_to_user_resident(
+__PRIVILEGED_CODE int32_t copy_to_user_nonblock(
     void* udst,
     const void* ksrc,
     size_t len
@@ -184,15 +184,19 @@ __PRIVILEGED_CODE int32_t copy_to_user_resident(
         cursor = next;
     }
 
-    // No page-in here: every page must already be resident. A present
-    // entry in a writable region is writable, nothing maps copy-on-write.
+    // Fault lazy stack pages in under the held lock, nothing blocks. A
+    // present entry in a writable region is writable, nothing maps
+    // copy-on-write.
     uintptr_t end_page = end & ~(pmm::PAGE_SIZE - 1);
     for (uintptr_t page = start & ~(pmm::PAGE_SIZE - 1);
          page <= end_page;
          page += pmm::PAGE_SIZE) {
-        if (paging::get_physical(page, mm_ctx->pt_root) == 0) {
+        if (paging::get_physical(page, mm_ctx->pt_root) != 0) {
+            continue;
+        }
+        if (!handle_user_pf_locked(mm_ctx, page, 0)) {
             sync::mutex_unlock(mm_ctx->lock);
-            return ERR_RETRY;
+            return ERR_FAULT;
         }
     }
 

--- a/kernel/mm/uaccess.cpp
+++ b/kernel/mm/uaccess.cpp
@@ -135,6 +135,76 @@ __PRIVILEGED_CODE int32_t copy_to_user(
 /**
  * @note Privilege: **required**
  */
+__PRIVILEGED_CODE int32_t copy_to_user_resident(
+    void* udst,
+    const void* ksrc,
+    size_t len
+) {
+    if (!udst || !ksrc || len == 0) {
+        return ERR_INVAL;
+    }
+
+    uintptr_t start = reinterpret_cast<uintptr_t>(udst);
+    uintptr_t end = start + len - 1;
+    if (end < start) {
+        return ERR_INVAL;
+    }
+    if (end >= USER_STACK_TOP) {
+        return ERR_FAULT;
+    }
+
+    sched::task* task = sched::current();
+    if (!task || !task->exec.mm_ctx) {
+        return ERR_NO_MMCTX;
+    }
+
+    // Interrupt context cannot block on the address-space lock
+    mm_context* mm_ctx = task->exec.mm_ctx;
+    if (!sync::mutex_trylock(mm_ctx->lock)) {
+        return ERR_RETRY;
+    }
+
+    uintptr_t cursor = start;
+    while (cursor <= end) {
+        vma* region = vma_find_locked(mm_ctx, cursor);
+        if (!region || cursor < region->start || cursor >= region->end ||
+            (region->prot & MM_PROT_WRITE) == 0) {
+            sync::mutex_unlock(mm_ctx->lock);
+            return ERR_FAULT;
+        }
+
+        uintptr_t next = region->end;
+        if (next == 0 || next <= cursor) {
+            sync::mutex_unlock(mm_ctx->lock);
+            return ERR_FAULT;
+        }
+        if (next > end) {
+            break;
+        }
+        cursor = next;
+    }
+
+    // No page-in here: every page must already be resident. A present
+    // entry in a writable region is writable, nothing maps copy-on-write.
+    uintptr_t end_page = end & ~(pmm::PAGE_SIZE - 1);
+    for (uintptr_t page = start & ~(pmm::PAGE_SIZE - 1);
+         page <= end_page;
+         page += pmm::PAGE_SIZE) {
+        if (paging::get_physical(page, mm_ctx->pt_root) == 0) {
+            sync::mutex_unlock(mm_ctx->lock);
+            return ERR_RETRY;
+        }
+    }
+
+    // Copying under the held lock keeps a concurrent unmap out of the range
+    string::memcpy(udst, ksrc, len);
+    sync::mutex_unlock(mm_ctx->lock);
+    return OK;
+}
+
+/**
+ * @note Privilege: **required**
+ */
 __PRIVILEGED_CODE int32_t copy_cstr_from_user(
     char* kdst,
     size_t cap,

--- a/kernel/mm/uaccess.h
+++ b/kernel/mm/uaccess.h
@@ -10,6 +10,7 @@ constexpr int32_t ERR_INVAL    = -1;
 constexpr int32_t ERR_NO_MMCTX = -2;
 constexpr int32_t ERR_FAULT    = -3;
 constexpr int32_t ERR_NAMETOOLONG = -4;
+constexpr int32_t ERR_RETRY    = -5;
 
 /**
  * @brief Validate that a user range is mapped and has required protections.
@@ -57,6 +58,20 @@ __PRIVILEGED_CODE int32_t copy_cstr_from_user(
     char* kdst,
     size_t cap,
     const char* usrc
+);
+
+/**
+ * @brief Copy to a resident user range without blocking or paging in.
+ * Safe from interrupt context: the address-space lock is only tried and
+ * every page must already be mapped, so the copy can never fault.
+ * @return OK on success, ERR_RETRY when the lock is contended or a page
+ * is not resident, ERR_FAULT/ERR_INVAL on a bad range.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE int32_t copy_to_user_resident(
+    void* udst,
+    const void* ksrc,
+    size_t len
 );
 
 } // namespace mm::uaccess

--- a/kernel/mm/uaccess.h
+++ b/kernel/mm/uaccess.h
@@ -61,14 +61,14 @@ __PRIVILEGED_CODE int32_t copy_cstr_from_user(
 );
 
 /**
- * @brief Copy to a resident user range without blocking or paging in.
- * Safe from interrupt context: the address-space lock is only tried and
- * every page must already be mapped, so the copy can never fault.
- * @return OK on success, ERR_RETRY when the lock is contended or a page
- * is not resident, ERR_FAULT/ERR_INVAL on a bad range.
+ * @brief Copy to a user range without ever blocking, for interrupt
+ * context. The address-space lock is only tried, and lazy stack pages
+ * are faulted in under it so the copy itself can never fault.
+ * @return OK on success, ERR_RETRY when the lock is contended,
+ * ERR_FAULT/ERR_INVAL on a bad range.
  * @note Privilege: **required**
  */
-__PRIVILEGED_CODE int32_t copy_to_user_resident(
+__PRIVILEGED_CODE int32_t copy_to_user_nonblock(
     void* udst,
     const void* ksrc,
     size_t len

--- a/kernel/sched/task_exec_core.h
+++ b/kernel/sched/task_exec_core.h
@@ -33,6 +33,12 @@ struct task_exec_core {
     mm::mm_context* mm_ctx; // owning reference to process address-space metadata
     fpu_state fpu_ctx;
     uint64_t  tls_base;    // thread-local storage base (FS_BASE on x86, TPIDR_EL0 on aarch64)
+
+    // Staged full-register return context (x86): a signal
+    // frame captured outside a syscall restores through an
+    // IRET exit. Consumed by the syscall exit assembly.
+    uint32_t  iret_pending;
+    thread_cpu_context iret_ctx;
 };
 
 constexpr size_t TASK_FLAGS_OFFSET          = __builtin_offsetof(task_exec_core, flags);
@@ -44,13 +50,29 @@ constexpr size_t TASK_PT_ROOT_OFFSET        = __builtin_offsetof(task_exec_core,
 constexpr size_t TASK_USER_PT_ROOT_OFFSET   = __builtin_offsetof(task_exec_core, user_pt_root);
 constexpr size_t TASK_MM_CTX_OFFSET         = __builtin_offsetof(task_exec_core, mm_ctx);
 constexpr size_t TASK_FPU_CTX_OFFSET        = __builtin_offsetof(task_exec_core, fpu_ctx);
+constexpr size_t TASK_IRET_PENDING_OFFSET   = __builtin_offsetof(task_exec_core, iret_pending);
+constexpr size_t TASK_IRET_CTX_OFFSET       = __builtin_offsetof(task_exec_core, iret_ctx);
 
 // Static assertions to ensure assembly offsets remain in sync
 // If these fail, update the assembly constants in:
 //   - kernel/arch/x86_64/trap/entry.S (TASK_FLAGS_OFFSET, TASK_SYS_STACK_OFFSET)
-//   - kernel/arch/x86_64/syscall/syscall_entry.S (TASK_FLAGS_OFFSET, TASK_SYS_STACK_OFFSET)
+//   - kernel/arch/x86_64/syscall/syscall_entry.S (TASK_FLAGS_OFFSET, TASK_SYS_STACK_OFFSET,
+//     TASK_IRET_PENDING_OFFSET, TASK_IRET_CTX_OFFSET, CTX_* register slots)
 static_assert(TASK_FLAGS_OFFSET == 0x00, "TASK_FLAGS_OFFSET changed - update x86_64 entry.S and syscall_entry.S");
 static_assert(TASK_SYS_STACK_OFFSET == 0x10, "TASK_SYS_STACK_OFFSET changed - update x86_64 entry.S and syscall_entry.S");
+
+#if defined(__x86_64__)
+static_assert(TASK_IRET_PENDING_OFFSET == 0x2E8, "TASK_IRET_PENDING_OFFSET changed - update syscall_entry.S");
+static_assert(TASK_IRET_CTX_OFFSET == 0x2F0, "TASK_IRET_CTX_OFFSET changed - update syscall_entry.S");
+static_assert(__builtin_offsetof(thread_cpu_context, rax) == 0x00);
+static_assert(__builtin_offsetof(thread_cpu_context, rcx) == 0x10);
+static_assert(__builtin_offsetof(thread_cpu_context, rsp) == 0x38);
+static_assert(__builtin_offsetof(thread_cpu_context, r11) == 0x58);
+static_assert(__builtin_offsetof(thread_cpu_context, rip) == 0x80);
+static_assert(__builtin_offsetof(thread_cpu_context, rflags) == 0x88);
+static_assert(__builtin_offsetof(thread_cpu_context, cs) == 0x90);
+static_assert(__builtin_offsetof(thread_cpu_context, ss) == 0x98);
+#endif
 
 int32_t init_boot_task();
 

--- a/kernel/signals/signal.cpp
+++ b/kernel/signals/signal.cpp
@@ -456,6 +456,24 @@ __PRIVILEGED_CODE bool take_deliverable(sched::task* t, uint32_t* sig,
     return true;
 }
 
+__PRIVILEGED_CODE void untake_deliverable(sched::task* t, uint32_t sig,
+                                          const k_sigaction* act,
+                                          sig_set_t old_blocked) {
+    set_blocked(t, SIG_SETMASK, &old_blocked, nullptr);
+
+    // Reinstate a one-shot action the take reset, so a deferred delivery
+    // still runs the handler instead of falling to the default
+    if ((act->flags & SA_RESETHAND) && t->group) {
+        sync::irq_state irq = sync::spin_lock_irqsave(t->group->sig.lock);
+        if (t->group->sig.actions[sig - 1].handler == SIG_DFL) {
+            t->group->sig.actions[sig - 1] = *act;
+        }
+        sync::spin_unlock_irqrestore(t->group->sig.lock, irq);
+    }
+
+    __atomic_fetch_or(&t->sig.pending, sig_bit(sig), __ATOMIC_ACQ_REL);
+}
+
 __PRIVILEGED_CODE void die_from_signal(uint32_t sig) {
     sched::task* self = sched::current();
     sched::thread_group* tg = self->group;

--- a/kernel/signals/signal.h
+++ b/kernel/signals/signal.h
@@ -119,6 +119,17 @@ __PRIVILEGED_CODE bool take_deliverable(sched::task* t, uint32_t* sig,
                                         sig_set_t* old_blocked);
 
 /**
+ * @brief Return a taken signal to the pending set with the pre-delivery
+ * mask, for a delivery that could not complete. An action SA_RESETHAND
+ * reset at take time is reinstated, unless another thread has installed
+ * a new one since.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE void untake_deliverable(sched::task* t, uint32_t sig,
+                                          const k_sigaction* act,
+                                          sig_set_t old_blocked);
+
+/**
  * @brief Terminate the current task because of signal sig.
  * Fatal signals kill the whole process: a non-leader records sig as the
  * group exit signal and force-kills the leader so teardown reaps every

--- a/kernel/tests/signals/delivery.test.cpp
+++ b/kernel/tests/signals/delivery.test.cpp
@@ -177,6 +177,103 @@ TEST(signal_delivery, x86_sanitizes_restored_mxcsr) {
     EXPECT_EQ(mxcsr >> 16, 0U);          // reserved bits never reach FXRSTOR
     EXPECT_EQ(mxcsr & 0x1F80U, 0x1F80U); // supported control bits survive
 }
+
+TEST(signal_delivery, x86_full_frame_captures_scratch_registers) {
+    x86::trap_frame tf{};
+    tf.rax = 0x2001; tf.rcx = 0x2002; tf.r11 = 0x2003;
+    tf.rdi = 0x2004; tf.rsp = 0x7fff0000; tf.rip = 0x401000;
+    tf.rflags = 0x246;
+
+    x86::rt_sigframe* frame = nullptr;
+    RUN_ELEVATED({ frame = heap::kalloc_new<x86::rt_sigframe>(); });
+    ASSERT_TRUE(frame != nullptr);
+
+    RUN_ELEVATED({
+        x86::pack_sigframe_full(frame, &tf, signals::SIGINT, 0xABCD, 0x7ffe0000);
+    });
+
+    // The scratch registers a syscall boundary never carries are captured
+    EXPECT_EQ(frame->uc.uc_mcontext.rax, 0x2001ULL);
+    EXPECT_EQ(frame->uc.uc_mcontext.rcx, 0x2002ULL);
+    EXPECT_EQ(frame->uc.uc_mcontext.r11, 0x2003ULL);
+    EXPECT_EQ(frame->uc.uc_flags & x86::UC_FULL_RESTORE, x86::UC_FULL_RESTORE);
+    EXPECT_EQ(frame->uc.uc_sigmask, 0xABCDULL);
+
+    RUN_ELEVATED({ heap::kfree_delete(frame); });
+}
+
+TEST(signal_delivery, x86_full_frame_round_trip) {
+    x86::trap_frame tf{};
+    tf.rax = 0x3001; tf.rcx = 0x3002; tf.r11 = 0x3003; tf.rbx = 0x3004;
+    tf.rbp = 0x3005; tf.r15 = 0x3006; tf.rsi = 0x3007; tf.rdx = 0x3008;
+    tf.rsp = 0x7fff0000; tf.rip = 0x401000; tf.rflags = 0x10246;
+
+    x86::rt_sigframe* frame = nullptr;
+    RUN_ELEVATED({ frame = heap::kalloc_new<x86::rt_sigframe>(); });
+    ASSERT_TRUE(frame != nullptr);
+
+    signals::sig_set_t mask = 0;
+    bool ok = false;
+    sched::thread_cpu_context out{};
+    RUN_ELEVATED({
+        x86::pack_sigframe_full(frame, &tf, signals::SIGUSR1, 0x77, 0);
+        ok = x86::unpack_sigframe_full(frame, &out, &mask);
+    });
+
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(out.rax, tf.rax);
+    EXPECT_EQ(out.rcx, tf.rcx);
+    EXPECT_EQ(out.r11, tf.r11);
+    EXPECT_EQ(out.rbx, tf.rbx);
+    EXPECT_EQ(out.r15, tf.r15);
+    EXPECT_EQ(out.rsp, tf.rsp);
+    EXPECT_EQ(out.rip, tf.rip);
+    EXPECT_EQ(mask, 0x77ULL);
+
+    RUN_ELEVATED({ heap::kfree_delete(frame); });
+}
+
+TEST(signal_delivery, x86_full_restore_sanitizes_forged_context) {
+    x86::trap_frame tf{};
+    tf.rsp = 0x7fff0000; tf.rip = 0x401000; tf.rflags = 0x246;
+
+    x86::rt_sigframe* frame = nullptr;
+    RUN_ELEVATED({ frame = heap::kalloc_new<x86::rt_sigframe>(); });
+    ASSERT_TRUE(frame != nullptr);
+
+    signals::sig_set_t mask = 0;
+    bool ok = false;
+    sched::thread_cpu_context out{};
+    uint16_t user_cs = 0;
+    uint16_t user_ss = 0;
+    RUN_ELEVATED({
+        x86::pack_sigframe_full(frame, &tf, signals::SIGUSR1, 0, 0);
+        user_cs = frame->uc.uc_mcontext.cs;
+        user_ss = frame->uc.uc_mcontext.ss;
+
+        // Forge ring 0 segments and privileged RFLAGS bits
+        frame->uc.uc_mcontext.cs = 0x08;
+        frame->uc.uc_mcontext.ss = 0x10;
+        frame->uc.uc_mcontext.eflags = 0xFFFFFFFF;
+        ok = x86::unpack_sigframe_full(frame, &out, &mask);
+    });
+
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(out.cs, static_cast<uint64_t>(user_cs));
+    EXPECT_EQ(out.ss, static_cast<uint64_t>(user_ss));
+    EXPECT_TRUE((out.rflags & (3ULL << 12)) == 0); // IOPL cleared
+    EXPECT_TRUE((out.rflags & (1ULL << 9)) != 0);  // IF forced on
+
+    // A kernel-half RIP rejects the whole frame
+    bool ok2 = true;
+    RUN_ELEVATED({
+        frame->uc.uc_mcontext.rip = 0x0000800000000000ULL;
+        ok2 = x86::unpack_sigframe_full(frame, &out, &mask);
+    });
+    EXPECT_TRUE(!ok2);
+
+    RUN_ELEVATED({ heap::kfree_delete(frame); });
+}
 #endif
 
 #ifdef __aarch64__

--- a/kernel/tests/signals/signal_state.test.cpp
+++ b/kernel/tests/signals/signal_state.test.cpp
@@ -381,6 +381,32 @@ TEST(signal_state, take_deliverable_resethand_restores_default) {
     EXPECT_EQ(g_tg->sig.actions[signals::SIGUSR1 - 1].handler, signals::SIG_DFL);
 }
 
+TEST(signal_state, untake_deliverable_restores_state) {
+    install_handler(signals::SIGUSR1, signals::SA_RESETHAND,
+                    signals::sig_bit(signals::SIGUSR2));
+    g_leader->sig.pending = signals::sig_bit(signals::SIGUSR1);
+
+    uint32_t sig = 0;
+    signals::k_sigaction act = {};
+    signals::sig_set_t old_blocked = 0;
+    bool taken = false;
+    RUN_ELEVATED({
+        taken = signals::take_deliverable(g_leader, &sig, &act, &old_blocked);
+    });
+    ASSERT_TRUE(taken);
+    EXPECT_EQ(g_leader->sig.pending, 0ULL);
+    EXPECT_EQ(g_tg->sig.actions[signals::SIGUSR1 - 1].handler, signals::SIG_DFL);
+
+    // A deferred delivery puts the signal, the mask, and the one-shot
+    // action all back
+    RUN_ELEVATED({
+        signals::untake_deliverable(g_leader, sig, &act, old_blocked);
+    });
+    EXPECT_EQ(g_leader->sig.pending, signals::sig_bit(signals::SIGUSR1));
+    EXPECT_EQ(g_leader->sig.blocked, 0ULL);
+    EXPECT_EQ(g_tg->sig.actions[signals::SIGUSR1 - 1].handler, 0x400000UL);
+}
+
 TEST(signal_state, take_deliverable_skips_blocked_and_unhandled) {
     uint32_t sig = 0;
     signals::k_sigaction act = {};

--- a/userland/apps/sigtest/src/sigtest.c
+++ b/userland/apps/sigtest/src/sigtest.c
@@ -314,6 +314,69 @@ static void test_poll_eintr_despite_restart(void) {
     close(fds[1]);
 }
 
+static volatile sig_atomic_t async_handler_ran = 0;
+
+static void async_handler(int sig) {
+    (void)sig;
+    async_handler_ran = 1;
+}
+
+static void async_helper(void* arg) {
+    (void)arg;
+
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGUSR2);
+    sigprocmask(SIG_BLOCK, &set, NULL);
+
+    usleep(200 * 1000);
+    kill(getpid(), SIGUSR2);
+    _exit(0);
+}
+
+static void test_async_compute_delivery(void) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = async_handler;
+    sigaction(SIGUSR2, &sa, NULL);
+    async_handler_ran = 0;
+
+    void* stk = mmap(NULL, HELPER_STACK_SIZE, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+    if (stk == MAP_FAILED) {
+        printf("  SKIP: helper stack unavailable\n");
+        return;
+    }
+    int h = proc_create_thread(async_helper, NULL,
+                               (char*)stk + HELPER_STACK_SIZE, "sig_helper");
+    if (h < 0) {
+        printf("  SKIP: thread creation unavailable\n");
+        munmap(stk, HELPER_STACK_SIZE);
+        return;
+    }
+    proc_thread_start(h);
+
+    /* Pure compute: no syscall happens until the handler flips the flag,
+     * so only asynchronous delivery can end this loop. */
+    volatile unsigned long spins = 0;
+    while (!async_handler_ran) {
+        spins++;
+    }
+
+    /* The interrupted loop's state must survive the full-register restore */
+    unsigned long resume_point = spins;
+    for (int i = 0; i < 1000; i++) {
+        spins++;
+    }
+
+    proc_thread_join(h, NULL);
+
+    check("handler fired mid-compute without a syscall", async_handler_ran == 1);
+    check("interrupted loop state survived", spins == resume_point + 1000);
+
+    munmap(stk, HELPER_STACK_SIZE);
+}
+
 static volatile sig_atomic_t sigpipe_count = 0;
 
 static void sigpipe_handler(int sig) {
@@ -383,6 +446,7 @@ int main(int argc, char** argv) {
     test_read_eintr();
     test_read_restart();
     test_poll_eintr_despite_restart();
+    test_async_compute_delivery();
     test_sigpipe_dispositions();
 
     printf("sigtest: %d passed, %d failed\n", passed, failed);


### PR DESCRIPTION
## Summary
- Handler delivery only happened at syscall returns, so a compute-bound task (a busy Python loop under Ctrl+C) never saw its signals until it made a call.
- The timer tick and yield boundaries now deliver: frames are written through a new interrupt-safe uaccess path that requires resident pages and defers losslessly otherwise, and on x86_64 rt_sigreturn stages the full register context for an IRET syscall exit, since SYSRET cannot rebuild RCX/R11 that live user code depends on.
- AArch64 reuses the existing builder and ERET restore wholesale; sigtest proves a handler fires mid-spin with zero syscalls and the interrupted loop state survives the full-register restore.

Made with [Cursor](https://cursor.com)