### PR TITLE
feat(mm): extended demand paging to anonymous mappings and MAP_NORESERVE

### DIFF
--- a/.cursor/rules/stellux-conventions.mdc
+++ b/.cursor/rules/stellux-conventions.mdc
@@ -1,0 +1,36 @@
+---
+description: StelluxOS engineering conventions for commits, code style, stacked-commit review, and verification gates
+alwaysApply: true
+---
+
+# StelluxOS Engineering Conventions
+
+## Commit style
+
+- Google style with domain scopes from repo history: `feat(sched):`, `feat(sysstat):`, `feat(client):`, `feat(userland):`, `feat(syscall):`, `fix(signals):`. Client = userland graphics/desktop.
+- Subject verbs in past tense: "added", "implemented", "rendered", "accounted".
+- Body: 2-4 sentences on WHY (the problem that existed, why this approach). No implementation play-by-play. Timeless wording, no "this PR/commit", no Linux mentions.
+- Work lands as a stack of small self-contained commits, each independently buildable and testable. Lib primitives may land with their first consumer.
+
+## Code style
+
+- Struct definitions and file-scope globals belong at the top of the file, above all function definitions, in both headers and .c/.cpp files.
+- Kernel modules use `namespace <module> { namespace { ... } }` for internals (see `kernel/random/random.cpp` as the template for devfs drivers).
+- Kernel test files use file-scope `static`, never anonymous namespaces (match `kernel/tests/sched/preemption.test.cpp`). Per-test globals sit adjacent to their test.
+- Comments: ASCII only, 1-2 lines, explain intent not mechanics. Headers use doxygen blocks with `@note Privilege: **required**` for privileged functions.
+- Public kernel APIs carry `__PRIVILEGED_CODE`; follow existing error-constant patterns (`fs::ERR_*`, per-module `OK`/`ERR`).
+- Userland apps: `APP_NAME := x` Makefile + `include ../../mk/app.mk`, register in `userland/apps/Makefile` APP_DIRS.
+
+## Stacked-commit review workflow
+
+- The user reviews commit-by-commit and comments in chat; feedback is folded into the commit where the code was born, not fixup commits.
+- To edit mid-stack: create `backup/<name>-vN` branch, `git reset --hard <base>`, then per commit `git cherry-pick -n <sha>`, edit, commit with the original message (updated if the change warrants). Never `git rebase -i`, never amend pushed commits.
+- After rebuilding a stack, verify `git diff backup/... HEAD` shows only the intended change, then rebuild and re-run the suite.
+- Work directly on master only when the user says so; they push themselves. Delete backup branches only after the user pushes.
+
+## Verification gates
+
+- Every kernel-touching stack: `make test ARCH=x86_64` and `ARCH=aarch64` fully green plus compile checks on both arches for every commit.
+- Userland/visual changes: live QEMU verification with before/after screenshots (see the stellux-qemu-testing skill). Present zoomed comparison crops in chat.
+- Delegate realistic interactive/visual testing to the user when they offer; they orchestrate GUI sessions better. Prepare diagnostic flags or builds for them instead of guessing.
+- `make test` leaves a test-flavored build; run `make clean && make image ARCH=x86_64` afterward so the shipped image matches committed code.

