### PR TITLE
feat(sync): added atomic<T> and atomic_ref<T> wrapper primitives over raw atomic builtins

### DIFF
--- a/kernel/rc/ref_counted.h
+++ b/kernel/rc/ref_counted.h
@@ -3,6 +3,7 @@
 
 #include "common/types.h"
 #include "common/logging.h"
+#include "sync/atomic.h"
 
 namespace rc {
 
@@ -34,7 +35,7 @@ public:
      * Saturates at REFCOUNT_SATURATED instead of wrapping.
      */
     void add_ref() const {
-        uint32_t cur = __atomic_load_n(&m_refcount, __ATOMIC_RELAXED);
+        uint32_t cur = m_refcount.load_relaxed();
 
         if (cur == REFCOUNT_POISON) {
             log::fatal("rc: add_ref on poisoned object %p", this);
@@ -47,7 +48,7 @@ public:
             return;
         }
 
-        __atomic_fetch_add(&m_refcount, 1, __ATOMIC_RELAXED);
+        m_refcount.fetch_add_relaxed(1);
     }
 
     /**
@@ -56,20 +57,21 @@ public:
      * @return true if a reference was acquired, false if the object is dead.
      */
     [[nodiscard]] bool try_add_ref() const {
-        uint32_t expected = __atomic_load_n(&m_refcount, __ATOMIC_RELAXED);
+        uint32_t expected = m_refcount.load_relaxed();
         for (;;) {
             if (expected == 0) {
                 return false;
             }
+
             if (expected == REFCOUNT_POISON) {
                 return false;
             }
+
             if (expected >= REFCOUNT_SATURATED) {
                 return true;
             }
 
-            if (__atomic_compare_exchange_n(&m_refcount, &expected, expected + 1,
-                                            true, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)) {
+            if (m_refcount.cmpxchg_weak_acquire(expected, expected + 1)) {
                 return true;
             }
         }
@@ -84,21 +86,23 @@ public:
      * destruction.
      */
     [[nodiscard]] bool release() const {
-        uint32_t old = __atomic_fetch_sub(&m_refcount, 1, __ATOMIC_RELEASE);
-
+        uint32_t old = m_refcount.fetch_sub_release(1);
         if (old == REFCOUNT_POISON) {
             log::fatal("rc: release on poisoned object %p", this);
         }
+
         if (old == 0) {
             log::fatal("rc: release underflow on %p", this);
         }
+
         if (old >= REFCOUNT_SATURATED) {
-            __atomic_store_n(&m_refcount, REFCOUNT_SATURATED, __ATOMIC_RELAXED);
+            m_refcount.store_relaxed(REFCOUNT_SATURATED);
             return false;
         }
+
         if (old == 1) {
-            __atomic_thread_fence(__ATOMIC_ACQUIRE);
-            __atomic_store_n(&m_refcount, REFCOUNT_POISON, __ATOMIC_RELAXED);
+            sync::atomic_fence_acquire();
+            m_refcount.store_relaxed(REFCOUNT_POISON);
             return true;
         }
 
@@ -109,15 +113,15 @@ public:
      * Read the current refcount (relaxed load, for debugging only).
      */
     [[nodiscard]] uint32_t ref_count() const {
-        return __atomic_load_n(&m_refcount, __ATOMIC_RELAXED);
+        return m_refcount.load_relaxed();
     }
 
 protected:
-    ref_counted() : m_refcount(1) {}
+    ref_counted() : m_refcount{1} {}
     ~ref_counted() = default;
 
 private:
-    mutable uint32_t m_refcount;
+    mutable sync::atomic<uint32_t> m_refcount;
 };
 
 } // namespace rc

--- a/kernel/sync/atomic.h
+++ b/kernel/sync/atomic.h
@@ -1,0 +1,325 @@
+#ifndef STELLUX_SYNC_ATOMIC_H
+#define STELLUX_SYNC_ATOMIC_H
+
+namespace sync {
+
+template<typename T>
+inline constexpr bool is_lock_free_atomic_value =
+    (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8) &&
+    (__is_integral(T) || __is_enum(T) || __is_pointer(T)) &&
+    __atomic_always_lock_free(sizeof(T), nullptr);
+
+template<typename T>
+inline constexpr bool is_atomic_arith = __is_integral(T) && !__is_same(T, bool);
+
+namespace atomic_detail {
+
+template<typename T, int order>
+[[nodiscard]] inline T load(const T* p) {
+    return __atomic_load_n(p, order);
+}
+
+template<typename T, int order>
+inline void store(T* p, T v) {
+    __atomic_store_n(p, v, order);
+}
+
+template<typename T, int order>
+[[nodiscard]] inline T exchange(T* p, T v) {
+    return __atomic_exchange_n(p, v, order);
+}
+
+template<typename T, int order>
+inline T fetch_add(T* p, T v) {
+    return __atomic_fetch_add(p, v, order);
+}
+
+template<typename T, int order>
+inline T fetch_sub(T* p, T v) {
+    return __atomic_fetch_sub(p, v, order);
+}
+
+template<typename T, int order>
+inline T fetch_and(T* p, T v) {
+    return __atomic_fetch_and(p, v, order);
+}
+
+template<typename T, int order>
+inline T fetch_or(T* p, T v) {
+    return __atomic_fetch_or(p, v, order);
+}
+
+template<typename T, int order>
+inline T fetch_xor(T* p, T v) {
+    return __atomic_fetch_xor(p, v, order);
+}
+
+template<typename T, int success_order, bool weak>
+[[nodiscard]] inline bool cmpxchg(T* p, T& expected, T desired) {
+    return __atomic_compare_exchange_n(
+        p, &expected, desired, weak, success_order, __ATOMIC_RELAXED);
+}
+
+/**
+ * @brief Shared atomic operations. self_t provides addr().
+ */
+template<typename T, typename self_t>
+class atomic_ops {
+    T* ptr() const {
+        return static_cast<const self_t*>(this)->addr();
+    }
+
+public:
+    [[nodiscard]] T load_relaxed() const {
+        return load<T, __ATOMIC_RELAXED>(ptr());
+    }
+
+    [[nodiscard]] T load_acquire() const {
+        return load<T, __ATOMIC_ACQUIRE>(ptr());
+    }
+
+    void store_relaxed(T v) const {
+        store<T, __ATOMIC_RELAXED>(ptr(), v);
+    }
+
+    void store_release(T v) const {
+        store<T, __ATOMIC_RELEASE>(ptr(), v);
+    }
+
+    [[nodiscard]] T exchange_relaxed(T v) const {
+        return exchange<T, __ATOMIC_RELAXED>(ptr(), v);
+    }
+
+    [[nodiscard]] T exchange_acquire(T v) const {
+        return exchange<T, __ATOMIC_ACQUIRE>(ptr(), v);
+    }
+
+    [[nodiscard]] T exchange_release(T v) const {
+        return exchange<T, __ATOMIC_RELEASE>(ptr(), v);
+    }
+
+    [[nodiscard]] T exchange_acq_rel(T v) const {
+        return exchange<T, __ATOMIC_ACQ_REL>(ptr(), v);
+    }
+
+    T fetch_add_relaxed(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_add<T, __ATOMIC_RELAXED>(ptr(), v);
+    }
+
+    T fetch_add_acquire(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_add<T, __ATOMIC_ACQUIRE>(ptr(), v);
+    }
+
+    T fetch_add_release(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_add<T, __ATOMIC_RELEASE>(ptr(), v);
+    }
+
+    T fetch_add_acq_rel(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_add<T, __ATOMIC_ACQ_REL>(ptr(), v);
+    }
+
+    T fetch_sub_relaxed(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_sub<T, __ATOMIC_RELAXED>(ptr(), v);
+    }
+
+    T fetch_sub_acquire(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_sub<T, __ATOMIC_ACQUIRE>(ptr(), v);
+    }
+
+    T fetch_sub_release(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_sub<T, __ATOMIC_RELEASE>(ptr(), v);
+    }
+
+    T fetch_sub_acq_rel(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_sub<T, __ATOMIC_ACQ_REL>(ptr(), v);
+    }
+
+    T fetch_and_relaxed(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_and<T, __ATOMIC_RELAXED>(ptr(), v);
+    }
+
+    T fetch_and_acquire(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_and<T, __ATOMIC_ACQUIRE>(ptr(), v);
+    }
+
+    T fetch_and_release(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_and<T, __ATOMIC_RELEASE>(ptr(), v);
+    }
+
+    T fetch_and_acq_rel(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_and<T, __ATOMIC_ACQ_REL>(ptr(), v);
+    }
+
+    T fetch_or_relaxed(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_or<T, __ATOMIC_RELAXED>(ptr(), v);
+    }
+
+    T fetch_or_acquire(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_or<T, __ATOMIC_ACQUIRE>(ptr(), v);
+    }
+
+    T fetch_or_release(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_or<T, __ATOMIC_RELEASE>(ptr(), v);
+    }
+
+    T fetch_or_acq_rel(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_or<T, __ATOMIC_ACQ_REL>(ptr(), v);
+    }
+
+    T fetch_xor_relaxed(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_xor<T, __ATOMIC_RELAXED>(ptr(), v);
+    }
+
+    T fetch_xor_acquire(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_xor<T, __ATOMIC_ACQUIRE>(ptr(), v);
+    }
+
+    T fetch_xor_release(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_xor<T, __ATOMIC_RELEASE>(ptr(), v);
+    }
+
+    T fetch_xor_acq_rel(T v) const
+        requires (is_atomic_arith<T>) {
+        return fetch_xor<T, __ATOMIC_ACQ_REL>(ptr(), v);
+    }
+
+    [[nodiscard]] bool cmpxchg_weak_relaxed(T& expected, T desired) const {
+        return cmpxchg<T, __ATOMIC_RELAXED, true>(ptr(), expected, desired);
+    }
+
+    [[nodiscard]] bool cmpxchg_weak_acquire(T& expected, T desired) const {
+        return cmpxchg<T, __ATOMIC_ACQUIRE, true>(ptr(), expected, desired);
+    }
+
+    [[nodiscard]] bool cmpxchg_weak_release(T& expected, T desired) const {
+        return cmpxchg<T, __ATOMIC_RELEASE, true>(ptr(), expected, desired);
+    }
+
+    [[nodiscard]] bool cmpxchg_weak_acq_rel(T& expected, T desired) const {
+        return cmpxchg<T, __ATOMIC_ACQ_REL, true>(ptr(), expected, desired);
+    }
+
+    [[nodiscard]] bool cmpxchg_strong_relaxed(T& expected, T desired) const {
+        return cmpxchg<T, __ATOMIC_RELAXED, false>(ptr(), expected, desired);
+    }
+
+    [[nodiscard]] bool cmpxchg_strong_acquire(T& expected, T desired) const {
+        return cmpxchg<T, __ATOMIC_ACQUIRE, false>(ptr(), expected, desired);
+    }
+
+    [[nodiscard]] bool cmpxchg_strong_release(T& expected, T desired) const {
+        return cmpxchg<T, __ATOMIC_RELEASE, false>(ptr(), expected, desired);
+    }
+
+    [[nodiscard]] bool cmpxchg_strong_acq_rel(T& expected, T desired) const {
+        return cmpxchg<T, __ATOMIC_ACQ_REL, false>(ptr(), expected, desired);
+    }
+};
+
+} // namespace atomic_detail
+
+/**
+ * @brief Owned lock free atomic cell.
+ *
+ * Order is part of the method name. CAS failure is always relaxed.
+ * The default constructor zero initializes the value, so a global
+ * atomic still lands in BSS. fetch_* returns the previous value.
+ * T is an integer, enum, or pointer of 1, 2, 4, or 8 bytes and must
+ * be lock free (no libatomic).
+ */
+template<typename T>
+class atomic : public atomic_detail::atomic_ops<T, atomic<T>> {
+    static_assert(is_lock_free_atomic_value<T>,
+                  "atomic<T> needs a lock free 1, 2, 4, or 8 byte integer, enum, or pointer");
+
+public:
+    atomic() = default;
+    explicit constexpr atomic(T value) : m_value(value) {}
+
+    atomic(const atomic&) = delete;
+    atomic& operator=(const atomic&) = delete;
+    atomic(atomic&&) = delete;
+    atomic& operator=(atomic&&) = delete;
+
+private:
+    friend class atomic_detail::atomic_ops<T, atomic<T>>;
+
+    T* addr() const {
+        static_assert(sizeof(atomic) == sizeof(T));
+        static_assert(alignof(atomic) == alignof(T));
+
+        return &m_value;
+    }
+
+    mutable T m_value{};
+};
+
+/**
+ * @brief Borrowed atomic view of existing storage.
+ *
+ * Use for storage that must stay a plain scalar, such as futex words
+ * in user memory or fields of structs that must remain copyable.
+ * The referenced object must outlive the view and be naturally aligned.
+ * Copying the view is fine. Assigning a view is deleted so a store is
+ * never written as operator=.
+ */
+template<typename T>
+class atomic_ref : public atomic_detail::atomic_ops<T, atomic_ref<T>> {
+    static_assert(is_lock_free_atomic_value<T>,
+                  "atomic_ref<T> needs a lock free 1, 2, 4, or 8 byte integer, enum, or pointer");
+
+public:
+    explicit atomic_ref(T& obj) : m_ptr(&obj) {}
+
+    atomic_ref(const atomic_ref&) = default;
+    atomic_ref& operator=(const atomic_ref&) = delete;
+
+private:
+    friend class atomic_detail::atomic_ops<T, atomic_ref<T>>;
+
+    T* addr() const {
+        return m_ptr;
+    }
+
+    T* m_ptr;
+};
+
+/**
+ * @brief Acquire fence pairing with a prior release RMW.
+ *
+ * Call this when a refcount drop observes the last reference, before
+ * destroying the object.
+ */
+inline void atomic_fence_acquire() {
+    __atomic_thread_fence(__ATOMIC_ACQUIRE);
+}
+
+/**
+ * @brief Release fence pairing with a later acquire load or RMW.
+ */
+inline void atomic_fence_release() {
+    __atomic_thread_fence(__ATOMIC_RELEASE);
+}
+
+} // namespace sync
+
+#endif // STELLUX_SYNC_ATOMIC_H

--- a/kernel/sync/futex.cpp
+++ b/kernel/sync/futex.cpp
@@ -1,4 +1,5 @@
 #include "sync/futex.h"
+#include "sync/atomic.h"
 #include "sync/spinlock.h"
 #include "sched/sched.h"
 #include "sched/task.h"
@@ -65,9 +66,8 @@ __PRIVILEGED_CODE int32_t futex_wait(uintptr_t uaddr, uint32_t expected,
     // Re-read the futex word under the bucket lock. The page is already
     // validated/faulted by the copy_from_user above, so a direct read
     // is safe here. This atomic check-and-enqueue prevents lost wakeups.
-    uint32_t current_val;
-    string::memcpy(&current_val, reinterpret_cast<const void*>(uaddr),
-                   sizeof(uint32_t));
+    uint32_t* word = reinterpret_cast<uint32_t*>(uaddr);
+    uint32_t current_val = atomic_ref<uint32_t>(*word).load_relaxed();
 
     if (current_val != expected) {
         spin_unlock_irqrestore(bucket->lock, irq);

--- a/kernel/sync/spinlock.h
+++ b/kernel/sync/spinlock.h
@@ -3,6 +3,7 @@
 
 #include "common/types.h"
 #include "hw/cpu.h"
+#include "sync/atomic.h"
 
 namespace sync {
 
@@ -18,14 +19,16 @@ struct irq_state {
 };
 
 inline void spin_lock(spinlock& lock) {
-    uint16_t ticket = __atomic_fetch_add(&lock.next_ticket, 1, __ATOMIC_RELAXED);
-    while (__atomic_load_n(&lock.now_serving, __ATOMIC_ACQUIRE) != ticket) {
+    uint16_t ticket = atomic_ref<uint16_t>{lock.next_ticket}.fetch_add_relaxed(1);
+
+    atomic_ref<uint16_t> serving{lock.now_serving};
+    while (serving.load_acquire() != ticket) {
         cpu::relax();
     }
 }
 
 inline void spin_unlock(spinlock& lock) {
-    __atomic_add_fetch(&lock.now_serving, 1, __ATOMIC_RELEASE);
+    atomic_ref<uint16_t>{lock.now_serving}.fetch_add_release(1);
     cpu::send_event();
 }
 


### PR DESCRIPTION
## Summary
- Atomic access was spelled as raw `__atomic_*` builtins with a memory order argument repeated at every call site, making orderings easy to get wrong and overall looked messy as hell.
- `sync::atomic<T>` (owned, non-copyable) and `sync::atomic_ref<T>` (borrowed view of plain storage) encode the ordering in the method name and reject non-lock-free types at compile time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes memory-order spelling and refcount/futex/spinlock synchronization paths; semantics are intended to match prior builtins but mistakes here affect core locking and object lifetime.
> 
> **Overview**
> Introduces **`sync::atomic<T>`** and **`sync::atomic_ref<T>`** as typed wrappers over GCC `__atomic_*` builtins, with memory order encoded in method names (`load_acquire`, `fetch_sub_release`, etc.) and **compile-time lock-free** requirements for 1/2/4/8-byte integers, enums, and pointers. **`atomic_fence_acquire`** / **`atomic_fence_release`** replace ad-hoc thread fences.
> 
> **`ref_counted`** stores the refcount in **`sync::atomic<uint32_t>`** instead of a plain `uint32_t` with raw builtins; **`try_add_ref`** now treats **`REFCOUNT_POISON`** like zero (returns false), and the last-ref path uses **`sync::atomic_fence_acquire`** before poisoning.
> 
> **Ticket spinlocks** in **`spinlock.h`** use **`atomic_ref<uint16_t>`** on `next_ticket` and `now_serving` with the same relaxed/acquire/release pattern as before.
> 
> **`futex_wait`** re-reads the user futex word under the bucket lock via **`atomic_ref<uint32_t>::load_relaxed()`** instead of **`memcpy`**, keeping the atomic check-and-enqueue behavior while spelling the read as an atomic load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a5eb48a34974cad94684ee1b68535fe17007684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->