### PR TITLE
fix(signals): delivered SIGTRAP and SIGFPE for user debug and FP traps

### DIFF
--- a/kernel/arch/aarch64/trap/trap.cpp
+++ b/kernel/arch/aarch64/trap/trap.cpp
@@ -56,8 +56,8 @@ static inline int ec_to_signal(uint8_t ec) {
         case aarch64::EC_DATA_ABORT_LOWER:
         case aarch64::EC_INST_ABORT_LOWER:
         case aarch64::EC_SP_ALIGN:           return 11;  // SIGSEGV
-        case aarch64::EC_UNKNOWN:
-        case aarch64::EC_BRK_A64:            return 4;   // SIGILL
+        case aarch64::EC_UNKNOWN:            return 4;   // SIGILL
+        case aarch64::EC_BRK_A64:            return 5;   // SIGTRAP
         case aarch64::EC_FP_A64:             return 8;   // SIGFPE
         case aarch64::EC_PC_ALIGN:           return 7;   // SIGBUS
         default:                             return 11;  // SIGSEGV fallback

--- a/kernel/arch/x86_64/trap/trap.cpp
+++ b/kernel/arch/x86_64/trap/trap.cpp
@@ -34,7 +34,11 @@ static inline int vector_to_signal(uint64_t vec) {
         case x86::EXC_BOUND_RANGE:        return 11;  // SIGSEGV
         case x86::EXC_INVALID_OPCODE:     return 4;   // SIGILL
         case x86::EXC_DIVIDE_ERROR:
-        case x86::EXC_OVERFLOW:           return 8;   // SIGFPE
+        case x86::EXC_OVERFLOW:
+        case x86::EXC_X87_FPU:
+        case x86::EXC_SIMD_FP:            return 8;   // SIGFPE
+        case x86::EXC_DEBUG:
+        case x86::EXC_BREAKPOINT:         return 5;   // SIGTRAP
         case x86::EXC_ALIGNMENT_CHECK:    return 7;   // SIGBUS
         default:                          return 11;  // SIGSEGV fallback
     }
@@ -117,7 +121,11 @@ extern "C" __PRIVILEGED_CODE void stlx_x86_64_trap_handler(x86::trap_frame* tf) 
         tf->vector == x86::EXC_OVERFLOW ||
         tf->vector == x86::EXC_BOUND_RANGE ||
         tf->vector == x86::EXC_STACK_FAULT ||
-        tf->vector == x86::EXC_ALIGNMENT_CHECK)
+        tf->vector == x86::EXC_ALIGNMENT_CHECK ||
+        tf->vector == x86::EXC_DEBUG ||
+        tf->vector == x86::EXC_BREAKPOINT ||
+        tf->vector == x86::EXC_X87_FPU ||
+        tf->vector == x86::EXC_SIMD_FP)
     ) {
         signals::die_from_signal(static_cast<uint32_t>(vector_to_signal(tf->vector)));
     }

--- a/userland/apps/sigtest/src/sigtest.c
+++ b/userland/apps/sigtest/src/sigtest.c
@@ -131,6 +131,16 @@ static int pipe_victim_child(void) {
     return 1; /* only reached if the signal never fired */
 }
 
+/* Child mode: a breakpoint trap must die by default SIGTRAP */
+static int trap_victim_child(void) {
+#if defined(__x86_64__)
+    __asm__ volatile("int3");
+#elif defined(__aarch64__)
+    __asm__ volatile("brk #0");
+#endif
+    return 1; /* only reached if the trap never fired */
+}
+
 static volatile sig_atomic_t eintr_handler_ran = 0;
 
 static void eintr_handler(int sig) {
@@ -431,9 +441,27 @@ static void test_sigpipe_dispositions(void) {
           STLX_WIFSIGNALED(status) && STLX_WTERMSIG(status) == SIGPIPE);
 }
 
+/* A breakpoint trap must kill the child with SIGTRAP, not the kernel */
+static void test_trap_default_kills(void) {
+    static const char* args[] = { "--trap-victim", NULL };
+    int h = proc_create("/bin/sigtest", args);
+    if (h < 0) {
+        printf("  SKIP: self exec unavailable\n");
+        return;
+    }
+    proc_start(h);
+    int status = 0;
+    proc_wait(h, &status);
+    check("default SIGTRAP kills a trapping child",
+          STLX_WIFSIGNALED(status) && STLX_WTERMSIG(status) == SIGTRAP);
+}
+
 int main(int argc, char** argv) {
     if (argc >= 2 && strcmp(argv[1], "--pipe-victim") == 0) {
         return pipe_victim_child();
+    }
+    if (argc >= 2 && strcmp(argv[1], "--trap-victim") == 0) {
+        return trap_victim_child();
     }
 
     setvbuf(stdout, NULL, _IONBF, 0);
@@ -448,6 +476,7 @@ int main(int argc, char** argv) {
     test_poll_eintr_despite_restart();
     test_async_compute_delivery();
     test_sigpipe_dispositions();
+    test_trap_default_kills();
 
     printf("sigtest: %d passed, %d failed\n", passed, failed);
     return failed > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary
- Breakpoint, single-step, x87, and SIMD exceptions from user code fell through the fault-to-signal mapping and panicked the kernel, so any process could bring the whole system down with a single int3 instruction (found live when a V8 fatal check trapped). These vectors now die by signal like every other user-mode fault: SIGTRAP for debug/breakpoint traps, SIGFPE for floating-point exceptions.
- aarch64's brk instruction previously mapped to SIGILL; it now delivers SIGTRAP so both architectures report the same termination signal.
- sigtest gains a trap-victim case proving a trapping child dies by SIGTRAP while the kernel keeps running (verified live: 24/24 passing, previously a kernel panic).

Made with [Cursor](https://cursor.com)