--- a/.cursor/skills/stellux-qemu-testing/SKILL.md
+++ b/.cursor/skills/stellux-qemu-testing/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: stellux-qemu-testing
+description: Boot, drive, and visually verify StelluxOS in QEMU from the host shell, including serial control, GUI input injection, screenshots, and known pitfalls. Use when testing StelluxOS changes in QEMU, capturing before/after screenshots, debugging boot behavior, or measuring anything inside the OS.
+---
+
+# StelluxOS QEMU Testing
+
+## Boot recipes
+
+Output-only session (most robust, no stdin fragility):
+
+```bash
+rm -f /tmp/stlx_serial.log
+OVMF_CODE=/opt/homebrew/share/qemu/edk2-x86_64-code.fd
+(qemu-system-x86_64 -machine q35 -cpu qemu64,+fsgsbase,+rdrand -m 4G -smp 4 \
+  -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
+  -drive if=pflash,format=raw,file=/tmp/stlx_vars.fd \
+  -drive format=raw,file=images/stellux-x86_64.img \
+  -device qemu-xhci -device usb-kbd -device usb-mouse \
+  -serial file:/tmp/stlx_serial.log \
+  -monitor unix:/tmp/stlx_mon,server,nowait \
+  -display none -no-reboot -no-shutdown > /dev/null 2>&1 & echo $! > /tmp/stlx_pid)
+```
+
+Interactive serial session: replace `-serial file:...` with
+`-serial stdio < /tmp/stlx_in > /tmp/stlx_out 2>&1` after `mkfifo /tmp/stlx_in`,
+then `exec 3>/tmp/stlx_in` and send commands with `printf 'cmd\r' >&3`.
+
+- CRITICAL: the fifo write end dies between separate shell tool calls, which
+  EOFs QEMU stdin and kills it. Keep boot plus all serial interaction in ONE
+  command chain, or use the output-only recipe with monitor input instead.
+- Wait for boot with: `for i in $(seq 1 90); do grep -q '\$ ' /tmp/stlx_out && break; sleep 1; done`
+  (with -serial file, grep the log for `stlxdm started`).
+- `/tmp/stlx_vars.fd` is a writable copy of `edk2-i386-vars.fd`.
+
+## Driving the GUI via the monitor socket
+
+All through `printf '<cmd>\n' | nc -U /tmp/stlx_mon`:
+
+- `sendkey ret` — dismiss the boot splash (required before the desktop shows).
+- `sendkey ctrl-alt-t` — open a terminal via the stlxdm shortcut.
+- Type into GUI apps one key at a time: `for k in s t l x t o p ret; do printf "sendkey $k\n" | nc -U /tmp/stlx_mon; sleep 0.2; done` (`spc` = space, `slash` = /).
+- Mouse is RELATIVE, cursor starts at screen center (960, 540) native:
+  `mouse_move <dx> <dy>`, `mouse_button 1` press, `mouse_button 0` release.
+  Taskbar items are centered at y=1056: with 2 items, first at x=940, second x=980.
+- `screendump /tmp/shot.png -f png` — native 1920x1080 PNG.
+
+## Screenshots and visual verification
+
+- The image Read tool displays captures scaled to 1024x576: multiply displayed
+  coordinates by 1.875 for native crop coordinates.
+- Zoom crops for pixel inspection: `magick shot.png -crop WxH+X+Y +repage -filter point -resize 500% out.png`.
+- Before/after strips: bordered images appended with `magick a.png b.png +append`
+  (montage labels need ghostscript, which is not installed).
+- The serial shell echoes every keystroke with `[2K` redraw sequences: NEVER
+  measure timing or count prompts from serial output, and filter echo noise
+  with `rg -v "2K"` when reading command output.
+
+## Known pitfalls
+
+- Kernel unit tests run on the BSP idle task: `sched::sleep_*` returns
+  immediately there and its spinning charges idle time. Tests needing a busy
+  task must spawn a finite, self-reporting spinner via `create_kernel_task`
+  and place it on another CPU with `enqueue_on`; infinite spinners starve the
+  runner and hang the suite.
+- Apps do not relink when only a lib archive changed: `touch` the app source
+  (or the app's Makefile inputs) after lib-only edits, and confirm with
+  `strings initrd/bin/<app> | rg <marker>`.
+- pty writes return short by design under load; userland writers must loop.
+  poll timeouts are not reliable from userland; pace loops with nanosleep
+  against a CLOCK_MONOTONIC deadline and poll input with timeout 0.
+- `[WARN] syscall: unimplemented nr=N from tid=T` in serial output is the
+  porting feedback loop; nr uses the arch's Linux syscall numbering.
+- `make test ARCH=x` does a clean test-flavored rebuild (~60-90s, 611/606
+  baseline passes); afterwards run `make clean && make image ARCH=x` so the
+  disk image matches committed code before any live verification.
+- stlxdm autostarts terminals and dropbear; a serial-shell-launched GUI app
+  fails with "failed to create window" until the splash is dismissed.

--- a/kernel/mm/mm.cpp
+++ b/kernel/mm/mm.cpp
@@ -97,10 +97,7 @@ bool handle_user_pf_locked(
     uintptr_t fault_address,
     uint64_t pf_flags
 ) {
-    /**
-     * For now, on-demand paging is not yet fully complete, so
-     * the only operation that's supported is lazy stack growing.
-     */
+    // Protection violations on present pages are never recoverable here
     if (pf_flags & PF_FLAG_PRESENT) {
         return false;
     }
@@ -110,8 +107,20 @@ bool handle_user_pf_locked(
     // Get the virtual memory area for this page
     vma* vm = vma_find_locked(mm_ctx, page_addr);
 
-    // Ensure that on-demand paging is supported for this page type
-    if (!vm || !(vm->flags & VMA_FLAG_STACK)) {
+    // Demand paging serves anonymous memory, including stacks. Regions
+    // with no access rights are pure reservations and never fault in.
+    if (!vm || !(vm->flags & (VMA_FLAG_ANONYMOUS | VMA_FLAG_STACK))) {
+        return false;
+    }
+    if (vm->prot == 0) {
+        return false;
+    }
+
+    // Reject access types the region forbids before committing a page
+    if ((pf_flags & PF_FLAG_WRITE) && !(vm->prot & MM_PROT_WRITE)) {
+        return false;
+    }
+    if ((pf_flags & PF_FLAG_INSTRUCTION) && !(vm->prot & MM_PROT_EXEC)) {
         return false;
     }
 
@@ -136,7 +145,6 @@ bool handle_user_pf_locked(
         return false;
     }
 
-    log::info("Lazily loading stack page: %p\n", page_addr);
     return true;
 }
 

--- a/kernel/mm/vma.cpp
+++ b/kernel/mm/vma.cpp
@@ -318,8 +318,9 @@ __PRIVILEGED_CODE int32_t apply_page_protection(
 ) {
     paging::page_flags_t page_flags = prot_to_page_flags(prot);
     for (uintptr_t vaddr = start; vaddr < end; vaddr += pmm::PAGE_SIZE) {
+        // Absent pages take the VMA's protection when they fault in
         if (!paging::is_mapped(vaddr, mm_ctx->pt_root)) {
-            return MM_CTX_ERR_NOT_MAPPED;
+            continue;
         }
         if (paging::set_page_flags(vaddr, page_flags, mm_ctx->pt_root) != paging::OK) {
             return MM_CTX_ERR_MAP_FAILED;

--- a/kernel/syscall/handlers/sys_mmap.cpp
+++ b/kernel/syscall/handlers/sys_mmap.cpp
@@ -182,13 +182,15 @@ DEFINE_SYSCALL6(mmap, addr, length, prot, flags, fd, offset) {
         return syscall::EINVAL;
     }
 
+    // Anonymous mappings are reservations: physical pages arrive through
+    // demand faults on first touch, so large reserves stay cheap
     uintptr_t mapped_addr = 0;
     int32_t rc = mm::mm_context_map_anonymous(
         task->exec.mm_ctx,
         static_cast<uintptr_t>(addr),
         static_cast<size_t>(length),
         linux_prot_to_mm(prot),
-        linux_map_to_mm(flags),
+        linux_map_to_mm(flags) | mm::MM_MAP_LAZY,
         &mapped_addr
     );
     if (rc != mm::MM_CTX_OK) {

--- a/kernel/syscall/handlers/sys_mmap.cpp
+++ b/kernel/syscall/handlers/sys_mmap.cpp
@@ -19,11 +19,16 @@ constexpr uint64_t LINUX_MAP_SHARED          = 0x00000001;
 constexpr uint64_t LINUX_MAP_PRIVATE         = 0x00000002;
 constexpr uint64_t LINUX_MAP_FIXED           = 0x00000010;
 constexpr uint64_t LINUX_MAP_ANONYMOUS       = 0x00000020;
+constexpr uint64_t LINUX_MAP_NORESERVE       = 0x00004000;
 constexpr uint64_t LINUX_MAP_STACK           = 0x00020000;
 constexpr uint64_t LINUX_MAP_FIXED_NOREPLACE = 0x00100000;
+
+// MAP_NORESERVE is accepted as a no-op: anonymous mappings are lazily
+// populated and no swap/commit accounting exists to opt out of.
 constexpr uint64_t LINUX_MAP_ALLOWED_MASK =
     LINUX_MAP_SHARED | LINUX_MAP_PRIVATE | LINUX_MAP_FIXED |
-    LINUX_MAP_ANONYMOUS | LINUX_MAP_STACK | LINUX_MAP_FIXED_NOREPLACE;
+    LINUX_MAP_ANONYMOUS | LINUX_MAP_STACK | LINUX_MAP_FIXED_NOREPLACE |
+    LINUX_MAP_NORESERVE;
 
 inline uint32_t linux_prot_to_mm(uint64_t prot) {
     uint32_t mm_prot = 0;

--- a/kernel/tests/memory/lazy_anon.test.cpp
+++ b/kernel/tests/memory/lazy_anon.test.cpp
@@ -1,0 +1,258 @@
+#define STLX_TEST_TIER TIER_MM_CORE
+
+#include "stlx_unit_test.h"
+#include "mm/mm.h"
+#include "mm/vma.h"
+#include "mm/paging.h"
+#include "mm/pmm.h"
+#include "common/string.h"
+
+TEST_SUITE(lazy_anon);
+
+static uint64_t g_initial_free_pages = 0;
+
+static int32_t lazy_anon_before_all() {
+    g_initial_free_pages = pmm::free_page_count();
+    return 0;
+}
+
+static int32_t lazy_anon_after_all() {
+    return pmm::free_page_count() == g_initial_free_pages ? 0 : -1;
+}
+
+BEFORE_ALL(lazy_anon, lazy_anon_before_all);
+AFTER_ALL(lazy_anon, lazy_anon_after_all);
+
+static constexpr size_t PAGE = pmm::PAGE_SIZE;
+static constexpr uint32_t LAZY_ANON =
+    mm::MM_MAP_PRIVATE | mm::MM_MAP_ANONYMOUS | mm::MM_MAP_LAZY;
+
+// --- lazy_map_reserves_without_pages ---
+// Proves: a lazy anonymous mapping consumes address space but no
+// physical pages until touched.
+
+TEST(lazy_anon, lazy_map_reserves_without_pages) {
+    mm::mm_context* mm_ctx = mm::mm_context_create();
+    ASSERT_NOT_NULL(mm_ctx);
+
+    uint64_t before = pmm::free_page_count();
+    uintptr_t addr = 0;
+    ASSERT_EQ(mm::mm_context_map_anonymous(
+        mm_ctx, 0, 16 * PAGE,
+        mm::MM_PROT_READ | mm::MM_PROT_WRITE, LAZY_ANON, &addr
+    ), mm::MM_CTX_OK);
+    EXPECT_NE(addr, static_cast<uintptr_t>(0));
+    EXPECT_EQ(pmm::free_page_count(), before);
+    EXPECT_EQ(paging::get_physical(addr, mm_ctx->pt_root),
+              static_cast<pmm::phys_addr_t>(0));
+
+    mm::mm_context_release(mm_ctx);
+}
+
+// --- fault_populates_lazy_page ---
+// Proves: a demand fault on a lazy anonymous page allocates, zeroes,
+// and maps exactly one page.
+
+TEST(lazy_anon, fault_populates_lazy_page) {
+    mm::mm_context* mm_ctx = mm::mm_context_create();
+    ASSERT_NOT_NULL(mm_ctx);
+
+    uintptr_t addr = 0;
+    ASSERT_EQ(mm::mm_context_map_anonymous(
+        mm_ctx, 0, 4 * PAGE,
+        mm::MM_PROT_READ | mm::MM_PROT_WRITE, LAZY_ANON, &addr
+    ), mm::MM_CTX_OK);
+
+    EXPECT_TRUE(mm::handle_user_pf(mm_ctx, addr + PAGE + 128, 0));
+
+    pmm::phys_addr_t phys = paging::get_physical(addr + PAGE, mm_ctx->pt_root);
+    ASSERT_NE(phys, static_cast<pmm::phys_addr_t>(0));
+
+    const uint8_t* data =
+        static_cast<const uint8_t*>(paging::phys_to_virt(phys));
+    bool all_zero = true;
+    for (size_t i = 0; i < PAGE; i++) {
+        if (data[i] != 0) {
+            all_zero = false;
+            break;
+        }
+    }
+    EXPECT_TRUE(all_zero);
+
+    // Neighboring pages stay absent
+    EXPECT_EQ(paging::get_physical(addr, mm_ctx->pt_root),
+              static_cast<pmm::phys_addr_t>(0));
+    EXPECT_EQ(paging::get_physical(addr + 2 * PAGE, mm_ctx->pt_root),
+              static_cast<pmm::phys_addr_t>(0));
+
+    mm::mm_context_release(mm_ctx);
+}
+
+// --- prot_none_reservation_never_faults_in ---
+// Proves: a no-access reservation refuses demand faults until a later
+// mprotect grants access, then faults in with the new protection.
+
+TEST(lazy_anon, prot_none_reservation_never_faults_in) {
+    mm::mm_context* mm_ctx = mm::mm_context_create();
+    ASSERT_NOT_NULL(mm_ctx);
+
+    uintptr_t addr = 0;
+    ASSERT_EQ(mm::mm_context_map_anonymous(
+        mm_ctx, 0, 8 * PAGE, 0, LAZY_ANON, &addr
+    ), mm::MM_CTX_OK);
+
+    EXPECT_FALSE(mm::handle_user_pf(mm_ctx, addr, 0));
+    EXPECT_EQ(paging::get_physical(addr, mm_ctx->pt_root),
+              static_cast<pmm::phys_addr_t>(0));
+
+    // Commit part of the reservation, reserve-then-commit style
+    ASSERT_EQ(mm::mm_context_mprotect(
+        mm_ctx, addr, 2 * PAGE, mm::MM_PROT_READ | mm::MM_PROT_WRITE
+    ), mm::MM_CTX_OK);
+
+    EXPECT_TRUE(mm::handle_user_pf(mm_ctx, addr, 0));
+    EXPECT_NE(paging::get_physical(addr, mm_ctx->pt_root),
+              static_cast<pmm::phys_addr_t>(0));
+
+    // The uncommitted tail still refuses faults
+    EXPECT_FALSE(mm::handle_user_pf(mm_ctx, addr + 4 * PAGE, 0));
+
+    mm::mm_context_release(mm_ctx);
+}
+
+// --- access_type_must_match_region_protection ---
+// Proves: a fault whose access type the region forbids is rejected
+// before any physical page is committed.
+
+TEST(lazy_anon, access_type_must_match_region_protection) {
+    mm::mm_context* mm_ctx = mm::mm_context_create();
+    ASSERT_NOT_NULL(mm_ctx);
+
+    uintptr_t addr = 0;
+    ASSERT_EQ(mm::mm_context_map_anonymous(
+        mm_ctx, 0, 2 * PAGE, mm::MM_PROT_READ, LAZY_ANON, &addr
+    ), mm::MM_CTX_OK);
+
+    // Writes and instruction fetches on a read-only region commit nothing
+    EXPECT_FALSE(mm::handle_user_pf(mm_ctx, addr, mm::PF_FLAG_WRITE));
+    EXPECT_FALSE(mm::handle_user_pf(mm_ctx, addr, mm::PF_FLAG_INSTRUCTION));
+    EXPECT_EQ(paging::get_physical(addr, mm_ctx->pt_root),
+              static_cast<pmm::phys_addr_t>(0));
+
+    // A plain read faults in as usual
+    EXPECT_TRUE(mm::handle_user_pf(mm_ctx, addr, 0));
+    EXPECT_NE(paging::get_physical(addr, mm_ctx->pt_root),
+              static_cast<pmm::phys_addr_t>(0));
+
+    mm::mm_context_release(mm_ctx);
+}
+
+// --- mprotect_splits_and_coalesces ---
+// Proves: protecting the middle of a mapping splits the VMA and
+// restoring the protection coalesces it back into one.
+
+static int count_vmas(mm::mm_context* mm_ctx) {
+    int count = 0;
+    mm::vma* cur = mm_ctx->vmas.min();
+    while (cur) {
+        count++;
+        cur = mm_ctx->vmas.next(*cur);
+    }
+    return count;
+}
+
+TEST(lazy_anon, mprotect_splits_and_coalesces) {
+    mm::mm_context* mm_ctx = mm::mm_context_create();
+    ASSERT_NOT_NULL(mm_ctx);
+
+    uintptr_t addr = 0;
+    ASSERT_EQ(mm::mm_context_map_anonymous(
+        mm_ctx, 0, 4 * PAGE,
+        mm::MM_PROT_READ | mm::MM_PROT_WRITE, LAZY_ANON, &addr
+    ), mm::MM_CTX_OK);
+    int base_count = count_vmas(mm_ctx);
+
+    ASSERT_EQ(mm::mm_context_mprotect(
+        mm_ctx, addr + PAGE, 2 * PAGE, mm::MM_PROT_READ
+    ), mm::MM_CTX_OK);
+    EXPECT_EQ(count_vmas(mm_ctx), base_count + 2);
+
+    ASSERT_EQ(mm::mm_context_mprotect(
+        mm_ctx, addr + PAGE, 2 * PAGE,
+        mm::MM_PROT_READ | mm::MM_PROT_WRITE
+    ), mm::MM_CTX_OK);
+    EXPECT_EQ(count_vmas(mm_ctx), base_count);
+
+    mm::mm_context_release(mm_ctx);
+}
+
+// --- mprotect_changes_present_pages ---
+// Proves: protection changes apply to already-faulted pages and to
+// pages faulted in afterward.
+
+TEST(lazy_anon, mprotect_changes_present_pages) {
+    mm::mm_context* mm_ctx = mm::mm_context_create();
+    ASSERT_NOT_NULL(mm_ctx);
+
+    uintptr_t addr = 0;
+    ASSERT_EQ(mm::mm_context_map_anonymous(
+        mm_ctx, 0, 2 * PAGE,
+        mm::MM_PROT_READ | mm::MM_PROT_WRITE, LAZY_ANON, &addr
+    ), mm::MM_CTX_OK);
+
+    // One page present, one still absent, then flip both read-only
+    EXPECT_TRUE(mm::handle_user_pf(mm_ctx, addr, 0));
+    ASSERT_EQ(mm::mm_context_mprotect(
+        mm_ctx, addr, 2 * PAGE, mm::MM_PROT_READ
+    ), mm::MM_CTX_OK);
+
+    EXPECT_TRUE(mm::handle_user_pf(mm_ctx, addr + PAGE, 0));
+    EXPECT_NE(paging::get_physical(addr + PAGE, mm_ctx->pt_root),
+              static_cast<pmm::phys_addr_t>(0));
+
+    mm::mm_context_release(mm_ctx);
+}
+
+// --- partial_munmap_punches_hole ---
+// Proves: unmapping the middle of a lazy reservation leaves both ends
+// faultable and the hole dead.
+
+TEST(lazy_anon, partial_munmap_punches_hole) {
+    mm::mm_context* mm_ctx = mm::mm_context_create();
+    ASSERT_NOT_NULL(mm_ctx);
+
+    uintptr_t addr = 0;
+    ASSERT_EQ(mm::mm_context_map_anonymous(
+        mm_ctx, 0, 6 * PAGE,
+        mm::MM_PROT_READ | mm::MM_PROT_WRITE, LAZY_ANON, &addr
+    ), mm::MM_CTX_OK);
+
+    ASSERT_EQ(mm::mm_context_unmap(mm_ctx, addr + 2 * PAGE, 2 * PAGE),
+              mm::MM_CTX_OK);
+
+    EXPECT_TRUE(mm::handle_user_pf(mm_ctx, addr, 0));
+    EXPECT_TRUE(mm::handle_user_pf(mm_ctx, addr + 5 * PAGE, 0));
+    EXPECT_FALSE(mm::handle_user_pf(mm_ctx, addr + 3 * PAGE, 0));
+
+    mm::mm_context_release(mm_ctx);
+}
+
+// --- present_fault_is_fatal ---
+// Proves: faults on present pages, which are protection violations,
+// are never resolved by demand paging.
+
+TEST(lazy_anon, present_fault_is_fatal) {
+    mm::mm_context* mm_ctx = mm::mm_context_create();
+    ASSERT_NOT_NULL(mm_ctx);
+
+    uintptr_t addr = 0;
+    ASSERT_EQ(mm::mm_context_map_anonymous(
+        mm_ctx, 0, PAGE,
+        mm::MM_PROT_READ | mm::MM_PROT_WRITE, LAZY_ANON, &addr
+    ), mm::MM_CTX_OK);
+
+    EXPECT_TRUE(mm::handle_user_pf(mm_ctx, addr, 0));
+    EXPECT_FALSE(mm::handle_user_pf(mm_ctx, addr, mm::PF_FLAG_PRESENT));
+
+    mm::mm_context_release(mm_ctx);
+}


### PR DESCRIPTION
## Summary
- Anonymous private mmaps are now demand-paged the same way stacks are: pages populate on first fault, faults on PROT_NONE regions are rejected, and mprotect skips non-present pages so protection changes apply at fault-in time. Large virtual address reservations no longer pay eager allocation costs.
- mmap accepts MAP_NORESERVE as a no-op: anonymous mappings are lazily populated and there is no swap or commit accounting to opt out of. Rejecting the flag made V8's first PROT_NONE reservation fail, which it reports as fatal out-of-memory.
- Also lands the agent workflow rules and the QEMU testing skill that drive the verification loops for this and future stacks.

Made with [Cursor](https://cursor.com)