### PR TITLE
chore(sync): migrated kernel atomics to the typed atomic wrappers

### DIFF
--- a/kernel/arch/aarch64/clock/clock.cpp
+++ b/kernel/arch/aarch64/clock/clock.cpp
@@ -2,13 +2,14 @@
 #include "hw/hwtimer.h"
 #include "hw/rtc.h"
 #include "common/logging.h"
+#include "sync/atomic.h"
 
 namespace clock {
 
 static uint64_t g_cnt_freq;
 static uint64_t g_mult;
 static uint32_t g_shift;
-static bool g_calibrated;
+static sync::atomic<bool> g_calibrated;
 static uint64_t g_boot_realtime_ns;
 
 constexpr uint64_t NS_PER_SEC = 1000000000ULL;
@@ -60,7 +61,7 @@ __PRIVILEGED_CODE int32_t init() {
     compute_mult_shift(g_cnt_freq, &g_mult, &g_shift);
     g_boot_realtime_ns = rtc::boot_unix_ns();
     enable_el0_counter_access();
-    __atomic_store_n(&g_calibrated, true, __ATOMIC_RELEASE);
+    g_calibrated.store_release(true);
 
     log::info("clock: CNTFRQ=%lu Hz, mult=%lu shift=%u",
               g_cnt_freq, g_mult, g_shift);
@@ -73,14 +74,14 @@ __PRIVILEGED_CODE int32_t init() {
  */
 __PRIVILEGED_CODE int32_t init_ap() {
     enable_el0_counter_access();
-    if (!__atomic_load_n(&g_calibrated, __ATOMIC_ACQUIRE)) {
+    if (!g_calibrated.load_acquire()) {
         return ERR;
     }
     return OK;
 }
 
 uint64_t now_ns() {
-    if (!__atomic_load_n(&g_calibrated, __ATOMIC_ACQUIRE)) {
+    if (!g_calibrated.load_acquire()) {
         return 0;
     }
     uint64_t ticks = hwtimer::read_cntvct();

--- a/kernel/arch/aarch64/sched/sched.cpp
+++ b/kernel/arch/aarch64/sched/sched.cpp
@@ -186,7 +186,7 @@ __PRIVILEGED_CODE void on_yield(aarch64::trap_frame* tf) {
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();
 
-    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state != TASK_STATE_DEAD) {
+    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state.load_relaxed() != TASK_STATE_DEAD) {
         uint32_t fsig = signals::fatal_pending(prev);
         if (fsig) {
             signals::die_from_signal(fsig);
@@ -199,7 +199,7 @@ __PRIVILEGED_CODE void on_yield(aarch64::trap_frame* tf) {
     }
 
     next->exec.cpu = percpu::current_cpu_id();
-    __atomic_store_n(&next->exec.on_cpu, 1, __ATOMIC_RELAXED);
+    sync::atomic_ref<uint32_t>{next->exec.on_cpu}.store_relaxed(1);
 
     fpu::save(&prev->exec.fpu_ctx);
     fpu::restore(&next->exec.fpu_ctx);
@@ -234,7 +234,7 @@ __PRIVILEGED_CODE void on_tick(aarch64::trap_frame* tf) {
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();
 
-    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state != TASK_STATE_DEAD) {
+    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state.load_relaxed() != TASK_STATE_DEAD) {
         uint32_t fsig = signals::fatal_pending(prev);
         if (fsig) {
             signals::die_from_signal(fsig);
@@ -247,7 +247,7 @@ __PRIVILEGED_CODE void on_tick(aarch64::trap_frame* tf) {
     }
 
     next->exec.cpu = percpu::current_cpu_id();
-    __atomic_store_n(&next->exec.on_cpu, 1, __ATOMIC_RELAXED);
+    sync::atomic_ref<uint32_t>{next->exec.on_cpu}.store_relaxed(1);
 
     fpu::save(&prev->exec.fpu_ctx);
     fpu::restore(&next->exec.fpu_ctx);

--- a/kernel/arch/aarch64/signals/delivery.cpp
+++ b/kernel/arch/aarch64/signals/delivery.cpp
@@ -190,7 +190,7 @@ __PRIVILEGED_CODE void deliver_async_signal(sched::task* self,
     // same rule every other delivery site applies
     if (!self || !self->group ||
         (self->exec.flags & sched::TASK_FLAG_ELEVATED) ||
-        self->state == sched::TASK_STATE_DEAD) {
+        self->state.load_relaxed() == sched::TASK_STATE_DEAD) {
         return;
     }
 

--- a/kernel/arch/aarch64/smp/smp.cpp
+++ b/kernel/arch/aarch64/smp/smp.cpp
@@ -187,7 +187,7 @@ extern "C" __PRIVILEGED_CODE void ap_entry(uint64_t logical_id) {
                          kva::tag::privileged_stack,
                          sys_stack_base, sys_stack_top) != vmm::OK) {
         smp::cpu_info* info = smp::get_cpu_info(cpu_id);
-        if (info) __atomic_store_n(&info->state, smp::CPU_OFFLINE, __ATOMIC_RELEASE);
+        if (info) info->state.store_release(smp::CPU_OFFLINE);
         while (true) { asm volatile("wfi"); }
     }
 
@@ -195,7 +195,7 @@ extern "C" __PRIVILEGED_CODE void ap_entry(uint64_t logical_id) {
 
     if (sched::init_ap(cpu_id, my_stack_top, sys_stack_top) != 0) {
         smp::cpu_info* info = smp::get_cpu_info(cpu_id);
-        if (info) __atomic_store_n(&info->state, smp::CPU_OFFLINE, __ATOMIC_RELEASE);
+        if (info) info->state.store_release(smp::CPU_OFFLINE);
         while (true) { asm volatile("wfi"); }
     }
 
@@ -211,7 +211,7 @@ extern "C" __PRIVILEGED_CODE void ap_entry(uint64_t logical_id) {
 
     if (clock::init_ap() != clock::OK || timer::init_ap(100) != timer::OK) {
         smp::cpu_info* info = smp::get_cpu_info(cpu_id);
-        if (info) __atomic_store_n(&info->state, smp::CPU_OFFLINE, __ATOMIC_RELEASE);
+        if (info) info->state.store_release(smp::CPU_OFFLINE);
         while (true) { asm volatile("wfi"); }
     }
 
@@ -220,7 +220,7 @@ extern "C" __PRIVILEGED_CODE void ap_entry(uint64_t logical_id) {
     }
 
     smp::cpu_info* info = smp::get_cpu_info(cpu_id);
-    __atomic_store_n(&info->state, smp::CPU_ONLINE, __ATOMIC_RELEASE);
+    info->state.store_release(smp::CPU_ONLINE);
 
     while (true) { cpu::halt(); }
 }
@@ -243,7 +243,7 @@ __PRIVILEGED_CODE uint32_t smp_enumerate(smp::cpu_info* cpus, uint32_t max) {
 
         cpus[count].logical_id = count;
         cpus[count].hw_id = madt.giccs[i].mpidr;
-        cpus[count].state = smp::CPU_OFFLINE;
+        cpus[count].state.store_relaxed(smp::CPU_OFFLINE);
         cpus[count].is_bsp = (entry_mpidr == current_mpidr);
         count++;
     }
@@ -383,7 +383,7 @@ __PRIVILEGED_CODE int32_t smp_boot_cpu(smp::cpu_info& cpu) {
     uint64_t timeout_ticks = (freq * AP_BOOT_TIMEOUT_MS) / 1000;
 
     while (hwtimer::read_cntpct() - start < timeout_ticks) {
-        if (__atomic_load_n(&cpu.state, __ATOMIC_ACQUIRE) == smp::CPU_ONLINE) {
+        if (cpu.state.load_acquire() == smp::CPU_ONLINE) {
             return smp::OK;
         }
         cpu::relax();

--- a/kernel/arch/aarch64/timer/timer.cpp
+++ b/kernel/arch/aarch64/timer/timer.cpp
@@ -212,7 +212,7 @@ __PRIVILEGED_CODE void schedule_sleep(sched::task* t, uint64_t deadline_ns) {
 }
 
 __PRIVILEGED_CODE void cancel_sleep(sched::task* t) {
-    uint32_t cpu = __atomic_load_n(&t->exec.cpu, __ATOMIC_RELAXED);
+    uint32_t cpu = sync::atomic_ref<uint32_t>{t->exec.cpu}.load_relaxed();
     timer_cpu_state& state = per_cpu_on(cpu_timer_state, cpu);
     sync::irq_state irq = sync::spin_lock_irqsave(state.lock);
     if (t->timer_link.is_linked()) {

--- a/kernel/arch/x86_64/clock/clock.cpp
+++ b/kernel/arch/x86_64/clock/clock.cpp
@@ -6,13 +6,14 @@
 #include "hw/rtc.h"
 #include "hw/cpu_features.h"
 #include "common/logging.h"
+#include "sync/atomic.h"
 
 namespace clock {
 
 static uint64_t g_tsc_freq;
 static uint64_t g_mult;
 static uint32_t g_shift;
-static bool g_calibrated;
+static sync::atomic<bool> g_calibrated;
 static uint64_t g_boot_realtime_ns;
 
 constexpr uint64_t NS_PER_SEC = 1000000000ULL;
@@ -92,7 +93,7 @@ __PRIVILEGED_CODE int32_t init() {
 
     compute_mult_shift(g_tsc_freq, &g_mult, &g_shift);
     g_boot_realtime_ns = rtc::boot_unix_ns();
-    __atomic_store_n(&g_calibrated, true, __ATOMIC_RELEASE);
+    g_calibrated.store_release(true);
 
     log::info("clock: TSC freq=%lu Hz, mult=%lu shift=%u%s",
               g_tsc_freq, g_mult, g_shift,
@@ -105,14 +106,14 @@ __PRIVILEGED_CODE int32_t init() {
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE int32_t init_ap() {
-    if (!__atomic_load_n(&g_calibrated, __ATOMIC_ACQUIRE)) {
+    if (!g_calibrated.load_acquire()) {
         return ERR;
     }
     return OK;
 }
 
 uint64_t now_ns() {
-    if (!__atomic_load_n(&g_calibrated, __ATOMIC_ACQUIRE)) {
+    if (!g_calibrated.load_acquire()) {
         return 0;
     }
     uint64_t ticks = tsc::rdtsc();

--- a/kernel/arch/x86_64/sched/sched.cpp
+++ b/kernel/arch/x86_64/sched/sched.cpp
@@ -174,7 +174,7 @@ __PRIVILEGED_CODE void on_yield(x86::trap_frame* tf) {
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();
 
-    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state != TASK_STATE_DEAD) {
+    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state.load_relaxed() != TASK_STATE_DEAD) {
         uint32_t fsig = signals::fatal_pending(prev);
         if (fsig) {
             signals::die_from_signal(fsig);
@@ -187,7 +187,7 @@ __PRIVILEGED_CODE void on_yield(x86::trap_frame* tf) {
     }
 
     next->exec.cpu = percpu::current_cpu_id();
-    __atomic_store_n(&next->exec.on_cpu, 1, __ATOMIC_RELAXED);
+    sync::atomic_ref<uint32_t>{next->exec.on_cpu}.store_relaxed(1);
 
     fpu::save(&prev->exec.fpu_ctx);
     fpu::restore(&next->exec.fpu_ctx);
@@ -221,7 +221,7 @@ __PRIVILEGED_CODE void on_tick(x86::trap_frame* tf) {
     save_cpu_context(tf, &prev->exec.cpu_ctx);
     prev->exec.tls_base = cpu::read_tls_base();
 
-    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state != TASK_STATE_DEAD) {
+    if (!(prev->exec.flags & TASK_FLAG_KERNEL) && prev->state.load_relaxed() != TASK_STATE_DEAD) {
         uint32_t fsig = signals::fatal_pending(prev);
         if (fsig) {
             signals::die_from_signal(fsig);
@@ -234,7 +234,7 @@ __PRIVILEGED_CODE void on_tick(x86::trap_frame* tf) {
     }
 
     next->exec.cpu = percpu::current_cpu_id();
-    __atomic_store_n(&next->exec.on_cpu, 1, __ATOMIC_RELAXED);
+    sync::atomic_ref<uint32_t>{next->exec.on_cpu}.store_relaxed(1);
 
     fpu::save(&prev->exec.fpu_ctx);
     fpu::restore(&next->exec.fpu_ctx);

--- a/kernel/arch/x86_64/signals/delivery.cpp
+++ b/kernel/arch/x86_64/signals/delivery.cpp
@@ -190,7 +190,7 @@ __PRIVILEGED_CODE int64_t restore_signal_frame(syscall_frame* ctx) {
     if (full) {
         // Publish only after the context is fully staged, the syscall
         // exit consumes it as soon as this handler returns
-        __atomic_store_n(&exec->iret_pending, 1u, __ATOMIC_RELEASE);
+        sync::atomic_ref<uint32_t>{exec->iret_pending}.store_release(1u);
     }
 
     heap::kfree_delete(frame);
@@ -331,7 +331,7 @@ __PRIVILEGED_CODE void deliver_async_signal(sched::task* self,
     // same rule every other delivery site applies
     if (!self || !self->group ||
         (self->exec.flags & sched::TASK_FLAG_ELEVATED) ||
-        self->state == sched::TASK_STATE_DEAD) {
+        self->state.load_relaxed() == sched::TASK_STATE_DEAD) {
         return;
     }
 
@@ -371,7 +371,7 @@ __PRIVILEGED_CODE int64_t arch::deliver_pending_signal(sched::task* self,
                                                        uint64_t syscall_num) {
     // A staged full-register return supersedes the frame, so it no longer
     // describes the resume context, delivery waits for a later boundary
-    if (__atomic_load_n(&self->exec.iret_pending, __ATOMIC_ACQUIRE)) {
+    if (sync::atomic_ref<uint32_t>{self->exec.iret_pending}.load_acquire()) {
         return result;
     }
 

--- a/kernel/arch/x86_64/smp/smp.cpp
+++ b/kernel/arch/x86_64/smp/smp.cpp
@@ -111,14 +111,14 @@ extern "C" __PRIVILEGED_CODE void ap_entry(uint64_t logical_id) {
     if (sched::init_ap(cpu_id, data->stack_top, sys_stack_top) != sched::OK) {
         smp::cpu_info* info = smp::get_cpu_info(cpu_id);
         if (info) {
-            __atomic_store_n(&info->state, smp::CPU_OFFLINE, __ATOMIC_RELEASE);
+            info->state.store_release(smp::CPU_OFFLINE);
         }
         while (true) { asm volatile("cli; hlt"); }
     }
 
     if (clock::init_ap() != clock::OK || timer::init_ap(100) != timer::OK) {
         smp::cpu_info* info = smp::get_cpu_info(cpu_id);
-        if (info) __atomic_store_n(&info->state, smp::CPU_OFFLINE, __ATOMIC_RELEASE);
+        if (info) info->state.store_release(smp::CPU_OFFLINE);
         while (true) { asm volatile("cli; hlt"); }
     }
 
@@ -127,7 +127,7 @@ extern "C" __PRIVILEGED_CODE void ap_entry(uint64_t logical_id) {
     }
 
     smp::cpu_info* info = smp::get_cpu_info(cpu_id);
-    __atomic_store_n(&info->state, smp::CPU_ONLINE, __ATOMIC_RELEASE);
+    info->state.store_release(smp::CPU_ONLINE);
 
     while (true) {
         cpu::halt();
@@ -190,7 +190,7 @@ __PRIVILEGED_CODE uint32_t smp_enumerate(smp::cpu_info* cpus, uint32_t max) {
 
         cpus[count].logical_id = count;
         cpus[count].hw_id = madt.lapics[i].apic_id;
-        cpus[count].state = smp::CPU_OFFLINE;
+        cpus[count].state.store_relaxed(smp::CPU_OFFLINE);
         cpus[count].is_bsp = (madt.lapics[i].apic_id == bsp_apic_id);
         count++;
     }
@@ -288,7 +288,7 @@ __PRIVILEGED_CODE int32_t smp_boot_cpu(smp::cpu_info& cpu) {
     delay::pit_ms(IPI_SIPI_DELAY_MS);
 
     // Check if AP came online
-    if (__atomic_load_n(&cpu.state, __ATOMIC_ACQUIRE) == smp::CPU_ONLINE) {
+    if (cpu.state.load_acquire() == smp::CPU_ONLINE) {
         return smp::OK;
     }
 
@@ -297,7 +297,7 @@ __PRIVILEGED_CODE int32_t smp_boot_cpu(smp::cpu_info& cpu) {
 
     for (uint32_t waited = 0; waited < IPI_TIMEOUT_MS; waited++) {
         delay::pit_ms(1);
-        if (__atomic_load_n(&cpu.state, __ATOMIC_ACQUIRE) == smp::CPU_ONLINE) {
+        if (cpu.state.load_acquire() == smp::CPU_ONLINE) {
             return smp::OK;
         }
     }

--- a/kernel/arch/x86_64/timer/timer.cpp
+++ b/kernel/arch/x86_64/timer/timer.cpp
@@ -278,7 +278,7 @@ __PRIVILEGED_CODE void schedule_sleep(sched::task* t, uint64_t deadline_ns) {
 }
 
 __PRIVILEGED_CODE void cancel_sleep(sched::task* t) {
-    uint32_t cpu = __atomic_load_n(&t->exec.cpu, __ATOMIC_RELAXED);
+    uint32_t cpu = sync::atomic_ref<uint32_t>{t->exec.cpu}.load_relaxed();
     timer_cpu_state& state = per_cpu_on(cpu_timer_state, cpu);
     sync::irq_state irq = sync::spin_lock_irqsave(state.lock);
     if (t->timer_link.is_linked()) {

--- a/kernel/irq/irq_dispatch.cpp
+++ b/kernel/irq/irq_dispatch.cpp
@@ -1,4 +1,5 @@
 #include "irq/irq.h"
+#include "sync/atomic.h"
 #include "sync/spinlock.h"
 #include "dynpriv/dynpriv.h"
 
@@ -29,7 +30,7 @@ __PRIVILEGED_CODE int32_t register_handler(uint32_t irq, irq_handler_fn fn,
         result = ERR_BUSY;
     } else {
         g_irq_table[irq].context = context;
-        __atomic_thread_fence(__ATOMIC_RELEASE);
+        sync::atomic_fence_release();
         g_irq_table[irq].fn = fn;
     }
 
@@ -54,7 +55,7 @@ __PRIVILEGED_CODE bool dispatch(uint32_t irq) {
     }
 
     irq_handler_fn fn = g_irq_table[irq].fn;
-    __atomic_thread_fence(__ATOMIC_ACQUIRE);
+    sync::atomic_fence_acquire();
 
     if (fn) {
         fn(irq, g_irq_table[irq].context);

--- a/kernel/msi/msi.cpp
+++ b/kernel/msi/msi.cpp
@@ -1,13 +1,14 @@
 #include "msi/msi.h"
 #include "arch/arch_msi.h"
+#include "sync/atomic.h"
 #include "sync/spinlock.h"
 #include "common/logging.h"
 
 namespace msi {
 
 struct handler_slot {
-    handler_fn fn;
-    void*      context;
+    sync::atomic<handler_fn> fn;
+    void*                    context;
 };
 
 __PRIVILEGED_BSS static handler_slot g_slots[MAX_VECTORS];
@@ -126,8 +127,7 @@ __PRIVILEGED_CODE int32_t free(uint32_t base, uint32_t count) {
     for (uint32_t i = base; i < base + count; i++) {
         bitmap_clear(i);
         g_slots[i].context = nullptr;
-        __atomic_store_n(&g_slots[i].fn, static_cast<handler_fn>(nullptr),
-                         __ATOMIC_RELEASE);
+        g_slots[i].fn.store_release(nullptr);
     }
 
     return OK;
@@ -144,7 +144,7 @@ __PRIVILEGED_CODE int32_t set_handler(uint32_t vector,
 
     sync::irq_lock_guard guard(g_lock);
     g_slots[vector].context = context;
-    __atomic_store_n(&g_slots[vector].fn, fn, __ATOMIC_RELEASE);
+    g_slots[vector].fn.store_release(fn);
     return OK;
 }
 
@@ -158,8 +158,7 @@ __PRIVILEGED_CODE void clear_handler(uint32_t vector) {
 
     sync::irq_lock_guard guard(g_lock);
     g_slots[vector].context = nullptr;
-    __atomic_store_n(&g_slots[vector].fn, static_cast<handler_fn>(nullptr),
-                     __ATOMIC_RELEASE);
+    g_slots[vector].fn.store_release(nullptr);
 }
 
 /**
@@ -169,7 +168,7 @@ __PRIVILEGED_CODE void dispatch(uint32_t vector) {
     if (vector >= g_capacity) {
         return;
     }
-    handler_fn fn = __atomic_load_n(&g_slots[vector].fn, __ATOMIC_ACQUIRE);
+    handler_fn fn = g_slots[vector].fn.load_acquire();
     if (fn) {
         fn(vector, g_slots[vector].context);
     }

--- a/kernel/net/dhcp.cpp
+++ b/kernel/net/dhcp.cpp
@@ -10,6 +10,7 @@
 #include "sched/sched.h"
 #include "clock/clock.h"
 #include "dynpriv/dynpriv.h"
+#include "sync/atomic.h"
 
 namespace net {
 
@@ -26,8 +27,8 @@ namespace {
 struct dhcp_rx_context {
     uint8_t  buffer[DHCP_PACKET_MAX];
     size_t   length;
-    volatile bool ready;   // set by udp_recv hook, cleared by DHCP poll
-    volatile bool active;  // true while DHCP is waiting for packets
+    sync::atomic<bool> ready;   // set by udp_recv hook, cleared by DHCP poll
+    sync::atomic<bool> active;  // true while DHCP is waiting for packets
 };
 
 } // anonymous namespace
@@ -44,15 +45,15 @@ static dhcp_rx_context g_dhcp_rx = {};
 // interrupt-driven path. NOT __PRIVILEGED_CODE because the buffer
 // is in regular .bss (accessible from both Ring 0 and Ring 3).
 void dhcp_rx_hook(const uint8_t* data, size_t len) {
-    if (!__atomic_load_n(&g_dhcp_rx.active, __ATOMIC_ACQUIRE)) return;
-    if (__atomic_load_n(&g_dhcp_rx.ready, __ATOMIC_ACQUIRE)) return;
+    if (!g_dhcp_rx.active.load_acquire()) return;
+    if (g_dhcp_rx.ready.load_acquire()) return;
 
     size_t copy_len = len < DHCP_PACKET_MAX ? len : DHCP_PACKET_MAX;
     string::memcpy(g_dhcp_rx.buffer, data, copy_len);
     g_dhcp_rx.length = copy_len;
 
     // Write barrier: ensure buffer/length are visible before ready flag
-    __atomic_store_n(&g_dhcp_rx.ready, true, __ATOMIC_RELEASE);
+    g_dhcp_rx.ready.store_release(true);
 }
 
 // Internal helpers
@@ -219,7 +220,7 @@ static bool try_read_dhcp_response(uint8_t* out_buf, size_t buf_size,
     if (!out_buf || !out_len) return false;
 
     // Check ready flag with acquire semantics
-    if (!__atomic_load_n(&g_dhcp_rx.ready, __ATOMIC_ACQUIRE)) {
+    if (!g_dhcp_rx.ready.load_acquire()) {
         return false;
     }
 
@@ -228,7 +229,7 @@ static bool try_read_dhcp_response(uint8_t* out_buf, size_t buf_size,
     *out_len = copy_len;
 
     // Mark as consumed
-    __atomic_store_n(&g_dhcp_rx.ready, false, __ATOMIC_RELEASE);
+    g_dhcp_rx.ready.store_release(false);
 
     return true;
 }
@@ -239,16 +240,16 @@ static bool try_read_dhcp_response(uint8_t* out_buf, size_t buf_size,
  */
 static void activate_rx_hook() {
     g_dhcp_rx.length = 0;
-    __atomic_store_n(&g_dhcp_rx.ready, false, __ATOMIC_RELEASE);
-    __atomic_store_n(&g_dhcp_rx.active, true, __ATOMIC_RELEASE);
+    g_dhcp_rx.ready.store_release(false);
+    g_dhcp_rx.active.store_release(true);
 }
 
 /**
  * Deactivate the DHCP receive hook.
  */
 static void deactivate_rx_hook() {
-    __atomic_store_n(&g_dhcp_rx.active, false, __ATOMIC_RELEASE);
-    __atomic_store_n(&g_dhcp_rx.ready, false, __ATOMIC_RELEASE);
+    g_dhcp_rx.active.store_release(false);
+    g_dhcp_rx.ready.store_release(false);
 }
 
 // Packet Build Functions

--- a/kernel/net/ipv4.cpp
+++ b/kernel/net/ipv4.cpp
@@ -14,7 +14,7 @@
 
 namespace net {
 
-__PRIVILEGED_DATA static sync::atomic<uint32_t> g_ipv4_id_counter;
+__PRIVILEGED_DATA static sync::atomic<uint32_t> g_ipv4_id_counter{0};
 
 static uint16_t next_ipv4_id() {
     return static_cast<uint16_t>(g_ipv4_id_counter.fetch_add_relaxed(1));

--- a/kernel/net/ipv4.cpp
+++ b/kernel/net/ipv4.cpp
@@ -10,14 +10,14 @@
 #include "common/logging.h"
 #include "common/string.h"
 #include "mm/heap.h"
+#include "sync/atomic.h"
 
 namespace net {
 
-__PRIVILEGED_DATA static volatile uint32_t g_ipv4_id_counter = 0;
+__PRIVILEGED_DATA static sync::atomic<uint32_t> g_ipv4_id_counter;
 
 static uint16_t next_ipv4_id() {
-    return static_cast<uint16_t>(
-        __atomic_fetch_add(&g_ipv4_id_counter, 1, __ATOMIC_RELAXED));
+    return static_cast<uint16_t>(g_ipv4_id_counter.fetch_add_relaxed(1));
 }
 
 void ipv4_recv(netif* iface, const uint8_t* data, size_t len) {

--- a/kernel/net/tcp.cpp
+++ b/kernel/net/tcp.cpp
@@ -9,6 +9,7 @@
 #include "common/string.h"
 #include "common/ring_buffer.h"
 #include "mm/heap.h"
+#include "sync/atomic.h"
 #include "sync/spinlock.h"
 #include "sync/poll.h"
 #include "fs/fstypes.h"
@@ -27,12 +28,12 @@ __PRIVILEGED_DATA static sync::spinlock g_tcp_sock_lock = sync::SPINLOCK_INIT;
 
 // Simple ISN generator. A real implementation uses a clock-based scheme
 // for security (RFC 6528), but a monotonic counter is correct for now.
-__PRIVILEGED_DATA static volatile uint32_t g_tcp_isn_counter = 1000;
+__PRIVILEGED_DATA static sync::atomic<uint32_t> g_tcp_isn_counter{1000};
 
 constexpr size_t TCP_MSS = ETH_MTU - sizeof(ipv4_header) - sizeof(tcp_header);
 
 static uint32_t tcp_generate_isn() {
-    return __atomic_fetch_add(&g_tcp_isn_counter, 64000, __ATOMIC_RELAXED);
+    return g_tcp_isn_counter.fetch_add_relaxed(64000);
 }
 
 constexpr uint16_t TCP_DEFAULT_WINDOW = 8192;
@@ -42,10 +43,10 @@ constexpr size_t TCP_RX_BUF_CAPACITY = 16384;
 constexpr uint16_t TCP_PORT_EPHEMERAL_MIN = 49152;
 constexpr uint16_t TCP_PORT_EPHEMERAL_MAX = 65535;
 
-__PRIVILEGED_DATA static volatile uint32_t g_tcp_ephemeral_next = TCP_PORT_EPHEMERAL_MIN;
+__PRIVILEGED_DATA static sync::atomic<uint32_t> g_tcp_ephemeral_next{TCP_PORT_EPHEMERAL_MIN};
 
 static uint16_t tcp_alloc_ephemeral_port() {
-    uint32_t port = __atomic_fetch_add(&g_tcp_ephemeral_next, 1, __ATOMIC_RELAXED);
+    uint32_t port = g_tcp_ephemeral_next.fetch_add_relaxed(1);
     uint32_t range = TCP_PORT_EPHEMERAL_MAX - TCP_PORT_EPHEMERAL_MIN + 1;
     return static_cast<uint16_t>(
         TCP_PORT_EPHEMERAL_MIN + (port - TCP_PORT_EPHEMERAL_MIN) % range);

--- a/kernel/net/udp.cpp
+++ b/kernel/net/udp.cpp
@@ -7,6 +7,7 @@
 #include "common/string.h"
 #include "common/ring_buffer.h"
 #include "mm/heap.h"
+#include "sync/atomic.h"
 #include "sync/spinlock.h"
 #include "dynpriv/dynpriv.h"
 #include "common/logging.h"
@@ -15,7 +16,7 @@ namespace net {
 
 __PRIVILEGED_DATA static inet_socket* g_udp_sock_list = nullptr;
 __PRIVILEGED_DATA static sync::spinlock g_udp_sock_lock = sync::SPINLOCK_INIT;
-__PRIVILEGED_DATA static volatile uint32_t g_ephemeral_next = UDP_PORT_EPHEMERAL_MIN;
+__PRIVILEGED_DATA static sync::atomic<uint32_t> g_ephemeral_next{UDP_PORT_EPHEMERAL_MIN};
 
 // Ring buffer entry framing for UDP:
 //   [4 bytes: src_ip, network byte order]
@@ -152,7 +153,7 @@ bool udp_try_register(inet_socket* sock) {
 }
 
 uint16_t udp_alloc_ephemeral_port() {
-    uint32_t port = __atomic_fetch_add(&g_ephemeral_next, 1, __ATOMIC_RELAXED);
+    uint32_t port = g_ephemeral_next.fetch_add_relaxed(1);
     uint32_t range = UDP_PORT_EPHEMERAL_MAX - UDP_PORT_EPHEMERAL_MIN + 1;
     return static_cast<uint16_t>(
         UDP_PORT_EPHEMERAL_MIN + (port - UDP_PORT_EPHEMERAL_MIN) % range);

--- a/kernel/pty/pty.cpp
+++ b/kernel/pty/pty.cpp
@@ -32,7 +32,7 @@ struct linux_termios {
     uint8_t  c_cc[19];
 };
 
-__PRIVILEGED_BSS static uint32_t g_next_pty_id;
+__PRIVILEGED_BSS static sync::atomic<uint32_t> g_next_pty_id;
 
 __PRIVILEGED_CODE void pty_channel::ref_destroy(pty_channel* self) {
     if (!self) {
@@ -50,7 +50,7 @@ __PRIVILEGED_CODE static void pty_echo_fn(void* ctx, const uint8_t* buf, size_t 
 
 __PRIVILEGED_CODE static void pty_signal_fn(void* ctx, uint32_t sig) {
     auto* chan = static_cast<pty_channel*>(ctx);
-    uint32_t fg = __atomic_load_n(&chan->m_fg_group, __ATOMIC_ACQUIRE);
+    uint32_t fg = chan->m_fg_group.load_acquire();
     if (fg) {
         (void)signals::send_to_group_id(fg, sig);
     }
@@ -247,8 +247,7 @@ static int32_t do_tcsets(pty_channel* chan, uint64_t arg) {
 }
 
 static int32_t do_tiocgpgrp(pty_channel* chan, uint64_t arg) {
-    int32_t g = static_cast<int32_t>(
-        __atomic_load_n(&chan->m_fg_group, __ATOMIC_ACQUIRE));
+    int32_t g = static_cast<int32_t>(chan->m_fg_group.load_acquire());
 
     int32_t rc = mm::uaccess::copy_to_user(
         reinterpret_cast<void*>(arg), &g, sizeof(g));
@@ -270,8 +269,7 @@ static int32_t do_tiocspgrp(pty_channel* chan, uint64_t arg) {
         return resource::ERR_INVAL;
     }
 
-    __atomic_store_n(&chan->m_fg_group, static_cast<uint32_t>(g),
-                     __ATOMIC_RELEASE);
+    chan->m_fg_group.store_release(static_cast<uint32_t>(g));
     return resource::OK;
 }
 
@@ -415,9 +413,9 @@ __PRIVILEGED_CODE int32_t create_pair(
     terminal::ld_init(&chan->m_ld);
     chan->m_echo = { pty_echo_fn, chan.ptr() };
     chan->m_sig = { pty_signal_fn, chan.ptr() };
-    chan->m_id = __atomic_fetch_add(&g_next_pty_id, 1, __ATOMIC_RELAXED);
+    chan->m_id = g_next_pty_id.fetch_add_relaxed(1);
     chan->m_oflags = PTY_OFLAG_ONLCR;
-    chan->m_fg_group = 0;
+    chan->m_fg_group.store_relaxed(0);
     chan->m_winsize = { 24, 80, 0, 0 };
 
     auto* ep_master = heap::kalloc_new<pty_endpoint>();

--- a/kernel/pty/pty.h
+++ b/kernel/pty/pty.h
@@ -4,6 +4,7 @@
 #include "common/types.h"
 #include "rc/ref_counted.h"
 #include "rc/strong_ref.h"
+#include "sync/atomic.h"
 #include "terminal/line_discipline.h"
 
 struct ring_buffer;
@@ -34,7 +35,7 @@ struct pty_channel : rc::ref_counted<pty_channel> {
     terminal::signal_target m_sig;
     uint32_t m_id;
     uint32_t m_oflags;                    // output processing flags
-    uint32_t m_fg_group;                  // foreground process group, 0 = none
+    sync::atomic<uint32_t> m_fg_group;    // foreground process group, 0 = none
     pty_winsize m_winsize;                // set via TIOCSWINSZ from either end
 
     /** @note Privilege: **required** */

--- a/kernel/rc/reaper.cpp
+++ b/kernel/rc/reaper.cpp
@@ -9,10 +9,10 @@
 namespace rc {
 namespace reaper {
 
-__PRIVILEGED_DATA static sync::atomic<dead_node*> g_queue_head;
+__PRIVILEGED_DATA static sync::atomic<dead_node*> g_queue_head{nullptr};
 __PRIVILEGED_DATA static sync::wait_queue g_wait_queue;
 __PRIVILEGED_DATA static sync::spinlock g_wait_lock = sync::SPINLOCK_INIT;
-__PRIVILEGED_DATA static sync::atomic<uint32_t> g_initialized;
+__PRIVILEGED_DATA static sync::atomic<uint32_t> g_initialized{0};
 __PRIVILEGED_DATA static sched::task* g_reaper_task = nullptr;
 
 constexpr uint32_t QUEUED_EMPTY = 0;

--- a/kernel/rc/reaper.cpp
+++ b/kernel/rc/reaper.cpp
@@ -1,6 +1,7 @@
 #include "rc/reaper.h"
 #include "sched/sched.h"
 #include "sched/task_exec_core.h"
+#include "sync/atomic.h"
 #include "sync/spinlock.h"
 #include "sync/wait_queue.h"
 #include "common/logging.h"
@@ -8,10 +9,10 @@
 namespace rc {
 namespace reaper {
 
-__PRIVILEGED_DATA static dead_node* g_queue_head = nullptr;
+__PRIVILEGED_DATA static sync::atomic<dead_node*> g_queue_head;
 __PRIVILEGED_DATA static sync::wait_queue g_wait_queue;
 __PRIVILEGED_DATA static sync::spinlock g_wait_lock = sync::SPINLOCK_INIT;
-__PRIVILEGED_DATA static uint32_t g_initialized = 0;
+__PRIVILEGED_DATA static sync::atomic<uint32_t> g_initialized;
 __PRIVILEGED_DATA static sched::task* g_reaper_task = nullptr;
 
 constexpr uint32_t QUEUED_EMPTY = 0;
@@ -44,7 +45,7 @@ static dead_node* reverse_list(dead_node* head) {
 }
 
 __PRIVILEGED_CODE static dead_node* pop_all() {
-    dead_node* head = __atomic_exchange_n(&g_queue_head, nullptr, __ATOMIC_ACQ_REL);
+    dead_node* head = g_queue_head.exchange_acq_rel(nullptr);
     return reverse_list(head);
 }
 
@@ -58,11 +59,10 @@ __PRIVILEGED_CODE static void enqueue_chain(dead_node* first, bool wake_if_empty
         tail = tail->next;
     }
 
-    dead_node* old_head = __atomic_load_n(&g_queue_head, __ATOMIC_ACQUIRE);
+    dead_node* old_head = g_queue_head.load_acquire();
     do {
         tail->next = old_head;
-    } while (!__atomic_compare_exchange_n(&g_queue_head, &old_head, first,
-                                          false, __ATOMIC_RELEASE, __ATOMIC_RELAXED));
+    } while (!g_queue_head.cmpxchg_strong_release(old_head, first));
 
     if (wake_if_empty && old_head == nullptr) {
         // Serialized with g_wait_lock to avoid lost wakeups.
@@ -75,8 +75,7 @@ __PRIVILEGED_CODE static void enqueue_chain(dead_node* first, bool wake_if_empty
 __PRIVILEGED_CODE static void requeue_retry(dead_node* node, uint32_t retry_count) {
     uint32_t encoded_retry = encode_retry_count(retry_count);
     uint32_t expected = QUEUED_EMPTY;
-    if (!__atomic_compare_exchange_n(&node->queued, &expected, encoded_retry,
-                                     false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+    if (!node->queued.cmpxchg_strong_acq_rel(expected, encoded_retry)) {
         return;
     }
 
@@ -92,7 +91,7 @@ __PRIVILEGED_CODE static void reaper_main(void*) {
         dead_node* list = pop_all();
         if (!list) {
             sync::irq_state irq = sync::spin_lock_irqsave(g_wait_lock);
-            while (__atomic_load_n(&g_queue_head, __ATOMIC_ACQUIRE) == nullptr) {
+            while (g_queue_head.load_acquire() == nullptr) {
                 irq = sync::wait(g_wait_queue, g_wait_lock, irq);
             }
             sync::spin_unlock_irqrestore(g_wait_lock, irq);
@@ -106,7 +105,7 @@ __PRIVILEGED_CODE static void reaper_main(void*) {
             cursor = cursor->next;
             node->next = nullptr;
 
-            uint32_t encoded = __atomic_exchange_n(&node->queued, QUEUED_EMPTY, __ATOMIC_ACQ_REL);
+            uint32_t encoded = node->queued.exchange_acq_rel(QUEUED_EMPTY);
             uint32_t retry_count = decode_retry_count(encoded);
 
             cleanup_result result = DONE;
@@ -135,19 +134,18 @@ __PRIVILEGED_CODE static void reaper_main(void*) {
  */
 __PRIVILEGED_CODE int32_t init() {
     uint32_t expected = 0;
-    if (!__atomic_compare_exchange_n(&g_initialized, &expected, 1,
-                                     false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+    if (!g_initialized.cmpxchg_strong_acq_rel(expected, 1)) {
         return OK;
     }
 
-    __atomic_store_n(&g_queue_head, nullptr, __ATOMIC_RELEASE);
+    g_queue_head.store_release(nullptr);
     g_wait_lock = sync::SPINLOCK_INIT;
     g_wait_queue.init();
 
     sched::task* task = sched::create_kernel_task(
         reaper_main, nullptr, "reaper", sched::TASK_FLAG_ELEVATED);
     if (!task) {
-        __atomic_store_n(&g_initialized, 0, __ATOMIC_RELEASE);
+        g_initialized.store_release(0);
         return ERR_NO_MEM;
     }
 
@@ -167,8 +165,7 @@ __PRIVILEGED_CODE void defer(dead_node* node) {
     }
 
     uint32_t expected = QUEUED_EMPTY;
-    if (!__atomic_compare_exchange_n(&node->queued, &expected, QUEUED_FIRST,
-                                     false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+    if (!node->queued.cmpxchg_strong_acq_rel(expected, QUEUED_FIRST)) {
         return;
     }
 

--- a/kernel/rc/reaper.h
+++ b/kernel/rc/reaper.h
@@ -2,6 +2,7 @@
 #define STELLUX_RC_REAPER_H
 
 #include "common/types.h"
+#include "sync/atomic.h"
 
 namespace rc {
 namespace reaper {
@@ -17,12 +18,12 @@ using cleanup_fn = cleanup_result (*)(dead_node*);
 struct dead_node {
     dead_node* next;
     cleanup_fn cleanup;
-    uint32_t queued;
+    sync::atomic<uint32_t> queued;
 
     void init(cleanup_fn fn) {
         next = nullptr;
         cleanup = fn;
-        queued = 0;
+        queued.store_relaxed(0);
     }
 };
 

--- a/kernel/resource/providers/proc_provider.cpp
+++ b/kernel/resource/providers/proc_provider.cpp
@@ -41,7 +41,7 @@ __PRIVILEGED_CODE static void proc_close(resource_object* obj) {
 
     sync::irq_state irq = sync::spin_lock_irqsave(pr->lock);
 
-    if (pr->child && pr->child->state == sched::TASK_STATE_CREATED) {
+    if (pr->child && pr->child->state.load_relaxed() == sched::TASK_STATE_CREATED) {
         auto* child = pr->child;
         pr->child = nullptr;
         sync::spin_unlock_irqrestore(pr->lock, irq);
@@ -162,9 +162,7 @@ __PRIVILEGED_CODE void destroy_unstarted_task(sched::task* t) {
     // Claim the task, a concurrent group teardown may have already
     // moved it to dead and handed the memory to the reaper
     uint32_t expected = sched::TASK_STATE_CREATED;
-    if (!__atomic_compare_exchange_n(&t->state, &expected,
-                                     sched::TASK_STATE_DEAD, false,
-                                     __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+    if (!t->state.cmpxchg_strong_acq_rel(expected, sched::TASK_STATE_DEAD)) {
         return;
     }
 

--- a/kernel/sched/sched.cpp
+++ b/kernel/sched/sched.cpp
@@ -14,6 +14,7 @@
 #include "mm/mm.h"
 #include "mm/paging.h"
 #include "common/logging.h"
+#include "sync/atomic.h"
 #include "sync/spinlock.h"
 #include "smp/smp.h"
 #include "hw/cpu.h"
@@ -40,10 +41,10 @@ static DEFINE_PER_CPU(sched::runqueue, cpu_rq);
 
 static DEFINE_PER_CPU(sched::cpu_accounting_stats, cpu_accounting);
 
-static uint32_t g_next_tid = 1;
-static uint32_t g_pending_tlb_sync_tickets = 0;
+static sync::atomic<uint32_t> g_next_tid{1};
+static sync::atomic<uint32_t> g_pending_tlb_sync_tickets;
 
-__PRIVILEGED_DATA static uint32_t g_lb_next_cpu = 0;
+__PRIVILEGED_DATA static sync::atomic<uint32_t> g_lb_next_cpu;
 
 namespace sched {
 
@@ -66,11 +67,11 @@ constexpr uint64_t AT_PHNUM  = 5;
 constexpr uint64_t AT_PAGESZ = 6;
 
 static uint32_t load_cleanup_stage(const task* t) {
-    return __atomic_load_n(&t->cleanup_stage, __ATOMIC_ACQUIRE);
+    return t->cleanup_stage.load_acquire();
 }
 
 static void store_cleanup_stage(task* t, uint32_t stage) {
-    __atomic_store_n(&t->cleanup_stage, stage, __ATOMIC_RELEASE);
+    t->cleanup_stage.store_release(stage);
 }
 
 #ifdef DEBUG
@@ -105,7 +106,7 @@ __PRIVILEGED_CODE static rc::reaper::cleanup_result reap_task(sched::task* t) {
         return rc::reaper::RETRY_LATER;
     }
 
-    if (__atomic_load_n(&t->exec.on_cpu, __ATOMIC_ACQUIRE)) {
+    if (sync::atomic_ref<uint32_t>{t->exec.on_cpu}.load_acquire()) {
         return rc::reaper::RETRY_LATER;
     }
 
@@ -118,16 +119,16 @@ __PRIVILEGED_CODE static rc::reaper::cleanup_result reap_task(sched::task* t) {
                 continue;
             }
             t->tlb_sync_ticket.cpu_epoch_snapshot[cpu] =
-                __atomic_load_n(&per_cpu_on(cpu_tlb_sync_epoch, cpu), __ATOMIC_ACQUIRE);
+                sync::atomic_ref<uint64_t>{per_cpu_on(cpu_tlb_sync_epoch, cpu)}.load_acquire();
         }
-        __atomic_store_n(&t->tlb_sync_ticket.armed, 1, __ATOMIC_RELEASE);
-        __atomic_add_fetch(&g_pending_tlb_sync_tickets, 1, __ATOMIC_ACQ_REL);
+        t->tlb_sync_ticket.armed.store_release(1);
+        g_pending_tlb_sync_tickets.fetch_add_acq_rel(1);
         store_cleanup_stage(t, TASK_CLEANUP_STAGE_WAITING_FOR_TLB_SYNC);
         return rc::reaper::RETRY_LATER;
     }
 
     if (stage == TASK_CLEANUP_STAGE_WAITING_FOR_TLB_SYNC) {
-        if (__atomic_load_n(&t->tlb_sync_ticket.armed, __ATOMIC_ACQUIRE) == 0) {
+        if (t->tlb_sync_ticket.armed.load_acquire() == 0) {
             return rc::reaper::RETRY_LATER;
         }
 
@@ -135,12 +136,12 @@ __PRIVILEGED_CODE static rc::reaper::cleanup_result reap_task(sched::task* t) {
             if (t->tlb_sync_ticket.cpu_epoch_snapshot[cpu] == TLB_SYNC_CPU_IGNORED) {
                 continue;
             }
-            uint64_t epoch = __atomic_load_n(&per_cpu_on(cpu_tlb_sync_epoch, cpu), __ATOMIC_ACQUIRE);
+            uint64_t epoch = sync::atomic_ref<uint64_t>{per_cpu_on(cpu_tlb_sync_epoch, cpu)}.load_acquire();
             if ((epoch - t->tlb_sync_ticket.cpu_epoch_snapshot[cpu]) == 0) {
                 return rc::reaper::RETRY_LATER;
             }
         }
-        __atomic_sub_fetch(&g_pending_tlb_sync_tickets, 1, __ATOMIC_ACQ_REL);
+        g_pending_tlb_sync_tickets.fetch_sub_acq_rel(1);
         store_cleanup_stage(t, TASK_CLEANUP_STAGE_READY_TO_RECLAIM);
     }
 
@@ -186,7 +187,7 @@ task* current() {
 
 // A pending SIGKILL bit is the task's "must terminate" marker
 static inline bool task_kill_bit_set(const task* t) {
-    return (__atomic_load_n(&t->sig.pending, __ATOMIC_ACQUIRE)
+    return (t->sig.pending.load_acquire()
             & signals::sig_bit(signals::SIGKILL)) != 0;
 }
 
@@ -196,12 +197,11 @@ bool is_kill_pending() {
 }
 
 __PRIVILEGED_CODE void force_wake_for_kill(task* t) {
-    __atomic_fetch_or(&t->sig.pending, signals::sig_bit(signals::SIGKILL),
-                      __ATOMIC_ACQ_REL);
+    t->sig.pending.fetch_or_acq_rel(signals::sig_bit(signals::SIGKILL));
 
     // Pairs with block_task_interrupted: the wake below sees BLOCKED,
     // or the blocker's interrupt check sees the SIGKILL bit. Never neither.
-    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    sync::atomic_fence_seq_cst();
     timer::cancel_sleep(t);
     wake(t);
 }
@@ -210,7 +210,7 @@ __PRIVILEGED_CODE void force_wake_for_kill(task* t) {
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE void prepare_to_block_task() {
-    __atomic_store_n(&current()->state, TASK_STATE_BLOCKED, __ATOMIC_RELEASE);
+    current()->state.store_release(TASK_STATE_BLOCKED);
 }
 
 /**
@@ -218,7 +218,7 @@ __PRIVILEGED_CODE void prepare_to_block_task() {
  */
 __PRIVILEGED_CODE bool block_task_interrupted() {
     // Fence pairs with force_wake_for_kill and signals wake_for_signal.
-    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    sync::atomic_fence_seq_cst();
     return signals::interrupt_pending(current());
 }
 
@@ -228,8 +228,7 @@ __PRIVILEGED_CODE bool block_task_interrupted() {
 __PRIVILEGED_CODE void cancel_block_task() {
     task* self = current();
     uint32_t expected = TASK_STATE_BLOCKED;
-    if (!__atomic_compare_exchange_n(&self->state, &expected, TASK_STATE_RUNNING,
-                                      false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+    if (!self->state.cmpxchg_strong_acq_rel(expected, TASK_STATE_RUNNING)) {
         // A wake already claimed this task READY and will requeue it once
         // it is off-CPU. Yield so that handoff can complete.
         yield();
@@ -247,8 +246,8 @@ __PRIVILEGED_CODE void record_cpu_tick(task* prev) {
     // use relaxed atomic loads
     uint64_t* counter = (prev == rq.idle_task) ? &stats.idle_ticks
                                                : &stats.busy_ticks;
-    __atomic_store_n(counter, *counter + 1, __ATOMIC_RELAXED);
-    __atomic_store_n(&prev->run_ticks, prev->run_ticks + 1, __ATOMIC_RELAXED);
+    sync::atomic_ref<uint64_t>{*counter}.store_relaxed(*counter + 1);
+    prev->run_ticks.store_relaxed(prev->run_ticks.load_relaxed() + 1);
 }
 
 /**
@@ -257,8 +256,8 @@ __PRIVILEGED_CODE void record_cpu_tick(task* prev) {
 __PRIVILEGED_CODE cpu_accounting_stats read_cpu_accounting_stats(uint32_t cpu_id) {
     cpu_accounting_stats& stats = per_cpu_on(cpu_accounting, cpu_id);
     cpu_accounting_stats out;
-    out.busy_ticks = __atomic_load_n(&stats.busy_ticks, __ATOMIC_RELAXED);
-    out.idle_ticks = __atomic_load_n(&stats.idle_ticks, __ATOMIC_RELAXED);
+    out.busy_ticks = sync::atomic_ref<uint64_t>{stats.busy_ticks}.load_relaxed();
+    out.idle_ticks = sync::atomic_ref<uint64_t>{stats.idle_ticks}.load_relaxed();
     out.tick_hz = timer::tick_hz();
     return out;
 }
@@ -273,7 +272,7 @@ __PRIVILEGED_CODE void finalize_pending_off_cpu() {
     }
 
     this_cpu(pending_off_cpu_task) = nullptr;
-    __atomic_store_n(&pending->exec.on_cpu, 0, __ATOMIC_RELEASE);
+    sync::atomic_ref<uint32_t>{pending->exec.on_cpu}.store_release(0);
     cpu::send_event();
 
     if (load_cleanup_stage(pending) == TASK_CLEANUP_STAGE_SCHEDULER_DETACHED) {
@@ -300,11 +299,11 @@ __PRIVILEGED_CODE void defer_off_cpu_finalize(task* prev) {
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE void advance_cpu_tlb_sync_epoch() {
-    if (__atomic_load_n(&g_pending_tlb_sync_tickets, __ATOMIC_ACQUIRE) == 0) {
+    if (g_pending_tlb_sync_tickets.load_acquire() == 0) {
         return;
     }
     paging::flush_tlb_all();
-    __atomic_add_fetch(&this_cpu(cpu_tlb_sync_epoch), 1, __ATOMIC_RELEASE);
+    sync::atomic_ref<uint64_t>{this_cpu(cpu_tlb_sync_epoch)}.fetch_add_release(1);
 }
 
 /**
@@ -314,7 +313,7 @@ __PRIVILEGED_CODE static uint32_t load_balance_select_cpu() {
     uint32_t online = smp::online_count();
     if (online <= 1) return 0;
 
-    uint32_t target = __atomic_fetch_add(&g_lb_next_cpu, 1, __ATOMIC_RELAXED) % online;
+    uint32_t target = g_lb_next_cpu.fetch_add_relaxed(1) % online;
     uint32_t total = smp::cpu_count();
     uint32_t seen = 0;
     for (uint32_t i = 0; i < total; i++) {
@@ -340,14 +339,14 @@ __PRIVILEGED_CODE task* pick_next_and_switch(task* prev) {
     sync::irq_state irq = sync::spin_lock_irqsave(rq.lock);
 
     // Only re-enqueue if prev was running (not dead, blocked, or already woken)
-    if (prev != rq.idle_task && prev->state == TASK_STATE_RUNNING) {
-        prev->state = TASK_STATE_READY;
+    if (prev != rq.idle_task && prev->state.load_relaxed() == TASK_STATE_RUNNING) {
+        prev->state.store_relaxed(TASK_STATE_READY);
         rq.policy->enqueue(prev);
         rq.nr_running++;
     }
 
     // Dead task is now scheduler-detached and can enter deferred cleanup flow.
-    if (prev != rq.idle_task && prev->state == TASK_STATE_DEAD) {
+    if (prev != rq.idle_task && prev->state.load_relaxed() == TASK_STATE_DEAD) {
         store_cleanup_stage(prev, TASK_CLEANUP_STAGE_SCHEDULER_DETACHED);
     }
 
@@ -358,7 +357,7 @@ __PRIVILEGED_CODE task* pick_next_and_switch(task* prev) {
         next = rq.idle_task;
     }
 
-    next->state = TASK_STATE_RUNNING;
+    next->state.store_relaxed(TASK_STATE_RUNNING);
     this_cpu(current_task) = next;
     this_cpu(current_task_exec) = &next->exec;
     // Runtime elevation state remains true while trap/syscall teardown continues.
@@ -378,8 +377,7 @@ __PRIVILEGED_CODE task* pick_next_and_switch(task* prev) {
  */
 __PRIVILEGED_CODE void enqueue(task* t) {
     uint32_t expected = TASK_STATE_CREATED;
-    if (!__atomic_compare_exchange_n(&t->state, &expected, TASK_STATE_READY,
-                                      false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+    if (!t->state.cmpxchg_strong_acq_rel(expected, TASK_STATE_READY)) {
         log::warn("sched: enqueue rejected tid=%u (state=%u)", t->tid, expected);
         return;
     }
@@ -398,8 +396,7 @@ __PRIVILEGED_CODE void enqueue(task* t) {
  */
 __PRIVILEGED_CODE void enqueue_on(task* t, uint32_t cpu_id) {
     uint32_t expected = TASK_STATE_CREATED;
-    if (!__atomic_compare_exchange_n(&t->state, &expected, TASK_STATE_READY,
-                                      false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+    if (!t->state.cmpxchg_strong_acq_rel(expected, TASK_STATE_READY)) {
         log::warn("sched: enqueue_on rejected tid=%u (state=%u)", t->tid, expected);
         return;
     }
@@ -417,14 +414,13 @@ __PRIVILEGED_CODE void enqueue_on(task* t, uint32_t cpu_id) {
  */
 __PRIVILEGED_CODE void wake(task* t) {
     uint32_t expected = TASK_STATE_BLOCKED;
-    if (!__atomic_compare_exchange_n(&t->state, &expected, TASK_STATE_READY,
-                                      false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+    if (!t->state.cmpxchg_strong_acq_rel(expected, TASK_STATE_READY)) {
         return;
     }
 
-    uint32_t task_cpu = __atomic_load_n(&t->exec.cpu, __ATOMIC_RELAXED);
+    uint32_t task_cpu = sync::atomic_ref<uint32_t>{t->exec.cpu}.load_relaxed();
     if (task_cpu != percpu::current_cpu_id()) {
-        while (__atomic_load_n(&t->exec.on_cpu, __ATOMIC_ACQUIRE)) {
+        while (sync::atomic_ref<uint32_t>{t->exec.on_cpu}.load_acquire()) {
             cpu::relax();
         }
     }
@@ -503,10 +499,8 @@ __PRIVILEGED_CODE void sleep_ms(uint64_t ms) {
                 // death cause
                 int32_t reap_status = TASK_KILL_STATUS;
 
-                uint32_t ges = __atomic_load_n(&tg->group_exit_status,
-                                               __ATOMIC_ACQUIRE);
-                uint32_t es = __atomic_load_n(&tg->sig.exit_signal,
-                                              __ATOMIC_ACQUIRE);
+                uint32_t ges = tg->group_exit_status.load_acquire();
+                uint32_t es = tg->sig.exit_signal.load_acquire();
 
                 if (ges != 0) {
                     reap_status = static_cast<int32_t>(ges & 0xFF00u);
@@ -521,9 +515,8 @@ __PRIVILEGED_CODE void sleep_ms(uint64_t ms) {
                     sched::task& thread = *it;
                     ++it; // advance before potential removal
                     uint32_t expected = TASK_STATE_CREATED;
-                    if (__atomic_compare_exchange_n(&thread.state, &expected,
-                            TASK_STATE_DEAD, false,
-                            __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)) {
+                    if (thread.state.cmpxchg_strong_acq_rel(expected,
+                            TASK_STATE_DEAD)) {
                         tg->threads.remove(&thread);
                         tg->thread_count--;
                         if (thread.proc_res) {
@@ -559,8 +552,7 @@ __PRIVILEGED_CODE void sleep_ms(uint64_t ms) {
             auto* pr = task->proc_res;
 
             uint32_t ges = task->group
-                ? __atomic_load_n(&task->group->group_exit_status,
-                                  __ATOMIC_ACQUIRE)
+                ? task->group->group_exit_status.load_acquire()
                 : 0;
 
             sync::irq_state irq = sync::spin_lock_irqsave(pr->lock);
@@ -588,7 +580,7 @@ __PRIVILEGED_CODE void sleep_ms(uint64_t ms) {
         }
 
         store_cleanup_stage(task, TASK_CLEANUP_STAGE_EXIT_REQUESTED);
-        task->state = TASK_STATE_DEAD;
+        task->state.store_relaxed(TASK_STATE_DEAD);
         task->exit_code = exit_code;
     });
     yield();
@@ -649,8 +641,8 @@ __PRIVILEGED_CODE task* create_kernel_task(
 
     t->exec.on_cpu = 0;
 
-    t->tid = __atomic_fetch_add(&g_next_tid, 1, __ATOMIC_RELAXED);
-    t->state = TASK_STATE_CREATED;
+    t->tid = g_next_tid.fetch_add_relaxed(1);
+    t->state.store_relaxed(TASK_STATE_CREATED);
     t->task_registry_link = {};
     t->sched_link = {};
     t->wait_link = {};
@@ -658,8 +650,8 @@ __PRIVILEGED_CODE task* create_kernel_task(
     t->timer_deadline = 0;
     string::memcpy(t->name, name, string::strnlen(name, TASK_NAME_MAX - 1));
     t->name[string::strnlen(name, TASK_NAME_MAX - 1)] = '\0';
-    t->cleanup_stage = TASK_CLEANUP_STAGE_ACTIVE;
-    t->tlb_sync_ticket.armed = 0;
+    t->cleanup_stage.store_relaxed(TASK_CLEANUP_STAGE_ACTIVE);
+    t->tlb_sync_ticket.armed.store_relaxed(0);
     for (uint32_t i = 0; i < MAX_CPUS; i++) {
         t->tlb_sync_ticket.cpu_epoch_snapshot[i] = 0;
     }
@@ -675,7 +667,8 @@ __PRIVILEGED_CODE task* create_kernel_task(
     t->proc_res = nullptr;
     t->cwd = nullptr;
     t->clear_child_tid = 0;
-    t->sig = {};
+    t->sig.blocked.store_relaxed(0);
+    t->sig.pending.store_relaxed(0);
     t->group = nullptr;
     t->group_link = {};
 
@@ -914,8 +907,8 @@ __PRIVILEGED_CODE task* create_user_task(
     t->exec.on_cpu = 0;
     fpu::init_state(&t->exec.fpu_ctx);
 
-    t->tid = __atomic_fetch_add(&g_next_tid, 1, __ATOMIC_RELAXED);
-    t->state = TASK_STATE_CREATED;
+    t->tid = g_next_tid.fetch_add_relaxed(1);
+    t->state.store_relaxed(TASK_STATE_CREATED);
     t->task_registry_link = {};
     t->sched_link = {};
     t->wait_link = {};
@@ -923,8 +916,8 @@ __PRIVILEGED_CODE task* create_user_task(
     t->timer_deadline = 0;
     string::memcpy(t->name, name, string::strnlen(name, TASK_NAME_MAX - 1));
     t->name[string::strnlen(name, TASK_NAME_MAX - 1)] = '\0';
-    t->cleanup_stage = TASK_CLEANUP_STAGE_ACTIVE;
-    t->tlb_sync_ticket.armed = 0;
+    t->cleanup_stage.store_relaxed(TASK_CLEANUP_STAGE_ACTIVE);
+    t->tlb_sync_ticket.armed.store_relaxed(0);
     for (uint32_t i = 0; i < MAX_CPUS; i++) {
         t->tlb_sync_ticket.cpu_epoch_snapshot[i] = 0;
     }
@@ -946,7 +939,8 @@ __PRIVILEGED_CODE task* create_user_task(
     t->proc_res = nullptr;
     t->cwd = nullptr;
     t->clear_child_tid = 0;
-    t->sig = {};
+    t->sig.blocked.store_relaxed(0);
+    t->sig.pending.store_relaxed(0);
 
     auto* tg = heap::kalloc_new<thread_group>();
     if (!tg) {
@@ -968,13 +962,13 @@ __PRIVILEGED_CODE task* create_user_task(
     tg->pid = t->tid;
     tg->threads.init();
     tg->thread_count = 0;
-    tg->group_exit_status = 0;
+    tg->group_exit_status.store_relaxed(0);
 
     // POSIX inheritance: a new process joins its creator's process group
     task* creator = current();
-    tg->group_id = (creator && creator->group)
-        ? __atomic_load_n(&creator->group->group_id, __ATOMIC_ACQUIRE)
-        : t->tid;
+    tg->group_id.store_relaxed((creator && creator->group)
+        ? creator->group->group_id.load_acquire()
+        : t->tid);
 
     t->group = tg; // task takes ownership of the initial ref (refcount=1)
     t->group_link = {};
@@ -1074,14 +1068,14 @@ __PRIVILEGED_CODE static task* init_user_thread_core(
         ctx_bytes[i] = 0;
     }
 
-    t->tid = __atomic_fetch_add(&g_next_tid, 1, __ATOMIC_RELAXED);
-    t->state = TASK_STATE_CREATED;
+    t->tid = g_next_tid.fetch_add_relaxed(1);
+    t->state.store_relaxed(TASK_STATE_CREATED);
     t->exit_code = 0;
-    t->cleanup_stage = TASK_CLEANUP_STAGE_ACTIVE;
+    t->cleanup_stage.store_relaxed(TASK_CLEANUP_STAGE_ACTIVE);
     t->clear_child_tid = 0;
 
-    t->sig = {};
-    t->sig.blocked = __atomic_load_n(&creator->sig.blocked, __ATOMIC_ACQUIRE);
+    t->sig.pending.store_relaxed(0);
+    t->sig.blocked.store_relaxed(creator->sig.blocked.load_acquire());
 
     string::memcpy(t->name, name, string::strnlen(name, TASK_NAME_MAX - 1)); 
     t->name[string::strnlen(name, TASK_NAME_MAX - 1)] = '\0';
@@ -1091,7 +1085,7 @@ __PRIVILEGED_CODE static task* init_user_thread_core(
     t->wait_link = {};
     t->timer_link = {};
     t->timer_deadline = 0;
-    t->tlb_sync_ticket.armed = 0;
+    t->tlb_sync_ticket.armed.store_relaxed(0);
 
     for (uint32_t i = 0; i < MAX_CPUS; i++) {
         t->tlb_sync_ticket.cpu_epoch_snapshot[i] = 0;
@@ -1199,7 +1193,7 @@ __PRIVILEGED_CODE int32_t init() {
     idle->exec.mm_ctx = nullptr;
     idle->exec.flags |= TASK_FLAG_IDLE;
     idle->tid = 0;
-    idle->state = TASK_STATE_RUNNING;
+    idle->state.store_relaxed(TASK_STATE_RUNNING);
     idle->task_stack_base = 0;
     idle->sys_stack_base = 0;
     idle->task_registry_link = {};
@@ -1209,8 +1203,8 @@ __PRIVILEGED_CODE int32_t init() {
     idle->timer_deadline = 0;
     string::memcpy(idle->name, "idle", 4);
     idle->name[4] = '\0';
-    idle->cleanup_stage = TASK_CLEANUP_STAGE_ACTIVE;
-    idle->tlb_sync_ticket.armed = 0;
+    idle->cleanup_stage.store_relaxed(TASK_CLEANUP_STAGE_ACTIVE);
+    idle->tlb_sync_ticket.armed.store_relaxed(0);
     fpu::init_state(&idle->exec.fpu_ctx);
     if (resource::init_task_handles(idle) != resource::OK) {
         log::error("sched: failed to allocate idle task handle table");
@@ -1219,7 +1213,8 @@ __PRIVILEGED_CODE int32_t init() {
     idle->proc_res = nullptr;
     idle->cwd = nullptr;
     idle->clear_child_tid = 0;
-    idle->sig = {};
+    idle->sig.blocked.store_relaxed(0);
+    idle->sig.pending.store_relaxed(0);
     idle->group = nullptr;
     idle->group_link = {};
 
@@ -1279,12 +1274,12 @@ __PRIVILEGED_CODE int32_t init_ap(uint32_t cpu_id, uintptr_t task_stack_top,
     idle->exec.mm_ctx = nullptr;
     idle->task_stack_base = 0;
     idle->sys_stack_base = 0;
-    idle->tid = __atomic_fetch_add(&g_next_tid, 1, __ATOMIC_RELAXED);
-    idle->state = TASK_STATE_RUNNING;
+    idle->tid = g_next_tid.fetch_add_relaxed(1);
+    idle->state.store_relaxed(TASK_STATE_RUNNING);
     string::memcpy(idle->name, "idle", 4);
     idle->name[4] = '\0';
-    idle->cleanup_stage = TASK_CLEANUP_STAGE_ACTIVE;
-    idle->tlb_sync_ticket.armed = 0;
+    idle->cleanup_stage.store_relaxed(TASK_CLEANUP_STAGE_ACTIVE);
+    idle->tlb_sync_ticket.armed.store_relaxed(0);
     fpu::init_state(&idle->exec.fpu_ctx);
     if (resource::init_task_handles(idle) != resource::OK) {
         return ERR_NO_MEM;

--- a/kernel/sched/sched.cpp
+++ b/kernel/sched/sched.cpp
@@ -113,7 +113,7 @@ __PRIVILEGED_CODE static rc::reaper::cleanup_result reap_task(sched::task* t) {
     if (stage == TASK_CLEANUP_STAGE_SCHEDULER_DETACHED) {
         for (uint32_t cpu = 0; cpu < cpu_count; cpu++) {
             smp::cpu_info* info = smp::get_cpu_info(cpu);
-            if (!info || __atomic_load_n(&info->state, __ATOMIC_ACQUIRE) != smp::CPU_ONLINE) {
+            if (!info || info->state.load_acquire() != smp::CPU_ONLINE) {
                 t->tlb_sync_ticket.cpu_epoch_snapshot[cpu] = TLB_SYNC_CPU_IGNORED;
                 continue;
             }
@@ -319,7 +319,7 @@ __PRIVILEGED_CODE static uint32_t load_balance_select_cpu() {
     uint32_t seen = 0;
     for (uint32_t i = 0; i < total; i++) {
         smp::cpu_info* info = smp::get_cpu_info(i);
-        if (info && __atomic_load_n(&info->state, __ATOMIC_ACQUIRE) == smp::CPU_ONLINE) {
+        if (info && info->state.load_acquire() == smp::CPU_ONLINE) {
             if (seen == target) return i;
             seen++;
         }

--- a/kernel/sched/sched.cpp
+++ b/kernel/sched/sched.cpp
@@ -44,7 +44,7 @@ static DEFINE_PER_CPU(sched::cpu_accounting_stats, cpu_accounting);
 static sync::atomic<uint32_t> g_next_tid{1};
 static sync::atomic<uint32_t> g_pending_tlb_sync_tickets;
 
-__PRIVILEGED_DATA static sync::atomic<uint32_t> g_lb_next_cpu;
+__PRIVILEGED_DATA static sync::atomic<uint32_t> g_lb_next_cpu{0};
 
 namespace sched {
 

--- a/kernel/sched/sched_policy.cpp
+++ b/kernel/sched/sched_policy.cpp
@@ -14,7 +14,7 @@ void round_robin_policy::enqueue(task* t) {
     }
     if (t->sched_link.is_linked()) {
         log::fatal("sched: ready-list double enqueue tid=%u name=%s state=%u cpu=%u on_cpu=%u",
-                   t->tid, t->name, t->state, t->exec.cpu, t->exec.on_cpu);
+                   t->tid, t->name, t->state.load_relaxed(), t->exec.cpu, t->exec.on_cpu);
     }
 #endif
     m_ready_list.push_back(t);

--- a/kernel/sched/task.h
+++ b/kernel/sched/task.h
@@ -7,6 +7,7 @@
 #include "rc/ref_counted.h"
 #include "rc/reaper.h"
 #include "signals/signal_types.h"
+#include "sync/atomic.h"
 #include "sync/spinlock.h"
 #include "resource/handle_table.h"
 
@@ -39,7 +40,7 @@ constexpr uint32_t TASK_CLEANUP_STAGE_READY_TO_RECLAIM      = 4;
  */
 struct task_tlb_sync_ticket {
     uint64_t cpu_epoch_snapshot[MAX_CPUS];
-    uint32_t armed;
+    sync::atomic<uint32_t> armed;
 };
 
 struct thread_group;
@@ -60,8 +61,8 @@ struct task {
 
     // Lifecycle
     int32_t        exit_code;
-    uint32_t       state;
-    uint32_t       cleanup_stage;
+    sync::atomic<uint32_t> state;
+    sync::atomic<uint32_t> cleanup_stage;
 
     // Thread id address registered by a cloned thread, exit writes
     // zero there and wakes one futex waiter so pthread_join returns
@@ -80,7 +81,7 @@ struct task {
     list::node              wait_link;
     list::node              timer_link;
     uint64_t                timer_deadline;
-    uint64_t                run_ticks; // timer ticks observed while current
+    sync::atomic<uint64_t>  run_ticks; // timer ticks observed while current
     task_tlb_sync_ticket    tlb_sync_ticket;
     rc::reaper::dead_node   reaper_node;
 
@@ -106,14 +107,14 @@ struct thread_group : rc::ref_counted<thread_group> {
     sync::spinlock lock;
     task*          leader;
     uint32_t       pid; // process leader tid
-    uint32_t       group_id; // process group this process belongs to
+    sync::atomic<uint32_t> group_id; // process group this process belongs to
     list::head<task, &task::group_link> threads; // non-leader threads only
     uint32_t       thread_count; // number of live non-leader threads
 
     // Group exit status recorded by exit_group, zero means unset,
     // otherwise bit 31 is set and bits 8 to 15 hold the exit code
     // already encoded as a normal wait status
-    uint32_t       group_exit_status;
+    sync::atomic<uint32_t> group_exit_status;
 
     // Signals (per-process action table and shared pending set)
     signals::group_signals sig;

--- a/kernel/signals/signal.cpp
+++ b/kernel/signals/signal.cpp
@@ -2,6 +2,7 @@
 #include "sched/sched.h"
 #include "sched/task.h"
 #include "sched/task_registry.h"
+#include "sync/atomic.h"
 #include "timer/timer.h"
 #include "common/logging.h"
 
@@ -24,14 +25,14 @@ constexpr uint32_t MAX_GROUP_SEND_GROUPS = 64;
  */
 __PRIVILEGED_CODE static void discard_pending(sched::thread_group* tg, uint32_t sig) {
     const sig_set_t keep = ~sig_bit(sig);
-    __atomic_fetch_and(&tg->sig.shared_pending, keep, __ATOMIC_ACQ_REL);
+    tg->sig.shared_pending.fetch_and_acq_rel(keep);
 
     sync::irq_state irq = sync::spin_lock_irqsave(tg->lock);
     if (tg->leader) {
-        __atomic_fetch_and(&tg->leader->sig.pending, keep, __ATOMIC_ACQ_REL);
+        tg->leader->sig.pending.fetch_and_acq_rel(keep);
     }
     for (sched::task& thread : tg->threads) {
-        __atomic_fetch_and(&thread.sig.pending, keep, __ATOMIC_ACQ_REL);
+        thread.sig.pending.fetch_and_acq_rel(keep);
     }
     sync::spin_unlock_irqrestore(tg->lock, irq);
 }
@@ -75,7 +76,7 @@ __PRIVILEGED_CODE int32_t set_blocked(sched::task* t, uint32_t how,
         return ERR_INVAL;
     }
 
-    sig_set_t cur = __atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE);
+    sig_set_t cur = t->sig.blocked.load_acquire();
     if (old) {
         *old = cur;
     }
@@ -93,16 +94,16 @@ __PRIVILEGED_CODE int32_t set_blocked(sched::task* t, uint32_t how,
     }
 
     next &= ~UNBLOCKABLE_MASK;
-    __atomic_store_n(&t->sig.blocked, next, __ATOMIC_RELEASE);
+    t->sig.blocked.store_release(next);
     return OK;
 }
 
 __PRIVILEGED_CODE sig_set_t pending_blocked_set(sched::task* t) {
-    sig_set_t pend = __atomic_load_n(&t->sig.pending, __ATOMIC_ACQUIRE);
+    sig_set_t pend = t->sig.pending.load_acquire();
     if (t->group) {
-        pend |= __atomic_load_n(&t->group->sig.shared_pending, __ATOMIC_ACQUIRE);
+        pend |= t->group->sig.shared_pending.load_acquire();
     }
-    return pend & __atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE);
+    return pend & t->sig.blocked.load_acquire();
 }
 
 /**
@@ -139,7 +140,7 @@ __PRIVILEGED_CODE static send_verdict classify_send(sched::thread_group* tg,
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE static void wake_for_signal(sched::task* t) {
-    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    sync::atomic_fence_seq_cst();
     timer::cancel_sleep(t);
     sched::wake(t);
 }
@@ -152,7 +153,7 @@ __PRIVILEGED_CODE static void wake_for_signal(sched::task* t) {
  */
 __PRIVILEGED_CODE static bool wake_eligible(sched::task* t, sig_set_t bit,
                                             bool needs_handler) {
-    if (__atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE) & bit) {
+    if (t->sig.blocked.load_acquire() & bit) {
         return false;
     }
     return !needs_handler || !(t->exec.flags & sched::TASK_FLAG_ELEVATED);
@@ -171,7 +172,7 @@ __PRIVILEGED_CODE int32_t send_to_task(sched::task* t, uint32_t sig) {
         // SIGKILL is process-wide: the shared bit is fatal for every thread
         // at its next kernel crossing, not only after leader teardown
         sched::thread_group* tg = t->group;
-        __atomic_fetch_or(&tg->sig.shared_pending, sig_bit(SIGKILL), __ATOMIC_ACQ_REL);
+        tg->sig.shared_pending.fetch_or_acq_rel(sig_bit(SIGKILL));
         sync::irq_state irq = sync::spin_lock_irqsave(tg->lock);
 
         if (tg->leader && tg->leader != t) {
@@ -184,7 +185,7 @@ __PRIVILEGED_CODE int32_t send_to_task(sched::task* t, uint32_t sig) {
     }
 
     send_verdict verdict = classify_send(t->group, sig);
-    sig_set_t blocked = __atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE);
+    sig_set_t blocked = t->sig.blocked.load_acquire();
     bool is_blocked = (blocked & sig_bit(sig)) != 0;
 
     // Ignored signals are dropped unless blocked (the action may change
@@ -193,7 +194,7 @@ __PRIVILEGED_CODE int32_t send_to_task(sched::task* t, uint32_t sig) {
         return OK;
     }
 
-    __atomic_fetch_or(&t->sig.pending, sig_bit(sig), __ATOMIC_ACQ_REL);
+    t->sig.pending.fetch_or_acq_rel(sig_bit(sig));
     if (verdict != send_verdict::IGNORABLE &&
         wake_eligible(t, sig_bit(sig), verdict == send_verdict::HANDLED)) {
         wake_for_signal(t);
@@ -207,7 +208,7 @@ __PRIVILEGED_CODE int32_t send_to_group(sched::thread_group* tg, uint32_t sig) {
     }
 
     if (sig == SIGKILL) {
-        __atomic_fetch_or(&tg->sig.shared_pending, sig_bit(SIGKILL), __ATOMIC_ACQ_REL);
+        tg->sig.shared_pending.fetch_or_acq_rel(sig_bit(SIGKILL));
         sync::irq_state irq = sync::spin_lock_irqsave(tg->lock);
 
         if (tg->leader) {
@@ -227,25 +228,25 @@ __PRIVILEGED_CODE int32_t send_to_group(sched::thread_group* tg, uint32_t sig) {
         // Droppable only if no thread has it blocked
         bool blocked_somewhere = false;
         if (tg->leader &&
-            (__atomic_load_n(&tg->leader->sig.blocked, __ATOMIC_ACQUIRE) & bit)) {
+            (tg->leader->sig.blocked.load_acquire() & bit)) {
             blocked_somewhere = true;
         }
 
         for (sched::task& thread : tg->threads) {
-            if (__atomic_load_n(&thread.sig.blocked, __ATOMIC_ACQUIRE) & bit) {
+            if (thread.sig.blocked.load_acquire() & bit) {
                 blocked_somewhere = true;
                 break;
             }
         }
 
         if (blocked_somewhere) {
-            __atomic_fetch_or(&tg->sig.shared_pending, bit, __ATOMIC_ACQ_REL);
+            tg->sig.shared_pending.fetch_or_acq_rel(bit);
         }
         sync::spin_unlock_irqrestore(tg->lock, irq);
         return OK;
     }
 
-    __atomic_fetch_or(&tg->sig.shared_pending, bit, __ATOMIC_ACQ_REL);
+    tg->sig.shared_pending.fetch_or_acq_rel(bit);
 
     if (verdict != send_verdict::IGNORABLE) {
         // Wake one thread the signal can act on now, leader preferred
@@ -278,7 +279,7 @@ __PRIVILEGED_CODE int32_t send_to_group_id(uint32_t group_id, uint32_t sig) {
     sync::irq_state irq = sched::g_task_registry.lock();
     sched::g_task_registry.for_each_locked([&](sched::task& t) {
         sched::thread_group* tg = t.group;
-        if (!tg || __atomic_load_n(&tg->group_id, __ATOMIC_ACQUIRE) != group_id) {
+        if (!tg || tg->group_id.load_acquire() != group_id) {
             return;
         }
 
@@ -302,15 +303,15 @@ __PRIVILEGED_CODE int32_t send_to_group_id(uint32_t group_id, uint32_t sig) {
 }
 
 __PRIVILEGED_CODE uint32_t fatal_pending(sched::task* t) {
-    sig_set_t pending = __atomic_load_n(&t->sig.pending, __ATOMIC_ACQUIRE);
+    sig_set_t pending = t->sig.pending.load_acquire();
     sig_set_t shared = t->group
-        ? __atomic_load_n(&t->group->sig.shared_pending, __ATOMIC_ACQUIRE) : 0;
+        ? t->group->sig.shared_pending.load_acquire() : 0;
 
     // A pending SIGKILL is the "must terminate" marker and outranks all.
     // Report the signal that began group termination if one was recorded.
     if ((pending | shared) & sig_bit(SIGKILL)) {
         uint32_t es = t->group
-            ? __atomic_load_n(&t->group->sig.exit_signal, __ATOMIC_ACQUIRE) : 0;
+            ? t->group->sig.exit_signal.load_acquire() : 0;
         return es ? es : SIGKILL;
     }
 
@@ -319,7 +320,7 @@ __PRIVILEGED_CODE uint32_t fatal_pending(sched::task* t) {
     }
 
     sig_set_t deliverable = (pending | shared)
-        & ~__atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE);
+        & ~t->sig.blocked.load_acquire();
     if (!deliverable) {
         return 0;
     }
@@ -360,10 +361,10 @@ __PRIVILEGED_CODE uint32_t next_deliverable(sched::task* t) {
         return 0;
     }
 
-    sig_set_t pending = __atomic_load_n(&t->sig.pending, __ATOMIC_ACQUIRE)
-        | __atomic_load_n(&t->group->sig.shared_pending, __ATOMIC_ACQUIRE);
+    sig_set_t pending = t->sig.pending.load_acquire()
+        | t->group->sig.shared_pending.load_acquire();
     sig_set_t deliverable = pending
-        & ~__atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE);
+        & ~t->sig.blocked.load_acquire();
 
     if (!deliverable) {
         return 0;
@@ -394,9 +395,9 @@ __PRIVILEGED_CODE bool take_deliverable(sched::task* t, uint32_t* sig,
     }
 
     // Lock-free fast path, the boundary check must stay cheap
-    sig_set_t blocked = __atomic_load_n(&t->sig.blocked, __ATOMIC_ACQUIRE);
-    sig_set_t deliverable = (__atomic_load_n(&t->sig.pending, __ATOMIC_ACQUIRE)
-        | __atomic_load_n(&t->group->sig.shared_pending, __ATOMIC_ACQUIRE))
+    sig_set_t blocked = t->sig.blocked.load_acquire();
+    sig_set_t deliverable = (t->sig.pending.load_acquire()
+        | t->group->sig.shared_pending.load_acquire())
         & ~blocked;
     if (!deliverable) {
         return false;
@@ -406,8 +407,8 @@ __PRIVILEGED_CODE bool take_deliverable(sched::task* t, uint32_t* sig,
 
     // Re-read under the lock: bits are only cleared by sig.lock holders,
     // so the selection cannot race with a discard or another consumer
-    deliverable = (__atomic_load_n(&t->sig.pending, __ATOMIC_ACQUIRE)
-        | __atomic_load_n(&t->group->sig.shared_pending, __ATOMIC_ACQUIRE))
+    deliverable = (t->sig.pending.load_acquire()
+        | t->group->sig.shared_pending.load_acquire())
         & ~blocked;
 
     uint32_t selected = 0;
@@ -429,9 +430,9 @@ __PRIVILEGED_CODE bool take_deliverable(sched::task* t, uint32_t* sig,
 
     // Consume one pending instance, thread set before the shared set
     const sig_set_t keep = ~sig_bit(selected);
-    if (!(__atomic_fetch_and(&t->sig.pending, keep, __ATOMIC_ACQ_REL)
+    if (!(t->sig.pending.fetch_and_acq_rel(keep)
           & sig_bit(selected))) {
-        __atomic_fetch_and(&t->group->sig.shared_pending, keep, __ATOMIC_ACQ_REL);
+        t->group->sig.shared_pending.fetch_and_acq_rel(keep);
     }
 
     *act = t->group->sig.actions[selected - 1];
@@ -471,7 +472,7 @@ __PRIVILEGED_CODE void untake_deliverable(sched::task* t, uint32_t sig,
         sync::spin_unlock_irqrestore(t->group->sig.lock, irq);
     }
 
-    __atomic_fetch_or(&t->sig.pending, sig_bit(sig), __ATOMIC_ACQ_REL);
+    t->sig.pending.fetch_or_acq_rel(sig_bit(sig));
 }
 
 __PRIVILEGED_CODE void die_from_signal(uint32_t sig) {
@@ -481,16 +482,16 @@ __PRIVILEGED_CODE void die_from_signal(uint32_t sig) {
     // Native kills (proc_kill) stay thread-scoped: the SIGKILL bit
     // is set without recording a group exit signal
     bool native_kill =
-        (__atomic_load_n(&self->sig.pending, __ATOMIC_ACQUIRE) & sig_bit(SIGKILL)) &&
-        (!tg || __atomic_load_n(&tg->sig.exit_signal, __ATOMIC_ACQUIRE) == 0);
+        (self->sig.pending.load_acquire() & sig_bit(SIGKILL)) &&
+        (!tg || tg->sig.exit_signal.load_acquire() == 0);
 
     if (tg && !native_kill) {
         // First recorded signal wins so every group member reports it,
         // including this thread if another already recorded one
         uint32_t expected = 0;
-        if (!__atomic_compare_exchange_n(&tg->sig.exit_signal, &expected, sig,
-                                         false, __ATOMIC_ACQ_REL,
-                                         __ATOMIC_ACQUIRE)) {
+        if (!tg->sig.exit_signal.cmpxchg_strong_acq_rel(expected, sig)) {
+            // Acquire pairs with the winning store before adopting its value.
+            sync::atomic_fence_acquire();
             sig = expected;
         }
 
@@ -504,7 +505,7 @@ __PRIVILEGED_CODE void die_from_signal(uint32_t sig) {
     }
 
     // The SIGKILL bit makes exit() encode a killed-by-signal wait status
-    __atomic_fetch_or(&self->sig.pending, sig_bit(SIGKILL), __ATOMIC_RELEASE);
+    self->sig.pending.fetch_or_release(sig_bit(SIGKILL));
     sched::exit(static_cast<int32_t>(sig));
 }
 

--- a/kernel/signals/signal_types.h
+++ b/kernel/signals/signal_types.h
@@ -2,6 +2,7 @@
 #define STELLUX_SIGNALS_SIGNAL_TYPES_H
 
 #include "common/types.h"
+#include "sync/atomic.h"
 #include "sync/spinlock.h"
 
 namespace signals {
@@ -69,15 +70,15 @@ static_assert(sizeof(k_sigaction) == 32, "k_sigaction must match musl rt_sigacti
 // Per-task signal state. pending is set by senders,
 // blocked is written only by the owning task.
 struct task_signals {
-    sig_set_t blocked;
-    sig_set_t pending;
+    sync::atomic<sig_set_t> blocked;
+    sync::atomic<sig_set_t> pending;
 };
 
 // Per-process signal state shared by all threads in a thread group.
 struct group_signals {
     sync::spinlock lock; // guards actions
-    sig_set_t shared_pending;
-    uint32_t exit_signal; // first fatal signal that began group termination, 0 if none
+    sync::atomic<sig_set_t> shared_pending;
+    sync::atomic<uint32_t> exit_signal; // first fatal signal that began group termination, 0 if none
     k_sigaction actions[NSIG];
 };
 

--- a/kernel/smp/smp.cpp
+++ b/kernel/smp/smp.cpp
@@ -26,9 +26,9 @@ __PRIVILEGED_CODE int32_t init() {
     uint32_t ap_count = 0;
     for (uint32_t i = 0; i < g_cpu_count; i++) {
         if (g_cpus[i].is_bsp) {
-            g_cpus[i].state = CPU_ONLINE;
+            g_cpus[i].state.store_relaxed(CPU_ONLINE);
         } else {
-            g_cpus[i].state = CPU_OFFLINE;
+            g_cpus[i].state.store_relaxed(CPU_OFFLINE);
             ap_count++;
         }
     }
@@ -50,14 +50,14 @@ __PRIVILEGED_CODE int32_t init() {
     for (uint32_t i = 0; i < g_cpu_count; i++) {
         if (g_cpus[i].is_bsp) continue;
 
-        __atomic_store_n(&g_cpus[i].state, CPU_BOOTING, __ATOMIC_RELEASE);
+        g_cpus[i].state.store_release(CPU_BOOTING);
 
         rc = arch::smp_boot_cpu(g_cpus[i]);
         if (rc == OK) {
             log::info("smp: CPU %u online",
                       g_cpus[i].logical_id);
         } else {
-            __atomic_store_n(&g_cpus[i].state, CPU_OFFLINE, __ATOMIC_RELEASE);
+            g_cpus[i].state.store_release(CPU_OFFLINE);
             log::warn("smp: CPU %u failed to start (hw_id 0x%lx)",
                       g_cpus[i].logical_id, g_cpus[i].hw_id);
         }
@@ -76,7 +76,7 @@ uint32_t cpu_count() {
 uint32_t online_count() {
     uint32_t count = 0;
     for (uint32_t i = 0; i < g_cpu_count; i++) {
-        if (__atomic_load_n(&g_cpus[i].state, __ATOMIC_ACQUIRE) == CPU_ONLINE) {
+        if (g_cpus[i].state.load_acquire() == CPU_ONLINE) {
             count++;
         }
     }

--- a/kernel/smp/smp.h
+++ b/kernel/smp/smp.h
@@ -2,6 +2,7 @@
 #define STELLUX_SMP_SMP_H
 
 #include "common/types.h"
+#include "sync/atomic.h"
 
 namespace smp {
 
@@ -10,10 +11,10 @@ constexpr uint32_t CPU_BOOTING = 1;
 constexpr uint32_t CPU_ONLINE  = 2;
 
 struct cpu_info {
-    uint32_t logical_id; // 0-based index
-    uint64_t hw_id;      // APIC ID (x86) or MPIDR (aarch64)
-    uint32_t state;      // CPU_OFFLINE / CPU_BOOTING / CPU_ONLINE
-    bool     is_bsp;     // true for the bootstrap processor
+    uint32_t logical_id;            // 0-based index
+    uint64_t hw_id;                 // APIC ID (x86) or MPIDR (aarch64)
+    sync::atomic<uint32_t> state;   // CPU_OFFLINE / CPU_BOOTING / CPU_ONLINE
+    bool     is_bsp;                // true for the bootstrap processor
 };
 
 constexpr int32_t OK               = 0;

--- a/kernel/sync/atomic.h
+++ b/kernel/sync/atomic.h
@@ -320,6 +320,16 @@ inline void atomic_fence_release() {
     __atomic_thread_fence(__ATOMIC_RELEASE);
 }
 
+/**
+ * @brief Full fence, orders prior stores against later loads.
+ *
+ * Use for store-then-check handshakes where two sides must never
+ * both miss each other, such as blocking versus kill delivery.
+ */
+inline void atomic_fence_seq_cst() {
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+}
+
 } // namespace sync
 
 #endif // STELLUX_SYNC_ATOMIC_H

--- a/kernel/sync/mutex.cpp
+++ b/kernel/sync/mutex.cpp
@@ -20,15 +20,15 @@ __PRIVILEGED_CODE void mutex_lock(mutex& m) {
 
     irq_state irq = spin_lock_irqsave(m.lock);
 
-    MUTEX_ASSERT(m.owner != self, "recursive lock detected");
+    MUTEX_ASSERT(m.owner.load_relaxed() != self, "recursive lock detected");
 
-    while (m.owner != nullptr) {
+    while (m.owner.load_relaxed() != nullptr) {
         MUTEX_ASSERT(!(self->exec.flags & sched::TASK_FLAG_IDLE),
                      "idle task blocked on contended mutex");
         irq = wait(m.wq, m.lock, irq);
     }
 
-    m.owner = self;
+    m.owner.store_relaxed(self);
     spin_unlock_irqrestore(m.lock, irq);
 }
 
@@ -38,10 +38,10 @@ __PRIVILEGED_CODE void mutex_lock(mutex& m) {
 __PRIVILEGED_CODE void mutex_unlock(mutex& m) {
     irq_state irq = spin_lock_irqsave(m.lock);
 
-    MUTEX_ASSERT(m.owner == sched::current(),
+    MUTEX_ASSERT(m.owner.load_relaxed() == sched::current(),
                  "unlock called by non-owner");
 
-    m.owner = nullptr;
+    m.owner.store_relaxed(nullptr);
     spin_unlock_irqrestore(m.lock, irq);
 
     wake_one(m.wq);
@@ -53,12 +53,12 @@ __PRIVILEGED_CODE void mutex_unlock(mutex& m) {
 __PRIVILEGED_CODE bool mutex_trylock(mutex& m) {
     irq_state irq = spin_lock_irqsave(m.lock);
 
-    if (m.owner != nullptr) {
+    if (m.owner.load_relaxed() != nullptr) {
         spin_unlock_irqrestore(m.lock, irq);
         return false;
     }
 
-    m.owner = sched::current();
+    m.owner.store_relaxed(sched::current());
     spin_unlock_irqrestore(m.lock, irq);
     return true;
 }

--- a/kernel/sync/mutex.h
+++ b/kernel/sync/mutex.h
@@ -1,6 +1,7 @@
 #ifndef STELLUX_SYNC_MUTEX_H
 #define STELLUX_SYNC_MUTEX_H
 
+#include "sync/atomic.h"
 #include "sync/spinlock.h"
 #include "sync/wait_queue.h"
 
@@ -8,12 +9,12 @@ namespace sync {
 
 struct mutex {
     spinlock lock;
-    sched::task* owner;
+    atomic<sched::task*> owner;
     wait_queue wq;
 
     void init() {
         lock = SPINLOCK_INIT;
-        owner = nullptr;
+        owner.store_relaxed(nullptr);
         wq.init();
     }
 };
@@ -44,7 +45,7 @@ __PRIVILEGED_CODE void mutex_unlock(mutex& m);
  * may be stale if checked without external synchronization.
  */
 inline bool mutex_is_locked(const mutex& m) {
-    return __atomic_load_n(&m.owner, __ATOMIC_RELAXED) != nullptr;
+    return m.owner.load_relaxed() != nullptr;
 }
 
 } // namespace sync

--- a/kernel/sync/poll.cpp
+++ b/kernel/sync/poll.cpp
@@ -12,7 +12,7 @@ namespace sync {
 __PRIVILEGED_CODE void poll_subscribe(poll_table& pt, wait_queue& wq) {
     auto* entry = heap::kalloc_new<poll_entry>();
     if (!entry) {
-        __atomic_store_n(&pt.error, 1, __ATOMIC_RELEASE);
+        pt.error.store_release(1);
         return;
     }
 
@@ -29,11 +29,11 @@ __PRIVILEGED_CODE void poll_subscribe(poll_table& pt, wait_queue& wq) {
 }
 
 __PRIVILEGED_CODE bool poll_wait(poll_table& pt, uint64_t timeout_ns) {
-    if (__atomic_load_n(&pt.triggered, __ATOMIC_ACQUIRE)) {
+    if (pt.triggered.load_acquire()) {
         return true;
     }
 
-    if (__atomic_load_n(&pt.error, __ATOMIC_ACQUIRE)) {
+    if (pt.error.load_acquire()) {
         return false;
     }
 
@@ -51,7 +51,7 @@ __PRIVILEGED_CODE bool poll_wait(poll_table& pt, uint64_t timeout_ns) {
 
     // The interrupt check's fence also orders this re-check against the
     // BLOCKED store, closing the race where a source fires during the transition.
-    if (__atomic_load_n(&pt.triggered, __ATOMIC_ACQUIRE)) {
+    if (pt.triggered.load_acquire()) {
         sched::cancel_block_task();
         return true;
     }
@@ -64,7 +64,7 @@ __PRIVILEGED_CODE bool poll_wait(poll_table& pt, uint64_t timeout_ns) {
     sched::yield();
 
     timer::cancel_sleep(self);
-    return __atomic_load_n(&pt.triggered, __ATOMIC_ACQUIRE) != 0;
+    return pt.triggered.load_acquire() != 0;
 }
 
 __PRIVILEGED_CODE void poll_cleanup(poll_table& pt) {

--- a/kernel/sync/poll.h
+++ b/kernel/sync/poll.h
@@ -3,6 +3,7 @@
 
 #include "common/types.h"
 #include "common/list.h"
+#include "sync/atomic.h"
 #include "sync/spinlock.h"
 
 namespace sched { struct task; }
@@ -29,15 +30,15 @@ struct poll_entry {
 
 struct poll_table {
     sched::task* task;
-    uint32_t triggered;
-    uint32_t error;
+    atomic<uint32_t> triggered;
+    atomic<uint32_t> error;
     spinlock lock;
     list::head<poll_entry, &poll_entry::table_link> entries;
 
     void init(sched::task* t) {
         task = t;
-        triggered = 0;
-        error = 0;
+        triggered.store_relaxed(0);
+        error.store_relaxed(0);
         lock = SPINLOCK_INIT;
         entries.init();
     }

--- a/kernel/sync/wait_queue.cpp
+++ b/kernel/sync/wait_queue.cpp
@@ -28,7 +28,7 @@ __PRIVILEGED_CODE static void notify_observers_and_unlock(
     uint32_t total = 0;
 
     for (auto& obs : wq.observers) {
-        __atomic_store_n(&obs.table->triggered, 1, __ATOMIC_RELEASE);
+        obs.table->triggered.store_release(1);
         if (n < OBSERVER_BATCH_SIZE) {
             batch[n++] = obs.table->task;
         }

--- a/kernel/syscall/handlers/sys_poll.cpp
+++ b/kernel/syscall/handlers/sys_poll.cpp
@@ -72,7 +72,7 @@ __PRIVILEGED_CODE static int64_t do_poll(
         ready += poll_one_fd(task, kfds[i], immediate ? nullptr : &pt);
     }
 
-    if (__atomic_load_n(&pt.error, __ATOMIC_ACQUIRE)) {
+    if (pt.error.load_acquire()) {
         sync::poll_cleanup(pt);
         return syscall::ENOMEM;
     }

--- a/kernel/syscall/handlers/sys_proc.cpp
+++ b/kernel/syscall/handlers/sys_proc.cpp
@@ -245,7 +245,7 @@ DEFINE_SYSCALL1(proc_start, u_handle) {
     }
 
     sync::irq_state irq = sync::spin_lock_irqsave(pr->lock);
-    if (!pr->child || pr->child->state != sched::TASK_STATE_CREATED) {
+    if (!pr->child || pr->child->state.load_relaxed() != sched::TASK_STATE_CREATED) {
         sync::spin_unlock_irqrestore(pr->lock, irq);
         resource::resource_release(obj);
         return syscall::EINVAL;
@@ -281,7 +281,7 @@ DEFINE_SYSCALL2(proc_wait, u_handle, u_exit_code_ptr) {
     }
 
     sync::irq_state irq = sync::spin_lock_irqsave(pr->lock);
-    if (pr->child && pr->child->state == sched::TASK_STATE_CREATED) {
+    if (pr->child && pr->child->state.load_relaxed() == sched::TASK_STATE_CREATED) {
         sync::spin_unlock_irqrestore(pr->lock, irq);
         resource::resource_release(obj);
         return syscall::EINVAL;
@@ -419,7 +419,7 @@ DEFINE_SYSCALL3(proc_set_handle, u_proc_handle, u_slot, u_resource_handle) {
     }
 
     sync::irq_state irq = sync::spin_lock_irqsave(pr->lock);
-    if (!pr->child || pr->child->state != sched::TASK_STATE_CREATED) {
+    if (!pr->child || pr->child->state.load_relaxed() != sched::TASK_STATE_CREATED) {
         sync::spin_unlock_irqrestore(pr->lock, irq);
         resource::resource_release(proc_obj);
         return syscall::EINVAL;

--- a/kernel/syscall/handlers/sys_select.cpp
+++ b/kernel/syscall/handlers/sys_select.cpp
@@ -97,7 +97,7 @@ __PRIVILEGED_CODE static int64_t do_select(
         if (pollfds[i].revents) ready++;
     }
 
-    if (__atomic_load_n(&pt.error, __ATOMIC_ACQUIRE)) {
+    if (pt.error.load_acquire()) {
         sync::poll_cleanup(pt);
         heap::kfree(fdmap);
         heap::kfree(pollfds);

--- a/kernel/syscall/handlers/sys_signal.cpp
+++ b/kernel/syscall/handlers/sys_signal.cpp
@@ -187,7 +187,7 @@ DEFINE_SYSCALL2(kill, u_pid, u_sig) {
         if (!caller->group) {
             return syscall::ESRCH;
         }
-        group_id = __atomic_load_n(&caller->group->group_id, __ATOMIC_ACQUIRE);
+        group_id = caller->group->group_id.load_acquire();
     } else {
         if (pid < -TASK_ID_LIMIT) {
             return syscall::ESRCH;

--- a/kernel/syscall/handlers/sys_task.cpp
+++ b/kernel/syscall/handlers/sys_task.cpp
@@ -2,6 +2,7 @@
 #include "sched/sched.h"
 #include "sched/task.h"
 #include "sched/task_registry.h"
+#include "sync/atomic.h"
 #include "resource/handle_table.h"
 #include "resource/resource.h"
 #include "resource/providers/proc_provider.h"
@@ -43,7 +44,7 @@ static bool group_exists(uint32_t group_id) {
     sync::irq_state irq = sched::g_task_registry.lock();
     sched::g_task_registry.for_each_locked([&](sched::task& t) {
         if (t.group &&
-            __atomic_load_n(&t.group->group_id, __ATOMIC_ACQUIRE) == group_id) {
+            t.group->group_id.load_acquire() == group_id) {
             found = true;
         }
     });
@@ -84,11 +85,10 @@ static int64_t regroup_unstarted_child(sched::task* caller, uint32_t pid,
         }
 
         int64_t result = 0;
-        if (child->state != sched::TASK_STATE_CREATED) {
+        if (child->state.load_relaxed() != sched::TASK_STATE_CREATED) {
             result = syscall::EACCES;
         } else {
-            __atomic_store_n(&child->group->group_id, group_id,
-                             __ATOMIC_RELEASE);
+            child->group->group_id.store_release(group_id);
         }
         sync::spin_unlock_irqrestore(pr->lock, irq);
         resource::resource_release(obj);
@@ -219,9 +219,10 @@ DEFINE_SYSCALL1(exit_group, status) {
             ((static_cast<uint32_t>(status) & 0xFF) << 8);
 
         uint32_t expected = 0;
-        __atomic_compare_exchange_n(&tg->group_exit_status, &expected,
-                                    packed, false, __ATOMIC_ACQ_REL,
-                                    __ATOMIC_ACQUIRE);
+        if (!tg->group_exit_status.cmpxchg_strong_acq_rel(expected, packed)) {
+            // Acquire pairs with the winning store that recorded the status.
+            sync::atomic_fence_acquire();
+        }
 
         // A non leader forces the leader down, the leader's exit then
         // reaps every remaining thread including this one
@@ -304,7 +305,7 @@ DEFINE_SYSCALL2(setpgid, u_pid, u_pgid) {
     }
 
     if (target_pid == caller->group->pid) {
-        __atomic_store_n(&caller->group->group_id, group_id, __ATOMIC_RELEASE);
+        caller->group->group_id.store_release(group_id);
         return 0;
     }
 
@@ -319,7 +320,7 @@ DEFINE_SYSCALL1(getpgid, u_pid) {
         if (!caller->group) {
             return syscall::ESRCH;
         }
-        return __atomic_load_n(&caller->group->group_id, __ATOMIC_ACQUIRE);
+        return caller->group->group_id.load_acquire();
     }
 
     if (pid < 0 || pid > TASK_ID_LIMIT) {
@@ -330,7 +331,7 @@ DEFINE_SYSCALL1(getpgid, u_pid) {
     sync::irq_state irq = sched::g_task_registry.lock();
     sched::task* t = sched::g_task_registry.find_locked(static_cast<uint32_t>(pid));
     if (t && t->group) {
-        result = __atomic_load_n(&t->group->group_id, __ATOMIC_ACQUIRE);
+        result = t->group->group_id.load_acquire();
     }
     sched::g_task_registry.unlock(irq);
 

--- a/kernel/sysstat/sysstat.cpp
+++ b/kernel/sysstat/sysstat.cpp
@@ -103,12 +103,11 @@ static size_t generate_tasks(char* buf, size_t cap) {
         pos = append_str(buf, cap, pos, " ");
         pos = append_u64(buf, cap, pos, t.group ? t.group->pid : 0);
         pos = append_str(buf, cap, pos, " ");
-        pos = append_str(buf, cap, pos, task_state_name(t.state));
+        pos = append_str(buf, cap, pos, task_state_name(t.state.load_relaxed()));
         pos = append_str(buf, cap, pos, " ");
         pos = append_u64(buf, cap, pos, t.exec.cpu);
         pos = append_str(buf, cap, pos, " ");
-        pos = append_u64(buf, cap, pos,
-                         __atomic_load_n(&t.run_ticks, __ATOMIC_RELAXED));
+        pos = append_u64(buf, cap, pos, t.run_ticks.load_relaxed());
         pos = append_str(buf, cap, pos, " ");
         pos = append_str(buf, cap, pos, t.name);
         pos = append_str(buf, cap, pos, "\n");

--- a/kernel/terminal/terminal.cpp
+++ b/kernel/terminal/terminal.cpp
@@ -12,6 +12,7 @@
 #include "fs/devfs/devfs.h"
 #include "mm/heap.h"
 #include "mm/uaccess.h"
+#include "sync/atomic.h"
 #include "sync/poll.h"
 
 namespace terminal {
@@ -21,7 +22,7 @@ constexpr size_t INPUT_RING_CAPACITY = 4096;
 __PRIVILEGED_BSS static struct {
     ring_buffer* input_rb;
     line_discipline ld;
-    uint32_t fg_group; // foreground process group, 0 = none
+    sync::atomic<uint32_t> fg_group; // foreground process group, 0 = none
 } g_console;
 
 __PRIVILEGED_CODE static void serial_echo(void* ctx, const uint8_t* buf, size_t len) {
@@ -36,7 +37,7 @@ __PRIVILEGED_DATA static const echo_target g_serial_echo = {
 
 __PRIVILEGED_CODE static void console_signal_fn(void* ctx, uint32_t sig) {
     (void)ctx;
-    uint32_t fg = __atomic_load_n(&g_console.fg_group, __ATOMIC_ACQUIRE);
+    uint32_t fg = g_console.fg_group.load_acquire();
     if (fg) {
         (void)signals::send_to_group_id(fg, sig);
     }
@@ -147,8 +148,7 @@ int32_t console_ioctl(uint32_t cmd, uint64_t arg) {
     if (cmd == TIOCGPGRP) {
         int32_t g = 0;
         RUN_ELEVATED({
-            g = static_cast<int32_t>(
-                __atomic_load_n(&g_console.fg_group, __ATOMIC_ACQUIRE));
+            g = static_cast<int32_t>(g_console.fg_group.load_acquire());
         });
         return mm::uaccess::copy_to_user(
             reinterpret_cast<void*>(arg), &g, sizeof(g)) == mm::uaccess::OK
@@ -170,8 +170,7 @@ int32_t console_ioctl(uint32_t cmd, uint64_t arg) {
                     static_cast<uint32_t>(g), 0) != signals::OK) {
                 result = fs::ERR_INVAL;
             } else {
-                __atomic_store_n(&g_console.fg_group, static_cast<uint32_t>(g),
-                                 __ATOMIC_RELEASE);
+                g_console.fg_group.store_release(static_cast<uint32_t>(g));
             }
         });
         return result;

--- a/kernel/tests/framework/helpers.h
+++ b/kernel/tests/framework/helpers.h
@@ -3,23 +3,24 @@
 
 #include "common/types.h"
 #include "clock/clock.h"
+#include "sync/atomic.h"
 
 namespace test_helpers {
 
 // Wall-clock bound: iteration counts vary ~100x across hosts and emulators.
 constexpr uint64_t SPIN_TIMEOUT_NS = 20000000000ULL; // 20s
 
-inline bool spin_wait(volatile uint32_t* flag) {
+inline bool spin_wait(const sync::atomic<uint32_t>& flag) {
     uint64_t deadline = clock::now_ns() + SPIN_TIMEOUT_NS;
-    while (!__atomic_load_n(flag, __ATOMIC_ACQUIRE)) {
+    while (!flag.load_acquire()) {
         if (clock::now_ns() > deadline) return false;
     }
     return true;
 }
 
-inline bool spin_wait_ge(volatile uint32_t* value, uint32_t target) {
+inline bool spin_wait_ge(const sync::atomic<uint32_t>& value, uint32_t target) {
     uint64_t deadline = clock::now_ns() + SPIN_TIMEOUT_NS;
-    while (__atomic_load_n(value, __ATOMIC_ACQUIRE) < target) {
+    while (value.load_acquire() < target) {
         if (clock::now_ns() > deadline) return false;
     }
     return true;

--- a/kernel/tests/fs/sysstat.test.cpp
+++ b/kernel/tests/fs/sysstat.test.cpp
@@ -144,10 +144,10 @@ TEST(sysstat, uptime_advances_between_reads) {
 // Proves: /dev/sysinfo/tasks reports a compute-bound task as running,
 // with numeric lead fields, even when the table spans many reads.
 
-static volatile uint32_t g_tasks_spin_started = 0;
+static sync::atomic<uint32_t> g_tasks_spin_started;
 
 static void tasks_spinner_fn(void*) {
-    __atomic_store_n(&g_tasks_spin_started, 1, __ATOMIC_RELEASE);
+    g_tasks_spin_started.store_release(1);
     // Spin long enough for the reader to stream the whole task table,
     // then exit on our own so no cross-task handshake is needed
     uint64_t deadline = clock::now_ns() + 500ULL * 1000 * 1000;
@@ -161,7 +161,7 @@ TEST(sysstat, tasks_lists_running_tasks) {
     if (smp::cpu_count() < 2) {
         return;
     }
-    g_tasks_spin_started = 0;
+    g_tasks_spin_started.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(tasks_spinner_fn, nullptr,
@@ -171,7 +171,7 @@ TEST(sysstat, tasks_lists_running_tasks) {
         uint32_t target = (percpu::current_cpu_id() + 1) % smp::cpu_count();
         sched::enqueue_on(t, target);
     });
-    ASSERT_TRUE(spin_wait(&g_tasks_spin_started));
+    ASSERT_TRUE(spin_wait(g_tasks_spin_started));
 
     fs::file* f = fs::open("/dev/sysinfo/tasks", fs::O_RDONLY);
     ASSERT_NOT_NULL(f);

--- a/kernel/tests/sched/fpu.test.cpp
+++ b/kernel/tests/sched/fpu.test.cpp
@@ -44,8 +44,8 @@ static uint64_t read_fpu_reg() {
 // --- fpu_basic_float ---
 // Task writes a known value to an FPU register and reads it back.
 
-static volatile uint64_t g_basic_result = 0;
-static volatile uint32_t g_basic_done = 0;
+static sync::atomic<uint64_t> g_basic_result;
+static sync::atomic<uint32_t> g_basic_done;
 
 static void basic_float_fn(void*) {
     constexpr uint64_t pattern = 0xDEADBEEFCAFEBABEULL;
@@ -56,14 +56,14 @@ static void basic_float_fn(void*) {
     RUN_ELEVATED({
         readback = read_fpu_reg();
     });
-    __atomic_store_n(&g_basic_result, readback, __ATOMIC_RELEASE);
-    __atomic_store_n(&g_basic_done, 1, __ATOMIC_RELEASE);
+    g_basic_result.store_release(readback);
+    g_basic_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(fpu, fpu_basic_float) {
-    g_basic_result = 0;
-    g_basic_done = 0;
+    g_basic_result.store_relaxed(0);
+    g_basic_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(
@@ -72,8 +72,8 @@ TEST(fpu, fpu_basic_float) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_basic_done));
-    EXPECT_EQ(__atomic_load_n(&g_basic_result, __ATOMIC_ACQUIRE),
+    ASSERT_TRUE(spin_wait(g_basic_done));
+    EXPECT_EQ(g_basic_result.load_acquire(),
               0xDEADBEEFCAFEBABEULL);
 }
 
@@ -83,13 +83,13 @@ TEST(fpu, fpu_basic_float) {
 
 constexpr uint32_t ISOLATION_ITERS = 50;
 
-static volatile uint32_t g_iso_fail_a = 0;
-static volatile uint32_t g_iso_fail_b = 0;
-static volatile uint32_t g_iso_done_count = 0;
+static sync::atomic<uint32_t> g_iso_fail_a;
+static sync::atomic<uint32_t> g_iso_fail_b;
+static sync::atomic<uint32_t> g_iso_done_count;
 
 static void isolation_task_fn(void* arg) {
     uint64_t fingerprint = reinterpret_cast<uint64_t>(arg);
-    volatile uint32_t* fail_flag = (fingerprint == 0xAAAAAAAAAAAAAAAAULL)
+    sync::atomic<uint32_t>* fail_flag = (fingerprint == 0xAAAAAAAAAAAAAAAAULL)
         ? &g_iso_fail_a : &g_iso_fail_b;
 
     for (uint32_t i = 0; i < ISOLATION_ITERS; i++) {
@@ -102,18 +102,18 @@ static void isolation_task_fn(void* arg) {
             readback = read_fpu_reg();
         });
         if (readback != fingerprint) {
-            __atomic_store_n(fail_flag, 1, __ATOMIC_RELEASE);
+            fail_flag->store_release(1);
             break;
         }
     }
-    __atomic_fetch_add(&g_iso_done_count, 1, __ATOMIC_ACQ_REL);
+    g_iso_done_count.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(fpu, fpu_context_isolation) {
-    g_iso_fail_a = 0;
-    g_iso_fail_b = 0;
-    g_iso_done_count = 0;
+    g_iso_fail_a.store_relaxed(0);
+    g_iso_fail_b.store_relaxed(0);
+    g_iso_done_count.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* ta = sched::create_kernel_task(
@@ -130,16 +130,16 @@ TEST(fpu, fpu_context_isolation) {
         sched::enqueue_on(tb, 0);
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_iso_done_count, 2));
-    EXPECT_EQ(__atomic_load_n(&g_iso_fail_a, __ATOMIC_ACQUIRE), 0u);
-    EXPECT_EQ(__atomic_load_n(&g_iso_fail_b, __ATOMIC_ACQUIRE), 0u);
+    ASSERT_TRUE(spin_wait_ge(g_iso_done_count, 2));
+    EXPECT_EQ(g_iso_fail_a.load_acquire(), 0u);
+    EXPECT_EQ(g_iso_fail_b.load_acquire(), 0u);
 }
 
 // --- fpu_cross_cpu ---
 // Tasks on different CPUs each write a fingerprint and verify it.
 
-static volatile uint32_t g_cross_fail = 0;
-static volatile uint32_t g_cross_done_count = 0;
+static sync::atomic<uint32_t> g_cross_fail;
+static sync::atomic<uint32_t> g_cross_done_count;
 
 static void cross_cpu_fpu_fn(void* arg) {
     uint64_t fingerprint = reinterpret_cast<uint64_t>(arg);
@@ -154,19 +154,19 @@ static void cross_cpu_fpu_fn(void* arg) {
             readback = read_fpu_reg();
         });
         if (readback != fingerprint) {
-            __atomic_store_n(&g_cross_fail, 1, __ATOMIC_RELEASE);
+            g_cross_fail.store_release(1);
             break;
         }
     }
-    __atomic_fetch_add(&g_cross_done_count, 1, __ATOMIC_ACQ_REL);
+    g_cross_done_count.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(fpu, fpu_cross_cpu) {
     if (smp::cpu_count() < 2) return;
 
-    g_cross_fail = 0;
-    g_cross_done_count = 0;
+    g_cross_fail.store_relaxed(0);
+    g_cross_done_count.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t0 = sched::create_kernel_task(
@@ -183,6 +183,6 @@ TEST(fpu, fpu_cross_cpu) {
         sched::enqueue_on(t1, 1);
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_cross_done_count, 2));
-    EXPECT_EQ(__atomic_load_n(&g_cross_fail, __ATOMIC_ACQUIRE), 0u);
+    ASSERT_TRUE(spin_wait_ge(g_cross_done_count, 2));
+    EXPECT_EQ(g_cross_fail.load_acquire(), 0u);
 }

--- a/kernel/tests/sched/kill.test.cpp
+++ b/kernel/tests/sched/kill.test.cpp
@@ -29,9 +29,9 @@ TEST_SUITE(kill);
 // A task sleeping for a long time is woken immediately by force_wake_for_kill.
 // Verifies: kill_pending is set, sleep is cancelled, task completes promptly.
 
-static volatile uint32_t g_sleep_kill_done = 0;
-static volatile uint32_t g_sleep_kill_was_pending = 0;
-static volatile uint64_t g_sleep_kill_elapsed_ns = 0;
+static sync::atomic<uint32_t> g_sleep_kill_done;
+static sync::atomic<uint32_t> g_sleep_kill_was_pending;
+static sync::atomic<uint64_t> g_sleep_kill_elapsed_ns;
 
 static void sleep_kill_fn(void*) {
     uint64_t start = clock::now_ns();
@@ -39,21 +39,21 @@ static void sleep_kill_fn(void*) {
         sched::sleep_ns(5000000000ULL); // 5 seconds -- should be cancelled
     });
     uint64_t elapsed = clock::now_ns() - start;
-    __atomic_store_n(&g_sleep_kill_elapsed_ns, elapsed, __ATOMIC_RELEASE);
+    g_sleep_kill_elapsed_ns.store_release(elapsed);
 
     uint32_t kp = 0;
     RUN_ELEVATED({
         kp = sched::is_kill_pending() ? 1u : 0u;
     });
-    __atomic_store_n(&g_sleep_kill_was_pending, kp, __ATOMIC_RELEASE);
-    __atomic_store_n(&g_sleep_kill_done, 1, __ATOMIC_RELEASE);
+    g_sleep_kill_was_pending.store_release(kp);
+    g_sleep_kill_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(kill, force_wake_kills_sleeping_task) {
-    g_sleep_kill_done = 0;
-    g_sleep_kill_was_pending = 0;
-    g_sleep_kill_elapsed_ns = 0;
+    g_sleep_kill_done.store_relaxed(0);
+    g_sleep_kill_was_pending.store_relaxed(0);
+    g_sleep_kill_elapsed_ns.store_relaxed(0);
 
     sched::task* t = nullptr;
     RUN_ELEVATED({
@@ -68,9 +68,9 @@ TEST(kill, force_wake_kills_sleeping_task) {
         sched::force_wake_for_kill(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_sleep_kill_done));
-    EXPECT_EQ(__atomic_load_n(&g_sleep_kill_was_pending, __ATOMIC_ACQUIRE), 1u);
-    EXPECT_LT(__atomic_load_n(&g_sleep_kill_elapsed_ns, __ATOMIC_ACQUIRE),
+    ASSERT_TRUE(spin_wait(g_sleep_kill_done));
+    EXPECT_EQ(g_sleep_kill_was_pending.load_acquire(), 1u);
+    EXPECT_LT(g_sleep_kill_elapsed_ns.load_acquire(),
               static_cast<uint64_t>(2000000000)); // woke in < 2s, not 5s
 }
 
@@ -79,9 +79,9 @@ TEST(kill, force_wake_kills_sleeping_task) {
 // at the block commit point instead of being lost until natural expiry.
 
 TEST(kill, kill_before_sleep_aborts_sleep) {
-    g_sleep_kill_done = 0;
-    g_sleep_kill_was_pending = 0;
-    g_sleep_kill_elapsed_ns = 0;
+    g_sleep_kill_done.store_relaxed(0);
+    g_sleep_kill_was_pending.store_relaxed(0);
+    g_sleep_kill_elapsed_ns.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(sleep_kill_fn, nullptr, "kill_presleep");
@@ -90,9 +90,9 @@ TEST(kill, kill_before_sleep_aborts_sleep) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_sleep_kill_done));
-    EXPECT_EQ(__atomic_load_n(&g_sleep_kill_was_pending, __ATOMIC_ACQUIRE), 1u);
-    EXPECT_LT(__atomic_load_n(&g_sleep_kill_elapsed_ns, __ATOMIC_ACQUIRE),
+    ASSERT_TRUE(spin_wait(g_sleep_kill_done));
+    EXPECT_EQ(g_sleep_kill_was_pending.load_acquire(), 1u);
+    EXPECT_LT(g_sleep_kill_elapsed_ns.load_acquire(),
               static_cast<uint64_t>(2000000000)); // aborted, not slept for 5s
 }
 
@@ -102,14 +102,14 @@ TEST(kill, kill_before_sleep_aborts_sleep) {
 
 static sync::wait_queue g_wq_kill_wq;
 static sync::spinlock g_wq_kill_lock;
-static volatile uint32_t g_wq_kill_waiting = 0;
-static volatile uint32_t g_wq_kill_done = 0;
-static volatile uint32_t g_wq_kill_was_pending = 0;
+static sync::atomic<uint32_t> g_wq_kill_waiting;
+static sync::atomic<uint32_t> g_wq_kill_done;
+static sync::atomic<uint32_t> g_wq_kill_was_pending;
 
 static void wq_kill_fn(void*) {
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_wq_kill_lock);
-        __atomic_store_n(&g_wq_kill_waiting, 1, __ATOMIC_RELEASE);
+        g_wq_kill_waiting.store_release(1);
         while (!sched::is_kill_pending()) {
             irq = sync::wait(g_wq_kill_wq, g_wq_kill_lock, irq);
         }
@@ -120,17 +120,17 @@ static void wq_kill_fn(void*) {
     RUN_ELEVATED({
         kp = sched::is_kill_pending() ? 1u : 0u;
     });
-    __atomic_store_n(&g_wq_kill_was_pending, kp, __ATOMIC_RELEASE);
-    __atomic_store_n(&g_wq_kill_done, 1, __ATOMIC_RELEASE);
+    g_wq_kill_was_pending.store_release(kp);
+    g_wq_kill_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(kill, force_wake_kills_blocked_on_wq) {
     g_wq_kill_wq.init();
     g_wq_kill_lock = sync::SPINLOCK_INIT;
-    g_wq_kill_waiting = 0;
-    g_wq_kill_done = 0;
-    g_wq_kill_was_pending = 0;
+    g_wq_kill_waiting.store_relaxed(0);
+    g_wq_kill_done.store_relaxed(0);
+    g_wq_kill_was_pending.store_relaxed(0);
 
     sched::task* t = nullptr;
     RUN_ELEVATED({
@@ -139,15 +139,15 @@ TEST(kill, force_wake_kills_blocked_on_wq) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_wq_kill_waiting));
+    ASSERT_TRUE(spin_wait(g_wq_kill_waiting));
     brief_delay();
 
     RUN_ELEVATED({
         sched::force_wake_for_kill(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_wq_kill_done));
-    EXPECT_EQ(__atomic_load_n(&g_wq_kill_was_pending, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_wq_kill_done));
+    EXPECT_EQ(g_wq_kill_was_pending.load_acquire(), 1u);
 }
 
 // --- self_removal_cleans_wq ---
@@ -155,27 +155,27 @@ TEST(kill, force_wake_kills_blocked_on_wq) {
 
 static sync::wait_queue g_sr_wq;
 static sync::spinlock g_sr_lock;
-static volatile uint32_t g_sr_waiting = 0;
-static volatile uint32_t g_sr_done = 0;
+static sync::atomic<uint32_t> g_sr_waiting;
+static sync::atomic<uint32_t> g_sr_done;
 
 static void sr_waiter_fn(void*) {
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_sr_lock);
-        __atomic_store_n(&g_sr_waiting, 1, __ATOMIC_RELEASE);
+        g_sr_waiting.store_release(1);
         while (!sched::is_kill_pending()) {
             irq = sync::wait(g_sr_wq, g_sr_lock, irq);
         }
         sync::spin_unlock_irqrestore(g_sr_lock, irq);
     });
-    __atomic_store_n(&g_sr_done, 1, __ATOMIC_RELEASE);
+    g_sr_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(kill, self_removal_cleans_wq) {
     g_sr_wq.init();
     g_sr_lock = sync::SPINLOCK_INIT;
-    g_sr_waiting = 0;
-    g_sr_done = 0;
+    g_sr_waiting.store_relaxed(0);
+    g_sr_done.store_relaxed(0);
 
     sched::task* t = nullptr;
     RUN_ELEVATED({
@@ -184,48 +184,46 @@ TEST(kill, self_removal_cleans_wq) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_sr_waiting));
+    ASSERT_TRUE(spin_wait(g_sr_waiting));
     brief_delay();
 
     RUN_ELEVATED({
         sched::force_wake_for_kill(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_sr_done));
+    ASSERT_TRUE(spin_wait(g_sr_done));
     EXPECT_TRUE(g_sr_wq.waiters.empty());
 }
 
 // --- double_kill_is_harmless ---
 // Calling force_wake_for_kill twice on the same task does not crash.
 
-static volatile uint32_t g_double_waiting = 0;
-static volatile uint32_t g_double_done = 0;
-static volatile uint32_t g_double_kp = 0;
+static sync::atomic<uint32_t> g_double_waiting;
+static sync::atomic<uint32_t> g_double_done;
+static sync::atomic<uint32_t> g_double_kp;
 static sync::wait_queue g_double_wq;
 static sync::spinlock g_double_lock;
 
 static void double_kill_fn(void*) {
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_double_lock);
-        __atomic_store_n(&g_double_waiting, 1, __ATOMIC_RELEASE);
+        g_double_waiting.store_release(1);
         while (!sched::is_kill_pending()) {
             irq = sync::wait(g_double_wq, g_double_lock, irq);
         }
         sync::spin_unlock_irqrestore(g_double_lock, irq);
-        __atomic_store_n(&g_double_kp,
-            sched::is_kill_pending() ? 1u : 0u,
-            __ATOMIC_RELEASE);
+        g_double_kp.store_release(sched::is_kill_pending() ? 1u : 0u);
     });
-    __atomic_store_n(&g_double_done, 1, __ATOMIC_RELEASE);
+    g_double_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(kill, double_kill_is_harmless) {
     g_double_wq.init();
     g_double_lock = sync::SPINLOCK_INIT;
-    g_double_waiting = 0;
-    g_double_done = 0;
-    g_double_kp = 0;
+    g_double_waiting.store_relaxed(0);
+    g_double_done.store_relaxed(0);
+    g_double_kp.store_relaxed(0);
 
     sched::task* t = nullptr;
     RUN_ELEVATED({
@@ -234,7 +232,7 @@ TEST(kill, double_kill_is_harmless) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_double_waiting));
+    ASSERT_TRUE(spin_wait(g_double_waiting));
     brief_delay();
 
     RUN_ELEVATED({
@@ -242,28 +240,28 @@ TEST(kill, double_kill_is_harmless) {
         sched::force_wake_for_kill(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_double_done));
-    EXPECT_EQ(__atomic_load_n(&g_double_kp, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_double_done));
+    EXPECT_EQ(g_double_kp.load_acquire(), 1u);
 }
 
 // --- is_kill_pending_accessor ---
 // Verifies is_kill_pending() returns correct values before and after setting the flag.
 
-static volatile uint32_t g_ikp_before = 0xFF;
-static volatile uint32_t g_ikp_after = 0xFF;
-static volatile uint32_t g_ikp_done = 0;
-static volatile uint32_t g_ikp_flag_set = 0;
-static volatile uint32_t g_ikp_started = 0;
+static sync::atomic<uint32_t> g_ikp_before{0xFF};
+static sync::atomic<uint32_t> g_ikp_after{0xFF};
+static sync::atomic<uint32_t> g_ikp_done;
+static sync::atomic<uint32_t> g_ikp_flag_set;
+static sync::atomic<uint32_t> g_ikp_started;
 
 static void ikp_fn(void*) {
     uint32_t before = 0;
     RUN_ELEVATED({
         before = sched::is_kill_pending() ? 1 : 0;
     });
-    __atomic_store_n(&g_ikp_before, before, __ATOMIC_RELEASE);
-    __atomic_store_n(&g_ikp_started, 1, __ATOMIC_RELEASE);
+    g_ikp_before.store_release(before);
+    g_ikp_started.store_release(1);
 
-    while (!__atomic_load_n(&g_ikp_flag_set, __ATOMIC_ACQUIRE)) {
+    while (!g_ikp_flag_set.load_acquire()) {
         // busy wait for test driver to set kill_pending
     }
 
@@ -271,17 +269,17 @@ static void ikp_fn(void*) {
     RUN_ELEVATED({
         after = sched::is_kill_pending() ? 1 : 0;
     });
-    __atomic_store_n(&g_ikp_after, after, __ATOMIC_RELEASE);
-    __atomic_store_n(&g_ikp_done, 1, __ATOMIC_RELEASE);
+    g_ikp_after.store_release(after);
+    g_ikp_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(kill, is_kill_pending_accessor) {
-    g_ikp_before = 0xFF;
-    g_ikp_after = 0xFF;
-    g_ikp_done = 0;
-    g_ikp_flag_set = 0;
-    g_ikp_started = 0;
+    g_ikp_before.store_relaxed(0xFF);
+    g_ikp_after.store_relaxed(0xFF);
+    g_ikp_done.store_relaxed(0);
+    g_ikp_flag_set.store_relaxed(0);
+    g_ikp_started.store_relaxed(0);
 
     sched::task* t = nullptr;
     RUN_ELEVATED({
@@ -290,16 +288,16 @@ TEST(kill, is_kill_pending_accessor) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_ikp_started));
+    ASSERT_TRUE(spin_wait(g_ikp_started));
 
     RUN_ELEVATED({
         t->sig.pending.fetch_or_release(signals::sig_bit(signals::SIGKILL));
     });
-    __atomic_store_n(&g_ikp_flag_set, 1, __ATOMIC_RELEASE);
+    g_ikp_flag_set.store_release(1);
 
-    ASSERT_TRUE(spin_wait(&g_ikp_done));
-    EXPECT_EQ(__atomic_load_n(&g_ikp_before, __ATOMIC_ACQUIRE), 0u);
-    EXPECT_EQ(__atomic_load_n(&g_ikp_after, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_ikp_done));
+    EXPECT_EQ(g_ikp_before.load_acquire(), 0u);
+    EXPECT_EQ(g_ikp_after.load_acquire(), 1u);
 }
 
 // --- wait_status_normal_exit ---

--- a/kernel/tests/sched/kill.test.cpp
+++ b/kernel/tests/sched/kill.test.cpp
@@ -17,7 +17,7 @@ using test_helpers::brief_delay;
 // Deterministic handshake: wait until the task has actually blocked.
 static bool wait_until_blocked(sched::task* t) {
     uint64_t deadline = clock::now_ns() + test_helpers::SPIN_TIMEOUT_NS;
-    while (__atomic_load_n(&t->state, __ATOMIC_ACQUIRE) != sched::TASK_STATE_BLOCKED) {
+    while (t->state.load_acquire() != sched::TASK_STATE_BLOCKED) {
         if (clock::now_ns() > deadline) return false;
     }
     return true;
@@ -293,8 +293,7 @@ TEST(kill, is_kill_pending_accessor) {
     ASSERT_TRUE(spin_wait(&g_ikp_started));
 
     RUN_ELEVATED({
-        __atomic_fetch_or(&t->sig.pending,
-                          signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
+        t->sig.pending.fetch_or_release(signals::sig_bit(signals::SIGKILL));
     });
     __atomic_store_n(&g_ikp_flag_set, 1, __ATOMIC_RELEASE);
 

--- a/kernel/tests/sched/preemption.test.cpp
+++ b/kernel/tests/sched/preemption.test.cpp
@@ -14,15 +14,15 @@ TEST_SUITE(preemption);
 // --- basic_preemption ---
 // Proves: timer preempts the boot task, created task runs without explicit yield.
 
-static volatile uint32_t g_basic_done = 0;
+static sync::atomic<uint32_t> g_basic_done;
 
 static void basic_task_fn(void*) {
-    __atomic_store_n(&g_basic_done, 1, __ATOMIC_RELEASE);
+    g_basic_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(preemption, basic_preemption) {
-    g_basic_done = 0;
+    g_basic_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(basic_task_fn, nullptr, "test_basic");
@@ -30,15 +30,15 @@ TEST(preemption, basic_preemption) {
         sched::enqueue(t);
     });
 
-    bool completed = spin_wait(&g_basic_done);
+    bool completed = spin_wait(g_basic_done);
     EXPECT_TRUE(completed);
 }
 
 // --- context_integrity ---
 // Proves: register context survives preemption across many timer ticks.
 
-static volatile uint32_t g_fib_result = 0;
-static volatile uint32_t g_fib_done = 0;
+static sync::atomic<uint32_t> g_fib_result;
+static sync::atomic<uint32_t> g_fib_done;
 
 static int fib(int n) {
     if (n <= 0) return 0;
@@ -49,14 +49,14 @@ static int fib(int n) {
 
 static void fib_task_fn(void*) {
     int result = fib(25);
-    __atomic_store_n(&g_fib_result, static_cast<uint32_t>(result), __ATOMIC_RELEASE);
-    __atomic_store_n(&g_fib_done, 1, __ATOMIC_RELEASE);
+    g_fib_result.store_release(static_cast<uint32_t>(result));
+    g_fib_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(preemption, context_integrity) {
-    g_fib_result = 0;
-    g_fib_done = 0;
+    g_fib_result.store_relaxed(0);
+    g_fib_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(fib_task_fn, nullptr, "test_fib");
@@ -64,26 +64,26 @@ TEST(preemption, context_integrity) {
         sched::enqueue(t);
     });
 
-    bool completed = spin_wait(&g_fib_done);
+    bool completed = spin_wait(g_fib_done);
     ASSERT_TRUE(completed);
-    EXPECT_EQ(g_fib_result, static_cast<uint32_t>(75025));
+    EXPECT_EQ(g_fib_result.load_acquire(), static_cast<uint32_t>(75025));
 }
 
 // --- multiple_tasks_complete ---
 // Proves: round-robin scheduler doesn't starve any task.
 
 constexpr uint32_t MULTI_COUNT = 4;
-static volatile uint32_t g_multi_done[MULTI_COUNT] = {};
+static sync::atomic<uint32_t> g_multi_done[MULTI_COUNT] = {};
 
 static void multi_task_fn(void* arg) {
     uint32_t idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg));
-    __atomic_store_n(&g_multi_done[idx], 1, __ATOMIC_RELEASE);
+    g_multi_done[idx].store_release(1);
     sched::exit(0);
 }
 
 TEST(preemption, multiple_tasks_complete) {
     for (uint32_t i = 0; i < MULTI_COUNT; i++) {
-        g_multi_done[i] = 0;
+        g_multi_done[i].store_relaxed(0);
     }
 
     RUN_ELEVATED({
@@ -98,7 +98,7 @@ TEST(preemption, multiple_tasks_complete) {
     });
 
     for (uint32_t i = 0; i < MULTI_COUNT; i++) {
-        bool completed = spin_wait(&g_multi_done[i]);
+        bool completed = spin_wait(g_multi_done[i]);
         EXPECT_TRUE(completed);
     }
 }
@@ -108,22 +108,22 @@ TEST(preemption, multiple_tasks_complete) {
 
 constexpr uint32_t ATOMIC_TASKS = 4;
 constexpr uint32_t ATOMIC_ITERS = 1000;
-static volatile uint32_t g_atomic_counter = 0;
-static volatile uint32_t g_atomic_done[ATOMIC_TASKS] = {};
+static sync::atomic<uint32_t> g_atomic_counter;
+static sync::atomic<uint32_t> g_atomic_done[ATOMIC_TASKS] = {};
 
 static void atomic_task_fn(void* arg) {
     uint32_t idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg));
     for (uint32_t i = 0; i < ATOMIC_ITERS; i++) {
-        __atomic_fetch_add(&g_atomic_counter, 1, __ATOMIC_RELAXED);
+        g_atomic_counter.fetch_add_relaxed(1);
     }
-    __atomic_store_n(&g_atomic_done[idx], 1, __ATOMIC_RELEASE);
+    g_atomic_done[idx].store_release(1);
     sched::exit(0);
 }
 
 TEST(preemption, atomic_counter) {
-    g_atomic_counter = 0;
+    g_atomic_counter.store_relaxed(0);
     for (uint32_t i = 0; i < ATOMIC_TASKS; i++) {
-        g_atomic_done[i] = 0;
+        g_atomic_done[i].store_relaxed(0);
     }
 
     RUN_ELEVATED({
@@ -138,10 +138,10 @@ TEST(preemption, atomic_counter) {
     });
 
     for (uint32_t i = 0; i < ATOMIC_TASKS; i++) {
-        bool completed = spin_wait(&g_atomic_done[i]);
+        bool completed = spin_wait(g_atomic_done[i]);
         EXPECT_TRUE(completed);
     }
 
-    uint32_t final_count = __atomic_load_n(&g_atomic_counter, __ATOMIC_ACQUIRE);
+    uint32_t final_count = g_atomic_counter.load_acquire();
     EXPECT_EQ(final_count, ATOMIC_TASKS * ATOMIC_ITERS);
 }

--- a/kernel/tests/sched/process_group.test.cpp
+++ b/kernel/tests/sched/process_group.test.cpp
@@ -29,12 +29,12 @@ static void init_process(sched::task* t, sched::thread_group* tg, uint32_t tid) 
     tg->lock = sync::SPINLOCK_INIT;
     tg->leader = t;
     tg->pid = tid;
-    tg->group_id = tid;
+    tg->group_id.store_relaxed(tid);
     tg->threads.init();
     tg->thread_count = 0;
 
     t->tid = tid;
-    t->state = sched::TASK_STATE_CREATED;
+    t->state.store_relaxed(sched::TASK_STATE_CREATED);
     t->group = tg;
 }
 
@@ -68,7 +68,7 @@ static void attach_self_group() {
     g_self_tg->lock = sync::SPINLOCK_INIT;
     g_self_tg->leader = self;
     g_self_tg->pid = self->tid;
-    g_self_tg->group_id = self->tid;
+    g_self_tg->group_id.store_relaxed(self->tid);
     g_self_tg->threads.init();
     g_self_tg->thread_count = 0;
 
@@ -143,12 +143,12 @@ TEST(process_group, setpgid_self_creates_and_joins) {
     // Making yourself your own group is always allowed
     RUN_ELEVATED({ rc = sys_setpgid(0, 0, 0, 0, 0, 0); });
     EXPECT_EQ(rc, 0);
-    EXPECT_EQ(g_self_tg->group_id, self_tid);
+    EXPECT_EQ(g_self_tg->group_id.load_relaxed(), self_tid);
 
     // Joining an existing group with a live member
     RUN_ELEVATED({ rc = sys_setpgid(0, TEST_TID, 0, 0, 0, 0); });
     EXPECT_EQ(rc, 0);
-    EXPECT_EQ(g_self_tg->group_id, TEST_TID);
+    EXPECT_EQ(g_self_tg->group_id.load_relaxed(), TEST_TID);
 
     detach_self_group();
 }
@@ -195,13 +195,13 @@ TEST(process_group, setpgid_regroups_unstarted_child) {
     // An unstarted child owned via a handle may be moved into a live group
     RUN_ELEVATED({ rc = sys_setpgid(TEST_TID, TEST_TID2, 0, 0, 0, 0); });
     EXPECT_EQ(rc, 0);
-    EXPECT_EQ(g_tg->group_id, TEST_TID2);
+    EXPECT_EQ(g_tg->group_id.load_relaxed(), TEST_TID2);
 
     // A started child may not be re-grouped anymore
-    g_proc->state = sched::TASK_STATE_READY;
+    g_proc->state.store_relaxed(sched::TASK_STATE_READY);
     RUN_ELEVATED({ rc = sys_setpgid(TEST_TID, 0, 0, 0, 0, 0); });
     EXPECT_EQ(rc, syscall::EACCES);
-    g_proc->state = sched::TASK_STATE_CREATED;
+    g_proc->state.store_relaxed(sched::TASK_STATE_CREATED);
 
     // Detach the hand-built child before dropping the proc resource so
     // its close path cannot run real task teardown on it

--- a/kernel/tests/sched/sleep.test.cpp
+++ b/kernel/tests/sched/sleep.test.cpp
@@ -19,18 +19,18 @@ constexpr uint32_t MAX_TEST_CPUS = 16;
 // --- sleep_ns_zero ---
 // Proves: sleep_ns(0) returns quickly (yields without blocking).
 
-static volatile uint32_t g_zero_done = 0;
+static sync::atomic<uint32_t> g_zero_done;
 
 static void zero_sleeper_fn(void*) {
     RUN_ELEVATED({
         sched::sleep_ns(0);
     });
-    __atomic_store_n(&g_zero_done, 1, __ATOMIC_RELEASE);
+    g_zero_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(sleep, sleep_ns_zero) {
-    g_zero_done = 0;
+    g_zero_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(
@@ -39,15 +39,15 @@ TEST(sleep, sleep_ns_zero) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_zero_done));
+    ASSERT_TRUE(spin_wait(g_zero_done));
 }
 
 // --- sleep_ms_basic ---
 // Proves: sleep_ns(100ms) sleeps for approximately 100ms.
 
-static volatile uint32_t g_basic_done = 0;
-static volatile uint64_t g_basic_elapsed_hi = 0;
-static volatile uint64_t g_basic_elapsed_lo = 0;
+static sync::atomic<uint32_t> g_basic_done;
+static sync::atomic<uint64_t> g_basic_elapsed_hi;
+static sync::atomic<uint64_t> g_basic_elapsed_lo;
 
 static void basic_sleeper_fn(void*) {
     uint64_t start = clock::now_ns();
@@ -55,16 +55,16 @@ static void basic_sleeper_fn(void*) {
         sched::sleep_ns(100000000ULL);
     });
     uint64_t elapsed = clock::now_ns() - start;
-    __atomic_store_n(&g_basic_elapsed_hi, elapsed >> 32, __ATOMIC_RELEASE);
-    __atomic_store_n(&g_basic_elapsed_lo, elapsed & 0xFFFFFFFF, __ATOMIC_RELEASE);
-    __atomic_store_n(&g_basic_done, 1, __ATOMIC_RELEASE);
+    g_basic_elapsed_hi.store_release(elapsed >> 32);
+    g_basic_elapsed_lo.store_release(elapsed & 0xFFFFFFFF);
+    g_basic_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(sleep, sleep_ms_basic) {
-    g_basic_done = 0;
-    g_basic_elapsed_hi = 0;
-    g_basic_elapsed_lo = 0;
+    g_basic_done.store_relaxed(0);
+    g_basic_elapsed_hi.store_relaxed(0);
+    g_basic_elapsed_lo.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(
@@ -73,10 +73,10 @@ TEST(sleep, sleep_ms_basic) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_basic_done));
+    ASSERT_TRUE(spin_wait(g_basic_done));
 
-    uint64_t elapsed = (__atomic_load_n(&g_basic_elapsed_hi, __ATOMIC_ACQUIRE) << 32)
-                     | __atomic_load_n(&g_basic_elapsed_lo, __ATOMIC_ACQUIRE);
+    uint64_t elapsed = (g_basic_elapsed_hi.load_acquire() << 32)
+                     | g_basic_elapsed_lo.load_acquire();
     EXPECT_GE(elapsed, static_cast<uint64_t>(50000000));
     EXPECT_LE(elapsed, static_cast<uint64_t>(2000000000));
 }
@@ -84,15 +84,15 @@ TEST(sleep, sleep_ms_basic) {
 // --- sleep_ordering ---
 // Proves: 50ms sleeper wakes before 100ms sleeper.
 
-static volatile uint32_t g_order_count = 0;
-static volatile uint32_t g_order_first = 0;
+static sync::atomic<uint32_t> g_order_count;
+static sync::atomic<uint32_t> g_order_first;
 
 static void order_short_fn(void*) {
     RUN_ELEVATED({
         sched::sleep_ns(50000000ULL);
     });
-    uint32_t idx = __atomic_fetch_add(&g_order_count, 1, __ATOMIC_ACQ_REL);
-    if (idx == 0) __atomic_store_n(&g_order_first, 1, __ATOMIC_RELEASE);
+    uint32_t idx = g_order_count.fetch_add_acq_rel(1);
+    if (idx == 0) g_order_first.store_release(1);
     sched::exit(0);
 }
 
@@ -100,14 +100,14 @@ static void order_long_fn(void*) {
     RUN_ELEVATED({
         sched::sleep_ns(150000000ULL);
     });
-    uint32_t idx = __atomic_fetch_add(&g_order_count, 1, __ATOMIC_ACQ_REL);
-    if (idx == 0) __atomic_store_n(&g_order_first, 2, __ATOMIC_RELEASE);
+    uint32_t idx = g_order_count.fetch_add_acq_rel(1);
+    if (idx == 0) g_order_first.store_release(2);
     sched::exit(0);
 }
 
 TEST(sleep, sleep_ordering) {
-    g_order_count = 0;
-    g_order_first = 0;
+    g_order_count.store_relaxed(0);
+    g_order_first.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t_long = sched::create_kernel_task(
@@ -120,18 +120,18 @@ TEST(sleep, sleep_ordering) {
         sched::enqueue_on(t_short, 0);
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_order_count, 2));
-    EXPECT_EQ(__atomic_load_n(&g_order_first, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait_ge(g_order_count, 2));
+    EXPECT_EQ(g_order_first.load_acquire(), 1u);
 }
 
 // --- sleep_does_not_block_others ---
 // Proves: a sleeping task does not prevent other tasks from running.
 
-static volatile uint32_t g_runner_done = 0;
-static volatile uint32_t g_sleeper_done = 0;
+static sync::atomic<uint32_t> g_runner_done;
+static sync::atomic<uint32_t> g_sleeper_done;
 
 static void nonblock_runner_fn(void*) {
-    __atomic_store_n(&g_runner_done, 1, __ATOMIC_RELEASE);
+    g_runner_done.store_release(1);
     sched::exit(0);
 }
 
@@ -139,13 +139,13 @@ static void nonblock_sleeper_fn(void*) {
     RUN_ELEVATED({
         sched::sleep_ns(200000000ULL);
     });
-    __atomic_store_n(&g_sleeper_done, 1, __ATOMIC_RELEASE);
+    g_sleeper_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(sleep, sleep_does_not_block_others) {
-    g_runner_done = 0;
-    g_sleeper_done = 0;
+    g_runner_done.store_relaxed(0);
+    g_sleeper_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* sleeper = sched::create_kernel_task(
@@ -158,30 +158,30 @@ TEST(sleep, sleep_does_not_block_others) {
         sched::enqueue(runner);
     });
 
-    ASSERT_TRUE(spin_wait(&g_runner_done));
-    ASSERT_TRUE(spin_wait(&g_sleeper_done));
+    ASSERT_TRUE(spin_wait(g_runner_done));
+    ASSERT_TRUE(spin_wait(g_sleeper_done));
 }
 
 // --- sleep_on_remote_cpu ---
 // Proves: task on CPU 1 can sleep and wake correctly.
 
-static volatile uint32_t g_remote_done = 0;
-static volatile uint32_t g_remote_cpu = 0xFFFFFFFF;
+static sync::atomic<uint32_t> g_remote_done;
+static sync::atomic<uint32_t> g_remote_cpu{0xFFFFFFFF};
 
 static void remote_sleeper_fn(void*) {
-    __atomic_store_n(&g_remote_cpu, percpu::current_cpu_id(), __ATOMIC_RELEASE);
+    g_remote_cpu.store_release(percpu::current_cpu_id());
     RUN_ELEVATED({
         sched::sleep_ns(50000000ULL);
     });
-    __atomic_store_n(&g_remote_done, 1, __ATOMIC_RELEASE);
+    g_remote_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(sleep, sleep_on_remote_cpu) {
     if (smp::cpu_count() < 2) return;
 
-    g_remote_done = 0;
-    g_remote_cpu = 0xFFFFFFFF;
+    g_remote_done.store_relaxed(0);
+    g_remote_cpu.store_relaxed(0xFFFFFFFF);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(
@@ -190,21 +190,21 @@ TEST(sleep, sleep_on_remote_cpu) {
         sched::enqueue_on(t, 1);
     });
 
-    ASSERT_TRUE(spin_wait(&g_remote_done));
-    EXPECT_EQ(__atomic_load_n(&g_remote_cpu, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_remote_done));
+    EXPECT_EQ(g_remote_cpu.load_acquire(), 1u);
 }
 
 // --- sleep_simultaneous ---
 // Proves: tasks on all CPUs can sleep and wake independently.
 
-static volatile uint32_t g_sim_done[MAX_TEST_CPUS] = {};
+static sync::atomic<uint32_t> g_sim_done[MAX_TEST_CPUS] = {};
 
 static void sim_sleeper_fn(void* arg) {
     uint32_t idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg));
     RUN_ELEVATED({
         sched::sleep_ns(100000000ULL);
     });
-    __atomic_store_n(&g_sim_done[idx], 1, __ATOMIC_RELEASE);
+    g_sim_done[idx].store_release(1);
     sched::exit(0);
 }
 
@@ -213,7 +213,7 @@ TEST(sleep, sleep_simultaneous) {
     if (cpus < 2 || cpus > MAX_TEST_CPUS) return;
 
     for (uint32_t i = 0; i < cpus; i++) {
-        g_sim_done[i] = 0;
+        g_sim_done[i].store_relaxed(0);
     }
 
     RUN_ELEVATED({
@@ -228,25 +228,25 @@ TEST(sleep, sleep_simultaneous) {
     });
 
     for (uint32_t i = 0; i < cpus; i++) {
-        ASSERT_TRUE(spin_wait(&g_sim_done[i]));
+        ASSERT_TRUE(spin_wait(g_sim_done[i]));
     }
 }
 
 // --- sleep_same_deadline ---
 // Proves: 4 tasks with identical deadlines all complete.
 
-static volatile uint32_t g_same_done_count = 0;
+static sync::atomic<uint32_t> g_same_done_count;
 
 static void same_deadline_fn(void*) {
     RUN_ELEVATED({
         sched::sleep_ns(80000000ULL);
     });
-    __atomic_fetch_add(&g_same_done_count, 1, __ATOMIC_ACQ_REL);
+    g_same_done_count.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(sleep, sleep_same_deadline) {
-    g_same_done_count = 0;
+    g_same_done_count.store_relaxed(0);
 
     RUN_ELEVATED({
         for (uint32_t i = 0; i < 4; i++) {
@@ -257,5 +257,5 @@ TEST(sleep, sleep_same_deadline) {
         }
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_same_done_count, 4));
+    ASSERT_TRUE(spin_wait_ge(g_same_done_count, 4));
 }

--- a/kernel/tests/sched/smp_scheduling.test.cpp
+++ b/kernel/tests/sched/smp_scheduling.test.cpp
@@ -18,12 +18,12 @@ constexpr uint32_t MAX_TEST_CPUS = 16;
 // --- enqueue_on_specific_cpu ---
 // Proves: enqueue_on(t, N) causes the task to execute on CPU N.
 
-static volatile uint32_t g_specific_cpu = 0xFFFFFFFF;
-static volatile uint32_t g_specific_done = 0;
+static sync::atomic<uint32_t> g_specific_cpu{0xFFFFFFFF};
+static sync::atomic<uint32_t> g_specific_done;
 
 static void specific_cpu_fn(void*) {
-    __atomic_store_n(&g_specific_cpu, percpu::current_cpu_id(), __ATOMIC_RELEASE);
-    __atomic_store_n(&g_specific_done, 1, __ATOMIC_RELEASE);
+    g_specific_cpu.store_release(percpu::current_cpu_id());
+    g_specific_done.store_release(1);
     sched::exit(0);
 }
 
@@ -32,8 +32,8 @@ TEST(smp_scheduling, enqueue_on_specific_cpu) {
     if (cpus < 2) return;
 
     uint32_t target = cpus - 1;
-    g_specific_cpu = 0xFFFFFFFF;
-    g_specific_done = 0;
+    g_specific_cpu.store_relaxed(0xFFFFFFFF);
+    g_specific_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(
@@ -42,20 +42,20 @@ TEST(smp_scheduling, enqueue_on_specific_cpu) {
         sched::enqueue_on(t, target);
     });
 
-    ASSERT_TRUE(spin_wait(&g_specific_done));
-    EXPECT_EQ(__atomic_load_n(&g_specific_cpu, __ATOMIC_ACQUIRE), target);
+    ASSERT_TRUE(spin_wait(g_specific_done));
+    EXPECT_EQ(g_specific_cpu.load_acquire(), target);
 }
 
 // --- enqueue_on_all_cpus ---
 // Proves: one task per CPU via enqueue_on, each runs on the correct CPU.
 
-static volatile uint32_t g_all_cpu[MAX_TEST_CPUS] = {};
-static volatile uint32_t g_all_done[MAX_TEST_CPUS] = {};
+static sync::atomic<uint32_t> g_all_cpu[MAX_TEST_CPUS] = {};
+static sync::atomic<uint32_t> g_all_done[MAX_TEST_CPUS] = {};
 
 static void all_cpus_fn(void* arg) {
     uint32_t idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg));
-    __atomic_store_n(&g_all_cpu[idx], percpu::current_cpu_id(), __ATOMIC_RELEASE);
-    __atomic_store_n(&g_all_done[idx], 1, __ATOMIC_RELEASE);
+    g_all_cpu[idx].store_release(percpu::current_cpu_id());
+    g_all_done[idx].store_release(1);
     sched::exit(0);
 }
 
@@ -64,8 +64,8 @@ TEST(smp_scheduling, enqueue_on_all_cpus) {
     if (cpus < 2 || cpus > MAX_TEST_CPUS) return;
 
     for (uint32_t i = 0; i < cpus; i++) {
-        g_all_cpu[i] = 0xFFFFFFFF;
-        g_all_done[i] = 0;
+        g_all_cpu[i].store_relaxed(0xFFFFFFFF);
+        g_all_done[i].store_relaxed(0);
     }
 
     RUN_ELEVATED({
@@ -80,8 +80,8 @@ TEST(smp_scheduling, enqueue_on_all_cpus) {
     });
 
     for (uint32_t i = 0; i < cpus; i++) {
-        ASSERT_TRUE(spin_wait(&g_all_done[i]));
-        EXPECT_EQ(__atomic_load_n(&g_all_cpu[i], __ATOMIC_ACQUIRE), i);
+        ASSERT_TRUE(spin_wait(g_all_done[i]));
+        EXPECT_EQ(g_all_cpu[i].load_acquire(), i);
     }
 }
 
@@ -91,13 +91,13 @@ TEST(smp_scheduling, enqueue_on_all_cpus) {
 constexpr uint32_t LB_PER_CPU = 4;
 constexpr uint32_t LB_MAX_TASKS = LB_PER_CPU * MAX_TEST_CPUS;
 
-static volatile uint32_t g_lb_cpu[LB_MAX_TASKS] = {};
-static volatile uint32_t g_lb_done[LB_MAX_TASKS] = {};
+static sync::atomic<uint32_t> g_lb_cpu[LB_MAX_TASKS] = {};
+static sync::atomic<uint32_t> g_lb_done[LB_MAX_TASKS] = {};
 
 static void lb_task_fn(void* arg) {
     uint32_t idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg));
-    __atomic_store_n(&g_lb_cpu[idx], percpu::current_cpu_id(), __ATOMIC_RELEASE);
-    __atomic_store_n(&g_lb_done[idx], 1, __ATOMIC_RELEASE);
+    g_lb_cpu[idx].store_release(percpu::current_cpu_id());
+    g_lb_done[idx].store_release(1);
     sched::exit(0);
 }
 
@@ -107,8 +107,8 @@ TEST(smp_scheduling, load_balance_distributes) {
 
     uint32_t task_count = LB_PER_CPU * cpus;
     for (uint32_t i = 0; i < task_count; i++) {
-        g_lb_cpu[i] = 0xFFFFFFFF;
-        g_lb_done[i] = 0;
+        g_lb_cpu[i].store_relaxed(0xFFFFFFFF);
+        g_lb_done[i].store_relaxed(0);
     }
 
     RUN_ELEVATED({
@@ -123,12 +123,12 @@ TEST(smp_scheduling, load_balance_distributes) {
     });
 
     for (uint32_t i = 0; i < task_count; i++) {
-        ASSERT_TRUE(spin_wait(&g_lb_done[i]));
+        ASSERT_TRUE(spin_wait(g_lb_done[i]));
     }
 
     uint32_t cpus_seen[MAX_TEST_CPUS] = {};
     for (uint32_t i = 0; i < task_count; i++) {
-        uint32_t cpu = __atomic_load_n(&g_lb_cpu[i], __ATOMIC_ACQUIRE);
+        uint32_t cpu = g_lb_cpu[i].load_acquire();
         if (cpu < cpus) {
             cpus_seen[cpu]++;
         }
@@ -144,13 +144,13 @@ TEST(smp_scheduling, load_balance_distributes) {
 // --- parallel_execution ---
 // Proves: tasks on all CPUs run and complete (truly parallel execution).
 
-static volatile uint32_t g_par_counter = 0;
-static volatile uint32_t g_par_done[MAX_TEST_CPUS] = {};
+static sync::atomic<uint32_t> g_par_counter;
+static sync::atomic<uint32_t> g_par_done[MAX_TEST_CPUS] = {};
 
 static void par_task_fn(void* arg) {
     uint32_t idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg));
-    __atomic_fetch_add(&g_par_counter, 1, __ATOMIC_ACQ_REL);
-    __atomic_store_n(&g_par_done[idx], 1, __ATOMIC_RELEASE);
+    g_par_counter.fetch_add_acq_rel(1);
+    g_par_done[idx].store_release(1);
     sched::exit(0);
 }
 
@@ -158,9 +158,9 @@ TEST(smp_scheduling, parallel_execution) {
     uint32_t cpus = smp::cpu_count();
     if (cpus < 2 || cpus > MAX_TEST_CPUS) return;
 
-    g_par_counter = 0;
+    g_par_counter.store_relaxed(0);
     for (uint32_t i = 0; i < cpus; i++) {
-        g_par_done[i] = 0;
+        g_par_done[i].store_relaxed(0);
     }
 
     RUN_ELEVATED({
@@ -175,10 +175,10 @@ TEST(smp_scheduling, parallel_execution) {
     });
 
     for (uint32_t i = 0; i < cpus; i++) {
-        ASSERT_TRUE(spin_wait(&g_par_done[i]));
+        ASSERT_TRUE(spin_wait(g_par_done[i]));
     }
 
-    EXPECT_EQ(__atomic_load_n(&g_par_counter, __ATOMIC_ACQUIRE), cpus);
+    EXPECT_EQ(g_par_counter.load_acquire(), cpus);
 }
 
 // --- cross_cpu_atomic_counter ---
@@ -186,15 +186,15 @@ TEST(smp_scheduling, parallel_execution) {
 
 constexpr uint32_t ATOMIC_ITERS = 1000;
 
-static volatile uint32_t g_xatom_counter = 0;
-static volatile uint32_t g_xatom_done[MAX_TEST_CPUS] = {};
+static sync::atomic<uint32_t> g_xatom_counter;
+static sync::atomic<uint32_t> g_xatom_done[MAX_TEST_CPUS] = {};
 
 static void xatom_task_fn(void* arg) {
     uint32_t idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg));
     for (uint32_t i = 0; i < ATOMIC_ITERS; i++) {
-        __atomic_fetch_add(&g_xatom_counter, 1, __ATOMIC_RELAXED);
+        g_xatom_counter.fetch_add_relaxed(1);
     }
-    __atomic_store_n(&g_xatom_done[idx], 1, __ATOMIC_RELEASE);
+    g_xatom_done[idx].store_release(1);
     sched::exit(0);
 }
 
@@ -202,9 +202,9 @@ TEST(smp_scheduling, cross_cpu_atomic_counter) {
     uint32_t cpus = smp::cpu_count();
     if (cpus < 2 || cpus > MAX_TEST_CPUS) return;
 
-    g_xatom_counter = 0;
+    g_xatom_counter.store_relaxed(0);
     for (uint32_t i = 0; i < cpus; i++) {
-        g_xatom_done[i] = 0;
+        g_xatom_done[i].store_relaxed(0);
     }
 
     RUN_ELEVATED({
@@ -219,9 +219,9 @@ TEST(smp_scheduling, cross_cpu_atomic_counter) {
     });
 
     for (uint32_t i = 0; i < cpus; i++) {
-        ASSERT_TRUE(spin_wait(&g_xatom_done[i]));
+        ASSERT_TRUE(spin_wait(g_xatom_done[i]));
     }
 
-    EXPECT_EQ(__atomic_load_n(&g_xatom_counter, __ATOMIC_ACQUIRE),
+    EXPECT_EQ(g_xatom_counter.load_acquire(),
               cpus * ATOMIC_ITERS);
 }

--- a/kernel/tests/sched/task_registry.test.cpp
+++ b/kernel/tests/sched/task_registry.test.cpp
@@ -3,7 +3,6 @@
 #include "stlx_unit_test.h"
 #include "sched/task_registry.h"
 #include "sched/task.h"
-#include "common/string.h"
 
 TEST_SUITE(task_registry);
 
@@ -18,9 +17,8 @@ static sched::task s_tasks[MAX_MOCK_TASKS];
 // Zero-initialize a mock task and set its TID. Only the tid and
 // task_registry_link fields matter for registry operations.
 static void init_mock_task(sched::task& t, uint32_t tid) {
-    string::memset(&t, 0, sizeof(sched::task));
+    new (&t) sched::task{};
     t.tid = tid;
-    t.task_registry_link = {};
 }
 
 // Re-initialize the static registry and all mock tasks for a clean test.

--- a/kernel/tests/sched/task_registry_integration.test.cpp
+++ b/kernel/tests/sched/task_registry_integration.test.cpp
@@ -43,15 +43,15 @@ static bool wait_for_tid_removal(uint32_t tid) {
 // create_kernel_task inserts the task into g_task_registry before returning.
 // The task is in CREATED state (not yet enqueued). Verify its TID appears.
 
-static volatile uint32_t g_appear_done = 0;
+static sync::atomic<uint32_t> g_appear_done;
 
 static void appear_fn(void*) {
-    __atomic_store_n(&g_appear_done, 1, __ATOMIC_RELEASE);
+    g_appear_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(task_registry_integration, created_task_appears_in_registry) {
-    g_appear_done = 0;
+    g_appear_done.store_relaxed(0);
 
     sched::task* t = nullptr;
     uint32_t tid = 0;
@@ -68,22 +68,22 @@ TEST(task_registry_integration, created_task_appears_in_registry) {
     RUN_ELEVATED({
         sched::enqueue(t);
     });
-    ASSERT_TRUE(spin_wait(&g_appear_done));
+    ASSERT_TRUE(spin_wait(g_appear_done));
 }
 
 // --- multiple_tasks_appear ---
 // Create several kernel tasks, verify all TIDs appear in the registry.
 
 constexpr uint32_t MULTI_COUNT = 4;
-static volatile uint32_t g_multi_done = 0;
+static sync::atomic<uint32_t> g_multi_done;
 
 static void multi_fn(void*) {
-    __atomic_fetch_add(&g_multi_done, 1, __ATOMIC_ACQ_REL);
+    g_multi_done.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(task_registry_integration, multiple_tasks_appear) {
-    g_multi_done = 0;
+    g_multi_done.store_relaxed(0);
     uint32_t tids[MULTI_COUNT];
     sched::task* tasks[MULTI_COUNT] = {};
 
@@ -107,21 +107,21 @@ TEST(task_registry_integration, multiple_tasks_appear) {
         }
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_multi_done, MULTI_COUNT));
+    ASSERT_TRUE(spin_wait_ge(g_multi_done, MULTI_COUNT));
 }
 
 // --- count_increases_on_create ---
 // Verify that g_task_registry.count() increases when a new task is created.
 
-static volatile uint32_t g_count_done = 0;
+static sync::atomic<uint32_t> g_count_done;
 
 static void count_task_fn(void*) {
-    __atomic_store_n(&g_count_done, 1, __ATOMIC_RELEASE);
+    g_count_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(task_registry_integration, count_increases_on_create) {
-    g_count_done = 0;
+    g_count_done.store_relaxed(0);
 
     uint32_t before = 0;
     uint32_t after = 0;
@@ -140,22 +140,22 @@ TEST(task_registry_integration, count_increases_on_create) {
     RUN_ELEVATED({
         sched::enqueue(t);
     });
-    ASSERT_TRUE(spin_wait(&g_count_done));
+    ASSERT_TRUE(spin_wait(g_count_done));
 }
 
 // --- exited_task_eventually_removed ---
 // Create a task, enqueue it, let it exit. Verify its TID eventually
 // disappears from the registry (cleaned up by the reaper).
 
-static volatile uint32_t g_exit_done = 0;
+static sync::atomic<uint32_t> g_exit_done;
 
 static void exit_task_fn(void*) {
-    __atomic_store_n(&g_exit_done, 1, __ATOMIC_RELEASE);
+    g_exit_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(task_registry_integration, exited_task_eventually_removed) {
-    g_exit_done = 0;
+    g_exit_done.store_relaxed(0);
 
     uint32_t tid = 0;
     RUN_ELEVATED({
@@ -166,7 +166,7 @@ TEST(task_registry_integration, exited_task_eventually_removed) {
     });
 
     // Wait for the task to signal it's about to exit
-    ASSERT_TRUE(spin_wait(&g_exit_done));
+    ASSERT_TRUE(spin_wait(g_exit_done));
 
     // Give the reaper time to process
     brief_delay();
@@ -180,21 +180,21 @@ TEST(task_registry_integration, exited_task_eventually_removed) {
 // A task that does some actual work (sleep) should be in the registry
 // while alive, and removed after exit.
 
-static volatile uint32_t g_work_alive = 0;
-static volatile uint32_t g_work_done = 0;
+static sync::atomic<uint32_t> g_work_alive;
+static sync::atomic<uint32_t> g_work_done;
 
 static void work_task_fn(void*) {
-    __atomic_store_n(&g_work_alive, 1, __ATOMIC_RELEASE);
+    g_work_alive.store_release(1);
     RUN_ELEVATED({
         sched::sleep_ns(50000000ULL); // 50ms
     });
-    __atomic_store_n(&g_work_done, 1, __ATOMIC_RELEASE);
+    g_work_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(task_registry_integration, task_with_work_appears_and_disappears) {
-    g_work_alive = 0;
-    g_work_done = 0;
+    g_work_alive.store_relaxed(0);
+    g_work_done.store_relaxed(0);
 
     uint32_t tid = 0;
     RUN_ELEVATED({
@@ -205,13 +205,13 @@ TEST(task_registry_integration, task_with_work_appears_and_disappears) {
     });
 
     // Wait for the task to be alive
-    ASSERT_TRUE(spin_wait(&g_work_alive));
+    ASSERT_TRUE(spin_wait(g_work_alive));
 
     // While alive, it must be in the registry
     EXPECT_TRUE(tid_in_snapshot(tid));
 
     // Wait for task to finish its work
-    ASSERT_TRUE(spin_wait(&g_work_done));
+    ASSERT_TRUE(spin_wait(g_work_done));
 
     // Give reaper time
     brief_delay();
@@ -226,15 +226,15 @@ TEST(task_registry_integration, task_with_work_appears_and_disappears) {
 // disappear from the registry.
 
 constexpr uint32_t BATCH_COUNT = 4;
-static volatile uint32_t g_batch_done = 0;
+static sync::atomic<uint32_t> g_batch_done;
 
 static void batch_exit_fn(void*) {
-    __atomic_fetch_add(&g_batch_done, 1, __ATOMIC_ACQ_REL);
+    g_batch_done.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(task_registry_integration, multiple_exits_all_cleaned) {
-    g_batch_done = 0;
+    g_batch_done.store_relaxed(0);
     uint32_t tids[BATCH_COUNT];
 
     RUN_ELEVATED({
@@ -247,7 +247,7 @@ TEST(task_registry_integration, multiple_exits_all_cleaned) {
     });
 
     // Wait for all tasks to signal they're exiting
-    ASSERT_TRUE(spin_wait_ge(&g_batch_done, BATCH_COUNT));
+    ASSERT_TRUE(spin_wait_ge(g_batch_done, BATCH_COUNT));
 
     // Give reaper time
     brief_delay();
@@ -262,22 +262,22 @@ TEST(task_registry_integration, multiple_exits_all_cleaned) {
 // --- snapshot_contains_running_tasks ---
 // While tasks are running, snapshot should contain their TIDs.
 
-static volatile uint32_t g_snap_ready = 0;
-static volatile uint32_t g_snap_done = 0;
+static sync::atomic<uint32_t> g_snap_ready;
+static sync::atomic<uint32_t> g_snap_done;
 
 static void snap_task_fn(void*) {
-    __atomic_fetch_add(&g_snap_ready, 1, __ATOMIC_ACQ_REL);
+    g_snap_ready.fetch_add_acq_rel(1);
     // Sleep just long enough for the test to take its snapshot
     RUN_ELEVATED({
         sched::sleep_ns(100000000ULL); // 100ms
     });
-    __atomic_fetch_add(&g_snap_done, 1, __ATOMIC_ACQ_REL);
+    g_snap_done.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(task_registry_integration, snapshot_contains_running_tasks) {
-    g_snap_ready = 0;
-    g_snap_done = 0;
+    g_snap_ready.store_relaxed(0);
+    g_snap_done.store_relaxed(0);
 
     constexpr uint32_t N = 3;
     uint32_t tids[N];
@@ -292,7 +292,7 @@ TEST(task_registry_integration, snapshot_contains_running_tasks) {
     });
 
     // Wait for all tasks to signal they're alive
-    ASSERT_TRUE(spin_wait_ge(&g_snap_ready, N));
+    ASSERT_TRUE(spin_wait_ge(g_snap_ready, N));
 
     // Tasks are now sleeping. Take a snapshot -- they must still be in registry.
     for (uint32_t i = 0; i < N; i++) {
@@ -303,22 +303,22 @@ TEST(task_registry_integration, snapshot_contains_running_tasks) {
     // Use a generous busy-wait since tasks sleep 100ms then exit.
     constexpr uint64_t DONE_TIMEOUT = 500000000ULL;
     uint64_t spins = 0;
-    while (__atomic_load_n(&g_snap_done, __ATOMIC_ACQUIRE) < N) {
+    while (g_snap_done.load_acquire() < N) {
         if (++spins > DONE_TIMEOUT) break;
     }
-    EXPECT_GE(__atomic_load_n(&g_snap_done, __ATOMIC_ACQUIRE), N);
+    EXPECT_GE(g_snap_done.load_acquire(), N);
 }
 
 // --- concurrent_inserts_from_multiple_cpus ---
 // Tasks running on different CPUs each create a sub-task, causing
 // concurrent inserts into the global registry. Verify all TIDs appear.
 
-static volatile uint32_t g_conc_tids[8] = {};
-static volatile uint32_t g_conc_ready = 0;
-static volatile uint32_t g_conc_subtask_done = 0;
+static sync::atomic<uint32_t> g_conc_tids[8] = {};
+static sync::atomic<uint32_t> g_conc_ready;
+static sync::atomic<uint32_t> g_conc_subtask_done;
 
 static void conc_subtask_fn(void*) {
-    __atomic_fetch_add(&g_conc_subtask_done, 1, __ATOMIC_ACQ_REL);
+    g_conc_subtask_done.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
@@ -327,11 +327,11 @@ static void conc_creator_fn(void* arg) {
     RUN_ELEVATED({
         sched::task* sub = sched::create_kernel_task(conc_subtask_fn, nullptr, "reg_csub");
         if (sub) {
-            __atomic_store_n(&g_conc_tids[idx], sub->tid, __ATOMIC_RELEASE);
+            g_conc_tids[idx].store_release(sub->tid);
             sched::enqueue(sub);
         }
     });
-    __atomic_fetch_add(&g_conc_ready, 1, __ATOMIC_ACQ_REL);
+    g_conc_ready.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
@@ -340,9 +340,9 @@ TEST(task_registry_integration, concurrent_inserts_from_multiple_cpus) {
     uint32_t n_creators = cpus < 4 ? cpus : 4;
     if (n_creators < 2) return; // Need at least 2 CPUs for this test
 
-    g_conc_ready = 0;
-    g_conc_subtask_done = 0;
-    for (uint32_t i = 0; i < 8; i++) g_conc_tids[i] = 0;
+    g_conc_ready.store_relaxed(0);
+    g_conc_subtask_done.store_relaxed(0);
+    for (uint32_t i = 0; i < 8; i++) g_conc_tids[i].store_relaxed(0);
 
     RUN_ELEVATED({
         for (uint32_t i = 0; i < n_creators; i++) {
@@ -356,15 +356,15 @@ TEST(task_registry_integration, concurrent_inserts_from_multiple_cpus) {
     });
 
     // Wait for all creators to finish
-    ASSERT_TRUE(spin_wait_ge(&g_conc_ready, n_creators));
+    ASSERT_TRUE(spin_wait_ge(g_conc_ready, n_creators));
 
     // Wait for subtasks
-    ASSERT_TRUE(spin_wait_ge(&g_conc_subtask_done, n_creators));
+    ASSERT_TRUE(spin_wait_ge(g_conc_subtask_done, n_creators));
 
     // All subtask TIDs should have appeared in the registry at some point.
     // Since subtasks may have already exited, we check that TIDs were assigned.
     for (uint32_t i = 0; i < n_creators; i++) {
-        uint32_t sub_tid = __atomic_load_n(&g_conc_tids[i], __ATOMIC_ACQUIRE);
+        uint32_t sub_tid = g_conc_tids[i].load_acquire();
         EXPECT_NE(sub_tid, static_cast<uint32_t>(0));
     }
 }
@@ -374,16 +374,16 @@ TEST(task_registry_integration, concurrent_inserts_from_multiple_cpus) {
 
 constexpr uint32_t RAPID_WAVES = 3;
 constexpr uint32_t RAPID_PER_WAVE = 4;
-static volatile uint32_t g_rapid_done = 0;
+static sync::atomic<uint32_t> g_rapid_done;
 
 static void rapid_exit_fn(void*) {
-    __atomic_fetch_add(&g_rapid_done, 1, __ATOMIC_ACQ_REL);
+    g_rapid_done.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(task_registry_integration, registry_survives_rapid_create_exit) {
     for (uint32_t wave = 0; wave < RAPID_WAVES; wave++) {
-        g_rapid_done = 0;
+        g_rapid_done.store_relaxed(0);
 
         RUN_ELEVATED({
             for (uint32_t i = 0; i < RAPID_PER_WAVE; i++) {
@@ -394,7 +394,7 @@ TEST(task_registry_integration, registry_survives_rapid_create_exit) {
             }
         });
 
-        ASSERT_TRUE(spin_wait_ge(&g_rapid_done, RAPID_PER_WAVE));
+        ASSERT_TRUE(spin_wait_ge(g_rapid_done, RAPID_PER_WAVE));
         brief_delay();
     }
 

--- a/kernel/tests/sched/tick_accounting.test.cpp
+++ b/kernel/tests/sched/tick_accounting.test.cpp
@@ -41,18 +41,17 @@ static void spin_for_ns(uint64_t duration_ns) {
 
 // The spinner runs for a fixed duration and reports its own run_ticks
 // before exiting, because its task struct is reaped after exit
-static volatile uint32_t g_spinner_done = 0;
-static volatile uint32_t g_spinner_ticks = 0;
+static sync::atomic<uint32_t> g_spinner_done;
+static sync::atomic<uint32_t> g_spinner_ticks;
 
 static void spinner_task_fn(void*) {
     spin_for_ns(SPIN_NS);
     RUN_ELEVATED({
         sched::task* self = sched::current();
         uint64_t ticks = self->run_ticks.load_relaxed();
-        __atomic_store_n(&g_spinner_ticks, static_cast<uint32_t>(ticks),
-                         __ATOMIC_RELEASE);
+        g_spinner_ticks.store_release(static_cast<uint32_t>(ticks));
     });
-    __atomic_store_n(&g_spinner_done, 1, __ATOMIC_RELEASE);
+    g_spinner_done.store_release(1);
     sched::exit(0);
 }
 
@@ -83,8 +82,8 @@ TEST(tick_accounting, ticks_advance) {
 // and its CPU charges that time as busy.
 
 TEST(tick_accounting, busy_task_charged) {
-    g_spinner_done = 0;
-    g_spinner_ticks = 0;
+    g_spinner_done.store_relaxed(0);
+    g_spinner_ticks.store_relaxed(0);
 
     uint64_t busy_before = 0;
     RUN_ELEVATED({
@@ -105,7 +104,7 @@ TEST(tick_accounting, busy_task_charged) {
         }
     });
 
-    ASSERT_TRUE(spin_wait(&g_spinner_done));
+    ASSERT_TRUE(spin_wait(g_spinner_done));
 
     uint64_t busy_after = 0;
     RUN_ELEVATED({
@@ -113,5 +112,5 @@ TEST(tick_accounting, busy_task_charged) {
     });
 
     EXPECT_LT(busy_before, busy_after);
-    EXPECT_TRUE(g_spinner_ticks > 0);
+    EXPECT_TRUE(g_spinner_ticks.load_acquire() > 0);
 }

--- a/kernel/tests/sched/tick_accounting.test.cpp
+++ b/kernel/tests/sched/tick_accounting.test.cpp
@@ -48,7 +48,7 @@ static void spinner_task_fn(void*) {
     spin_for_ns(SPIN_NS);
     RUN_ELEVATED({
         sched::task* self = sched::current();
-        uint64_t ticks = __atomic_load_n(&self->run_ticks, __ATOMIC_RELAXED);
+        uint64_t ticks = self->run_ticks.load_relaxed();
         __atomic_store_n(&g_spinner_ticks, static_cast<uint32_t>(ticks),
                          __ATOMIC_RELEASE);
     });

--- a/kernel/tests/signals/delivery.test.cpp
+++ b/kernel/tests/signals/delivery.test.cpp
@@ -51,7 +51,7 @@ static void install_handler(uint32_t sig) {
 TEST(signal_delivery, selects_pending_handled_signal) {
     uint32_t sig = 0;
     install_handler(signals::SIGUSR1);
-    g_leader->sig.pending |= signals::sig_bit(signals::SIGUSR1);
+    g_leader->sig.pending.fetch_or_relaxed(signals::sig_bit(signals::SIGUSR1));
     RUN_ELEVATED({ sig = signals::next_deliverable(g_leader); });
     EXPECT_EQ(sig, signals::SIGUSR1);
 }
@@ -60,14 +60,14 @@ TEST(signal_delivery, ignores_default_and_blocked_signals) {
     uint32_t sig = 0;
 
     // A pending signal left at its default action is not for a handler
-    g_leader->sig.pending |= signals::sig_bit(signals::SIGTERM);
+    g_leader->sig.pending.fetch_or_relaxed(signals::sig_bit(signals::SIGTERM));
     RUN_ELEVATED({ sig = signals::next_deliverable(g_leader); });
     EXPECT_EQ(sig, 0U);
 
     // A handled signal that is blocked is not deliverable
     install_handler(signals::SIGUSR1);
-    g_leader->sig.pending |= signals::sig_bit(signals::SIGUSR1);
-    g_leader->sig.blocked |= signals::sig_bit(signals::SIGUSR1);
+    g_leader->sig.pending.fetch_or_relaxed(signals::sig_bit(signals::SIGUSR1));
+    g_leader->sig.blocked.fetch_or_relaxed(signals::sig_bit(signals::SIGUSR1));
     RUN_ELEVATED({ sig = signals::next_deliverable(g_leader); });
     EXPECT_EQ(sig, 0U);
 }
@@ -78,9 +78,9 @@ TEST(signal_delivery, selects_lowest_handled_signal) {
     install_handler(signals::SIGUSR2); // 12
 
     // A default-action SIGTERM pending alongside must not win over a handler
-    g_leader->sig.pending |= signals::sig_bit(signals::SIGUSR2);
-    g_leader->sig.pending |= signals::sig_bit(signals::SIGUSR1);
-    g_leader->sig.pending |= signals::sig_bit(signals::SIGTERM);
+    g_leader->sig.pending.fetch_or_relaxed(signals::sig_bit(signals::SIGUSR2));
+    g_leader->sig.pending.fetch_or_relaxed(signals::sig_bit(signals::SIGUSR1));
+    g_leader->sig.pending.fetch_or_relaxed(signals::sig_bit(signals::SIGTERM));
     RUN_ELEVATED({ sig = signals::next_deliverable(g_leader); });
     EXPECT_EQ(sig, signals::SIGUSR1);
 }

--- a/kernel/tests/signals/interrupt_results.test.cpp
+++ b/kernel/tests/signals/interrupt_results.test.cpp
@@ -21,8 +21,7 @@ static int32_t setup_rb() {
 }
 
 static int32_t teardown_rb() {
-    __atomic_fetch_and(&sched::current()->sig.pending,
-                       ~signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
+    sched::current()->sig.pending.fetch_and_release(~signals::sig_bit(signals::SIGKILL));
     RUN_ELEVATED({
         if (g_rb) ring_buffer_destroy(g_rb);
     });
@@ -36,8 +35,7 @@ AFTER_EACH(interrupt_results, teardown_rb);
 TEST(interrupt_results, interrupted_empty_read_is_not_eof) {
     uint8_t buf[8];
     ssize_t rc = 0;
-    __atomic_fetch_or(&sched::current()->sig.pending,
-                      signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
+    sched::current()->sig.pending.fetch_or_release(signals::sig_bit(signals::SIGKILL));
     RUN_ELEVATED({ rc = ring_buffer_read(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, RB_ERR_INTR);
 }
@@ -46,8 +44,7 @@ TEST(interrupt_results, closed_writer_read_stays_eof_when_interrupted) {
     uint8_t buf[8];
     ssize_t rc = -100;
     RUN_ELEVATED({ ring_buffer_close_write(g_rb); });
-    __atomic_fetch_or(&sched::current()->sig.pending,
-                      signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
+    sched::current()->sig.pending.fetch_or_release(signals::sig_bit(signals::SIGKILL));
     RUN_ELEVATED({ rc = ring_buffer_read(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, 0LL);
 }
@@ -67,8 +64,7 @@ TEST(interrupt_results, interrupted_full_write_is_not_epipe) {
     uint8_t buf[8];
     ssize_t rc = 0;
     fill_buffer(g_rb);
-    __atomic_fetch_or(&sched::current()->sig.pending,
-                      signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
+    sched::current()->sig.pending.fetch_or_release(signals::sig_bit(signals::SIGKILL));
     RUN_ELEVATED({ rc = ring_buffer_write(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, RB_ERR_INTR);
 
@@ -80,8 +76,7 @@ TEST(interrupt_results, interrupted_full_write_is_not_epipe) {
 TEST(interrupt_results, interrupted_write_with_space_still_writes) {
     uint8_t buf[8];
     ssize_t rc = 0;
-    __atomic_fetch_or(&sched::current()->sig.pending,
-                      signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
+    sched::current()->sig.pending.fetch_or_release(signals::sig_bit(signals::SIGKILL));
     RUN_ELEVATED({ rc = ring_buffer_write(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, 8LL);
 
@@ -94,8 +89,7 @@ TEST(interrupt_results, closed_reader_write_stays_epipe_when_interrupted) {
     uint8_t buf[8];
     ssize_t rc = 0;
     RUN_ELEVATED({ ring_buffer_close_read(g_rb); });
-    __atomic_fetch_or(&sched::current()->sig.pending,
-                      signals::sig_bit(signals::SIGKILL), __ATOMIC_RELEASE);
+    sched::current()->sig.pending.fetch_or_release(signals::sig_bit(signals::SIGKILL));
     RUN_ELEVATED({ rc = ring_buffer_write(g_rb, buf, sizeof(buf), false); });
     EXPECT_EQ(rc, RB_ERR_PIPE);
 }

--- a/kernel/tests/signals/kill_syscalls.test.cpp
+++ b/kernel/tests/signals/kill_syscalls.test.cpp
@@ -29,12 +29,12 @@ static void init_process(sched::task* t, sched::thread_group* tg, uint32_t tid) 
     tg->lock = sync::SPINLOCK_INIT;
     tg->leader = t;
     tg->pid = tid;
-    tg->group_id = tid;
+    tg->group_id.store_relaxed(tid);
     tg->threads.init();
     tg->thread_count = 0;
 
     t->tid = tid;
-    t->state = sched::TASK_STATE_CREATED;
+    t->state.store_relaxed(sched::TASK_STATE_CREATED);
     t->group = tg;
 }
 
@@ -55,13 +55,13 @@ static int32_t setup_tasks() {
     init_process(g_proc2, g_tg2, TEST_TID2);
 
     g_thread->tid = THREAD_TID;
-    g_thread->state = sched::TASK_STATE_CREATED;
+    g_thread->state.store_relaxed(sched::TASK_STATE_CREATED);
     g_thread->group = g_tg;
     g_tg->threads.push_back(g_thread);
     g_tg->thread_count = 1;
 
     g_ktask->tid = KTASK_TID;
-    g_ktask->state = sched::TASK_STATE_CREATED;
+    g_ktask->state.store_relaxed(sched::TASK_STATE_CREATED);
     g_ktask->exec.flags = sched::TASK_FLAG_KERNEL;
 
     RUN_ELEVATED({
@@ -154,27 +154,27 @@ TEST(kill_syscalls, null_signal_probes_without_sending) {
     RUN_ELEVATED({ rc = sys_tkill(KTASK_TID, 0, 0, 0, 0, 0); });
     EXPECT_EQ(rc, syscall::EPERM);
 
-    EXPECT_EQ(g_proc->sig.pending, 0ULL);
-    EXPECT_EQ(g_tg->sig.shared_pending, 0ULL);
+    EXPECT_EQ(g_proc->sig.pending.load_relaxed(), 0ULL);
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), 0ULL);
 }
 
 TEST(kill_syscalls, kill_signals_the_whole_process) {
     int64_t rc = 0;
     RUN_ELEVATED({ rc = sys_kill(TEST_TID, signals::SIGTERM, 0, 0, 0, 0); });
     EXPECT_EQ(rc, 0);
-    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGTERM));
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), signals::sig_bit(signals::SIGTERM));
 }
 
 TEST(kill_syscalls, kill_accepts_nonleader_thread_ids) {
     int64_t rc = 0;
     RUN_ELEVATED({ rc = sys_kill(THREAD_TID, signals::SIGTERM, 0, 0, 0, 0); });
     EXPECT_EQ(rc, 0);
-    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGTERM));
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), signals::sig_bit(signals::SIGTERM));
 }
 
 TEST(kill_syscalls, group_kill_reaches_every_member_process) {
     // Both processes join one group, addressed by negative pid
-    g_tg2->group_id = TEST_TID;
+    g_tg2->group_id.store_relaxed(TEST_TID);
 
     int64_t rc = 0;
     RUN_ELEVATED({
@@ -182,16 +182,16 @@ TEST(kill_syscalls, group_kill_reaches_every_member_process) {
                       signals::SIGTERM, 0, 0, 0, 0);
     });
     EXPECT_EQ(rc, 0);
-    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGTERM));
-    EXPECT_EQ(g_tg2->sig.shared_pending, signals::sig_bit(signals::SIGTERM));
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), signals::sig_bit(signals::SIGTERM));
+    EXPECT_EQ(g_tg2->sig.shared_pending.load_relaxed(), signals::sig_bit(signals::SIGTERM));
 }
 
 TEST(kill_syscalls, tkill_is_thread_directed) {
     int64_t rc = 0;
     RUN_ELEVATED({ rc = sys_tkill(THREAD_TID, signals::SIGTERM, 0, 0, 0, 0); });
     EXPECT_EQ(rc, 0);
-    EXPECT_EQ(g_thread->sig.pending, signals::sig_bit(signals::SIGTERM));
-    EXPECT_EQ(g_tg->sig.shared_pending, 0ULL);
+    EXPECT_EQ(g_thread->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGTERM));
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), 0ULL);
 }
 
 TEST(kill_syscalls, tgkill_validates_the_pair) {
@@ -201,7 +201,7 @@ TEST(kill_syscalls, tgkill_validates_the_pair) {
         rc = sys_tgkill(TEST_TID, THREAD_TID, signals::SIGTERM, 0, 0, 0);
     });
     EXPECT_EQ(rc, 0);
-    EXPECT_EQ(g_thread->sig.pending, signals::sig_bit(signals::SIGTERM));
+    EXPECT_EQ(g_thread->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGTERM));
 
     // A thread paired with the wrong process is not a match
     RUN_ELEVATED({

--- a/kernel/tests/signals/signal_death.test.cpp
+++ b/kernel/tests/signals/signal_death.test.cpp
@@ -53,27 +53,27 @@ TEST(signal_death, killed_member_reports_group_exit_signal) {
     uint32_t fatal = 0;
 
     // A killed member of a group dying from SIGSEGV reports SIGSEGV
-    g_leader->sig.pending |= signals::sig_bit(signals::SIGKILL);
-    g_tg->sig.exit_signal = signals::SIGSEGV;
+    g_leader->sig.pending.fetch_or_relaxed(signals::sig_bit(signals::SIGKILL));
+    g_tg->sig.exit_signal.store_relaxed(signals::SIGSEGV);
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
     EXPECT_EQ(fatal, signals::SIGSEGV);
 
     // Every thread of the group reports the same signal
-    g_thread->sig.pending |= signals::sig_bit(signals::SIGKILL);
+    g_thread->sig.pending.fetch_or_relaxed(signals::sig_bit(signals::SIGKILL));
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_thread); });
     EXPECT_EQ(fatal, signals::SIGSEGV);
 }
 
 TEST(signal_death, kill_without_exit_signal_reports_sigkill) {
     uint32_t fatal = 0;
-    g_leader->sig.pending |= signals::sig_bit(signals::SIGKILL);
+    g_leader->sig.pending.fetch_or_relaxed(signals::sig_bit(signals::SIGKILL));
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
     EXPECT_EQ(fatal, signals::SIGKILL);
 }
 
 TEST(signal_death, exit_signal_alone_reports_nothing) {
     uint32_t fatal = 0;
-    g_tg->sig.exit_signal = signals::SIGTERM;
+    g_tg->sig.exit_signal.store_relaxed(signals::SIGTERM);
 
     // Without the kill flag the exit signal alone reports nothing
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });

--- a/kernel/tests/signals/signal_interrupt.test.cpp
+++ b/kernel/tests/signals/signal_interrupt.test.cpp
@@ -52,32 +52,32 @@ AFTER_EACH(signal_interrupt, teardown_group);
 TEST(signal_interrupt, pending_sigkill_reports_sigkill) {
     uint32_t fatal = 0;
     // SIGKILL wins over a lower pending signal
-    g_leader->sig.pending = signals::sig_bit(signals::SIGKILL)
-                          | signals::sig_bit(signals::SIGTERM);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGKILL)
+                          | signals::sig_bit(signals::SIGTERM));
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
     EXPECT_EQ(fatal, signals::SIGKILL);
 }
 
 TEST(signal_interrupt, lowest_fatal_signal_wins) {
     uint32_t fatal = 0;
-    g_leader->sig.pending = signals::sig_bit(signals::SIGTERM)
-                          | signals::sig_bit(signals::SIGINT);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGTERM)
+                          | signals::sig_bit(signals::SIGINT));
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
     EXPECT_EQ(fatal, signals::SIGINT);
 }
 
 TEST(signal_interrupt, pending_sigkill_outranks_lower_signals) {
     uint32_t fatal = 0;
-    g_leader->sig.pending = signals::sig_bit(signals::SIGINT);
-    g_tg->sig.shared_pending = signals::sig_bit(signals::SIGKILL);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGINT));
+    g_tg->sig.shared_pending .store_relaxed(signals::sig_bit(signals::SIGKILL));
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
     EXPECT_EQ(fatal, signals::SIGKILL);
 }
 
 TEST(signal_interrupt, blocked_signals_are_not_fatal) {
     uint32_t fatal = 1;
-    g_leader->sig.pending = signals::sig_bit(signals::SIGTERM);
-    g_leader->sig.blocked = signals::sig_bit(signals::SIGTERM);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGTERM));
+    g_leader->sig.blocked .store_relaxed(signals::sig_bit(signals::SIGTERM));
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
     EXPECT_EQ(fatal, 0U);
 }
@@ -89,21 +89,21 @@ TEST(signal_interrupt, handled_signals_are_not_fatal) {
     RUN_ELEVATED({
         signals::set_action(g_tg, signals::SIGTERM, &act, nullptr);
     });
-    g_leader->sig.pending = signals::sig_bit(signals::SIGTERM);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGTERM));
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
     EXPECT_EQ(fatal, 0U);
 }
 
 TEST(signal_interrupt, default_ignore_pending_is_not_fatal) {
     uint32_t fatal = 1;
-    g_leader->sig.pending = signals::sig_bit(signals::SIGCHLD);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGCHLD));
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_leader); });
     EXPECT_EQ(fatal, 0U);
 }
 
 TEST(signal_interrupt, shared_pending_is_visible_to_every_thread) {
     uint32_t fatal = 0;
-    g_tg->sig.shared_pending = signals::sig_bit(signals::SIGTERM);
+    g_tg->sig.shared_pending .store_relaxed(signals::sig_bit(signals::SIGTERM));
     RUN_ELEVATED({ fatal = signals::fatal_pending(g_thread); });
     EXPECT_EQ(fatal, signals::SIGTERM);
 }
@@ -113,7 +113,7 @@ TEST(signal_interrupt, interrupt_pending_truth) {
     RUN_ELEVATED({ intr = signals::interrupt_pending(g_leader); });
     EXPECT_FALSE(intr);
 
-    g_leader->sig.pending = signals::sig_bit(signals::SIGTERM);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGTERM));
     RUN_ELEVATED({ intr = signals::interrupt_pending(g_leader); });
     EXPECT_TRUE(intr);
 
@@ -130,12 +130,12 @@ TEST(signal_interrupt, interrupt_pending_covers_handled_signals) {
     });
 
     bool intr = false;
-    g_leader->sig.pending = signals::sig_bit(signals::SIGUSR1);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGUSR1));
     RUN_ELEVATED({ intr = signals::interrupt_pending(g_leader); });
     EXPECT_TRUE(intr);
 
     // Blocking the signal removes the interrupt reason
-    g_leader->sig.blocked = signals::sig_bit(signals::SIGUSR1);
+    g_leader->sig.blocked .store_relaxed(signals::sig_bit(signals::SIGUSR1));
     RUN_ELEVATED({ intr = signals::interrupt_pending(g_leader); });
     EXPECT_FALSE(intr);
 }
@@ -149,13 +149,13 @@ TEST(signal_interrupt, elevated_task_defers_handled_interrupts) {
 
     // Undeliverable while elevated, so the wait must not unwind
     bool intr = true;
-    g_leader->sig.pending = signals::sig_bit(signals::SIGUSR1);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGUSR1));
     g_leader->exec.flags = sched::TASK_FLAG_ELEVATED;
     RUN_ELEVATED({ intr = signals::interrupt_pending(g_leader); });
     EXPECT_FALSE(intr);
 
     // Fatal signals still interrupt an elevated task
-    g_leader->sig.pending |= signals::sig_bit(signals::SIGKILL);
+    g_leader->sig.pending.fetch_or_relaxed(signals::sig_bit(signals::SIGKILL));
     RUN_ELEVATED({ intr = signals::interrupt_pending(g_leader); });
     EXPECT_TRUE(intr);
     g_leader->exec.flags = 0;

--- a/kernel/tests/signals/signal_send.test.cpp
+++ b/kernel/tests/signals/signal_send.test.cpp
@@ -77,24 +77,24 @@ TEST(signal_send, fatal_send_pends_without_kill_flag) {
     int32_t rc = 0;
     RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGTERM); });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_EQ(g_thread->sig.pending, signals::sig_bit(signals::SIGTERM));
-    EXPECT_BITS_CLEAR(g_thread->sig.pending, signals::sig_bit(signals::SIGKILL));
-    EXPECT_BITS_CLEAR(g_leader->sig.pending, signals::sig_bit(signals::SIGKILL));
+    EXPECT_EQ(g_thread->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGTERM));
+    EXPECT_BITS_CLEAR(g_thread->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGKILL));
+    EXPECT_BITS_CLEAR(g_leader->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGKILL));
 }
 
 TEST(signal_send, ignored_unblocked_send_drops) {
     int32_t rc = 0;
     RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGCHLD); });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_EQ(g_thread->sig.pending, 0ULL);
+    EXPECT_EQ(g_thread->sig.pending.load_relaxed(), 0ULL);
 }
 
 TEST(signal_send, ignored_blocked_send_pends) {
-    g_thread->sig.blocked = signals::sig_bit(signals::SIGCHLD);
+    g_thread->sig.blocked .store_relaxed(signals::sig_bit(signals::SIGCHLD));
     int32_t rc = 0;
     RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGCHLD); });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_EQ(g_thread->sig.pending, signals::sig_bit(signals::SIGCHLD));
+    EXPECT_EQ(g_thread->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGCHLD));
 }
 
 TEST(signal_send, handled_send_pends) {
@@ -108,8 +108,8 @@ TEST(signal_send, handled_send_pends) {
         }
     });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_EQ(g_thread->sig.pending, signals::sig_bit(signals::SIGTERM));
-    EXPECT_BITS_CLEAR(g_thread->sig.pending, signals::sig_bit(signals::SIGKILL));
+    EXPECT_EQ(g_thread->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGTERM));
+    EXPECT_BITS_CLEAR(g_thread->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGKILL));
 }
 
 TEST(signal_send, sigkill_to_thread_kills_group) {
@@ -118,43 +118,43 @@ TEST(signal_send, sigkill_to_thread_kills_group) {
     EXPECT_EQ(rc, signals::OK);
     // SIGKILL is process-wide: target and leader are marked, and the
     // shared bit makes it fatal for every other thread immediately
-    EXPECT_BITS_SET(g_thread->sig.pending, signals::sig_bit(signals::SIGKILL));
-    EXPECT_BITS_SET(g_leader->sig.pending, signals::sig_bit(signals::SIGKILL));
-    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGKILL));
+    EXPECT_BITS_SET(g_thread->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGKILL));
+    EXPECT_BITS_SET(g_leader->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGKILL));
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), signals::sig_bit(signals::SIGKILL));
 }
 
 TEST(signal_send, sigkill_to_group_marks_leader) {
     int32_t rc = 0;
     RUN_ELEVATED({ rc = signals::send_to_group(g_tg, signals::SIGKILL); });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_BITS_SET(g_leader->sig.pending, signals::sig_bit(signals::SIGKILL));
-    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGKILL));
+    EXPECT_BITS_SET(g_leader->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGKILL));
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), signals::sig_bit(signals::SIGKILL));
 }
 
 TEST(signal_send, group_fatal_send_sets_shared) {
     int32_t rc = 0;
     RUN_ELEVATED({ rc = signals::send_to_group(g_tg, signals::SIGTERM); });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGTERM));
-    EXPECT_BITS_CLEAR(g_leader->sig.pending, signals::sig_bit(signals::SIGKILL));
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), signals::sig_bit(signals::SIGTERM));
+    EXPECT_BITS_CLEAR(g_leader->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGKILL));
 }
 
 TEST(signal_send, group_ignored_send_drops_unless_blocked) {
     int32_t rc = 0;
     RUN_ELEVATED({ rc = signals::send_to_group(g_tg, signals::SIGCHLD); });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_EQ(g_tg->sig.shared_pending, 0ULL);
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), 0ULL);
 
     // One thread blocking the signal keeps it pending
-    g_thread->sig.blocked = signals::sig_bit(signals::SIGCHLD);
+    g_thread->sig.blocked .store_relaxed(signals::sig_bit(signals::SIGCHLD));
     RUN_ELEVATED({ rc = signals::send_to_group(g_tg, signals::SIGCHLD); });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGCHLD));
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), signals::sig_bit(signals::SIGCHLD));
 }
 
 TEST(signal_send, stop_class_send_is_ignored) {
     int32_t rc = 0;
     RUN_ELEVATED({ rc = signals::send_to_task(g_thread, signals::SIGTSTP); });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_EQ(g_thread->sig.pending, 0ULL);
+    EXPECT_EQ(g_thread->sig.pending.load_relaxed(), 0ULL);
 }

--- a/kernel/tests/signals/signal_state.test.cpp
+++ b/kernel/tests/signals/signal_state.test.cpp
@@ -60,7 +60,7 @@ TEST(signal_state, set_blocked_block_unblock_setmask) {
     });
     EXPECT_EQ(rc, signals::OK);
     EXPECT_EQ(old, 0ULL);
-    EXPECT_EQ(g_leader->sig.blocked, set);
+    EXPECT_EQ(g_leader->sig.blocked.load_relaxed(), set);
 
     signals::sig_set_t unblock = signals::sig_bit(signals::SIGTERM);
     RUN_ELEVATED({
@@ -68,14 +68,14 @@ TEST(signal_state, set_blocked_block_unblock_setmask) {
     });
     EXPECT_EQ(rc, signals::OK);
     EXPECT_EQ(old, set);
-    EXPECT_EQ(g_leader->sig.blocked, signals::sig_bit(signals::SIGINT));
+    EXPECT_EQ(g_leader->sig.blocked.load_relaxed(), signals::sig_bit(signals::SIGINT));
 
     signals::sig_set_t mask = signals::sig_bit(signals::SIGUSR1);
     RUN_ELEVATED({
         rc = signals::set_blocked(g_leader, signals::SIG_SETMASK, &mask, nullptr);
     });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_EQ(g_leader->sig.blocked, mask);
+    EXPECT_EQ(g_leader->sig.blocked.load_relaxed(), mask);
 }
 
 TEST(signal_state, set_blocked_never_blocks_kill_stop) {
@@ -85,14 +85,14 @@ TEST(signal_state, set_blocked_never_blocks_kill_stop) {
         rc = signals::set_blocked(g_leader, signals::SIG_SETMASK, &all, nullptr);
     });
     EXPECT_EQ(rc, signals::OK);
-    EXPECT_BITS_CLEAR(g_leader->sig.blocked, signals::UNBLOCKABLE_MASK);
-    EXPECT_EQ(g_leader->sig.blocked, ~0ULL & ~signals::UNBLOCKABLE_MASK);
+    EXPECT_BITS_CLEAR(g_leader->sig.blocked.load_relaxed(), signals::UNBLOCKABLE_MASK);
+    EXPECT_EQ(g_leader->sig.blocked.load_relaxed(), ~0ULL & ~signals::UNBLOCKABLE_MASK);
 }
 
 TEST(signal_state, set_blocked_query_only_ignores_how) {
     int32_t rc = 0;
     signals::sig_set_t old = ~0ULL;
-    g_leader->sig.blocked = signals::sig_bit(signals::SIGINT);
+    g_leader->sig.blocked .store_relaxed(signals::sig_bit(signals::SIGINT));
 
     // set == nullptr: how is not significant (POSIX)
     RUN_ELEVATED({
@@ -100,7 +100,7 @@ TEST(signal_state, set_blocked_query_only_ignores_how) {
     });
     EXPECT_EQ(rc, signals::OK);
     EXPECT_EQ(old, signals::sig_bit(signals::SIGINT));
-    EXPECT_EQ(g_leader->sig.blocked, signals::sig_bit(signals::SIGINT));
+    EXPECT_EQ(g_leader->sig.blocked.load_relaxed(), signals::sig_bit(signals::SIGINT));
 }
 
 TEST(signal_state, set_blocked_rejects_bad_how) {
@@ -110,7 +110,7 @@ TEST(signal_state, set_blocked_rejects_bad_how) {
         rc = signals::set_blocked(g_leader, 99, &set, nullptr);
     });
     EXPECT_EQ(rc, signals::ERR_INVAL);
-    EXPECT_EQ(g_leader->sig.blocked, 0ULL);
+    EXPECT_EQ(g_leader->sig.blocked.load_relaxed(), 0ULL);
 }
 
 TEST(signal_state, set_action_roundtrip) {
@@ -206,8 +206,8 @@ TEST(signal_state, dfl_on_default_ignore_signal_discards_pending) {
     const signals::sig_set_t sigchld = signals::sig_bit(signals::SIGCHLD);
     const signals::sig_set_t sigtstp = signals::sig_bit(signals::SIGTSTP);
 
-    g_tg->sig.shared_pending = sigchld | sigtstp;
-    g_leader->sig.pending    = sigchld | sigtstp;
+    g_tg->sig.shared_pending .store_relaxed(sigchld | sigtstp);
+    g_leader->sig.pending    .store_relaxed(sigchld | sigtstp);
 
     signals::k_sigaction act = {};
     act.handler = signals::SIG_DFL;
@@ -221,17 +221,17 @@ TEST(signal_state, dfl_on_default_ignore_signal_discards_pending) {
     EXPECT_EQ(rc, signals::OK);
 
     // Default-ignore SIGCHLD is discarded, stop-class SIGTSTP is not
-    EXPECT_EQ(g_tg->sig.shared_pending, sigtstp);
-    EXPECT_EQ(g_leader->sig.pending, sigtstp);
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), sigtstp);
+    EXPECT_EQ(g_leader->sig.pending.load_relaxed(), sigtstp);
 }
 
 TEST(signal_state, sig_ign_discards_pending) {
     const signals::sig_set_t sigusr1 = signals::sig_bit(signals::SIGUSR1);
     const signals::sig_set_t sigterm = signals::sig_bit(signals::SIGTERM);
 
-    g_tg->sig.shared_pending = sigusr1 | sigterm;
-    g_leader->sig.pending    = sigusr1 | sigterm;
-    g_thread->sig.pending    = sigusr1 | sigterm;
+    g_tg->sig.shared_pending .store_relaxed(sigusr1 | sigterm);
+    g_leader->sig.pending    .store_relaxed(sigusr1 | sigterm);
+    g_thread->sig.pending    .store_relaxed(sigusr1 | sigterm);
 
     signals::k_sigaction act = {};
     act.handler = signals::SIG_IGN;
@@ -242,9 +242,9 @@ TEST(signal_state, sig_ign_discards_pending) {
     EXPECT_EQ(rc, signals::OK);
 
     // SIGUSR1 discarded everywhere, SIGTERM untouched
-    EXPECT_EQ(g_tg->sig.shared_pending, sigterm);
-    EXPECT_EQ(g_leader->sig.pending, sigterm);
-    EXPECT_EQ(g_thread->sig.pending, sigterm);
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), sigterm);
+    EXPECT_EQ(g_leader->sig.pending.load_relaxed(), sigterm);
+    EXPECT_EQ(g_thread->sig.pending.load_relaxed(), sigterm);
 }
 
 TEST(signal_state, pending_blocked_set_combines_sets) {
@@ -252,9 +252,9 @@ TEST(signal_state, pending_blocked_set_combines_sets) {
     const signals::sig_set_t sigusr1 = signals::sig_bit(signals::SIGUSR1);
     const signals::sig_set_t sigterm = signals::sig_bit(signals::SIGTERM);
 
-    g_leader->sig.pending     = sigint;
-    g_tg->sig.shared_pending  = sigusr1 | sigterm;
-    g_leader->sig.blocked     = sigint | sigusr1;
+    g_leader->sig.pending     .store_relaxed(sigint);
+    g_tg->sig.shared_pending  .store_relaxed(sigusr1 | sigterm);
+    g_leader->sig.blocked     .store_relaxed(sigint | sigusr1);
 
     signals::sig_set_t result = 0;
     RUN_ELEVATED({
@@ -279,8 +279,8 @@ static void install_handler(uint32_t sig, uint64_t flags,
 TEST(signal_state, take_deliverable_consumes_and_masks) {
     const signals::sig_set_t handler_mask = signals::sig_bit(signals::SIGUSR2);
     install_handler(signals::SIGUSR1, 0, handler_mask);
-    g_leader->sig.pending = signals::sig_bit(signals::SIGUSR1);
-    g_leader->sig.blocked = signals::sig_bit(signals::SIGTERM);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGUSR1));
+    g_leader->sig.blocked .store_relaxed(signals::sig_bit(signals::SIGTERM));
 
     uint32_t sig = 0;
     signals::k_sigaction act = {};
@@ -293,19 +293,19 @@ TEST(signal_state, take_deliverable_consumes_and_masks) {
     EXPECT_TRUE(taken);
     EXPECT_EQ(sig, signals::SIGUSR1);
     EXPECT_EQ(act.handler, 0x400000UL);
-    EXPECT_EQ(g_leader->sig.pending, 0ULL);
+    EXPECT_EQ(g_leader->sig.pending.load_relaxed(), 0ULL);
     EXPECT_EQ(old_blocked, signals::sig_bit(signals::SIGTERM));
 
     // The handler runs with sa_mask plus its own signal on top of old_blocked
-    EXPECT_EQ(g_leader->sig.blocked, signals::sig_bit(signals::SIGTERM)
+    EXPECT_EQ(g_leader->sig.blocked.load_relaxed(), signals::sig_bit(signals::SIGTERM)
                                    | handler_mask
                                    | signals::sig_bit(signals::SIGUSR1));
 }
 
 TEST(signal_state, take_deliverable_prefers_thread_set) {
     install_handler(signals::SIGUSR1, 0, 0);
-    g_leader->sig.pending    = signals::sig_bit(signals::SIGUSR1);
-    g_tg->sig.shared_pending = signals::sig_bit(signals::SIGUSR1);
+    g_leader->sig.pending    .store_relaxed(signals::sig_bit(signals::SIGUSR1));
+    g_tg->sig.shared_pending .store_relaxed(signals::sig_bit(signals::SIGUSR1));
 
     uint32_t sig = 0;
     signals::k_sigaction act = {};
@@ -316,16 +316,16 @@ TEST(signal_state, take_deliverable_prefers_thread_set) {
     });
 
     EXPECT_TRUE(taken);
-    EXPECT_EQ(g_leader->sig.pending, 0ULL);
-    EXPECT_EQ(g_tg->sig.shared_pending, signals::sig_bit(signals::SIGUSR1));
+    EXPECT_EQ(g_leader->sig.pending.load_relaxed(), 0ULL);
+    EXPECT_EQ(g_tg->sig.shared_pending.load_relaxed(), signals::sig_bit(signals::SIGUSR1));
 }
 
 TEST(signal_state, take_deliverable_lowest_handled_first) {
     install_handler(signals::SIGUSR1, 0, 0);
     install_handler(signals::SIGUSR2, 0, 0);
-    g_leader->sig.pending = signals::sig_bit(signals::SIGUSR1)
-                          | signals::sig_bit(signals::SIGUSR2);
-    g_leader->sig.blocked = 0;
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGUSR1)
+                          | signals::sig_bit(signals::SIGUSR2));
+    g_leader->sig.blocked .store_relaxed(0);
 
     uint32_t sig = 0;
     signals::k_sigaction act = {};
@@ -338,18 +338,18 @@ TEST(signal_state, take_deliverable_lowest_handled_first) {
     EXPECT_EQ(sig, signals::SIGUSR1);
 
     // Reset the mask the first take installed, then the next one follows
-    g_leader->sig.blocked = 0;
+    g_leader->sig.blocked .store_relaxed(0);
     RUN_ELEVATED({
         taken = signals::take_deliverable(g_leader, &sig, &act, &old_blocked);
     });
     EXPECT_TRUE(taken);
     EXPECT_EQ(sig, signals::SIGUSR2);
-    EXPECT_EQ(g_leader->sig.pending, 0ULL);
+    EXPECT_EQ(g_leader->sig.pending.load_relaxed(), 0ULL);
 }
 
 TEST(signal_state, take_deliverable_nodefer_leaves_signal_unblocked) {
     install_handler(signals::SIGUSR1, signals::SA_NODEFER, 0);
-    g_leader->sig.pending = signals::sig_bit(signals::SIGUSR1);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGUSR1));
 
     uint32_t sig = 0;
     signals::k_sigaction act = {};
@@ -360,12 +360,12 @@ TEST(signal_state, take_deliverable_nodefer_leaves_signal_unblocked) {
     });
 
     EXPECT_TRUE(taken);
-    EXPECT_EQ(g_leader->sig.blocked, 0ULL);
+    EXPECT_EQ(g_leader->sig.blocked.load_relaxed(), 0ULL);
 }
 
 TEST(signal_state, take_deliverable_resethand_restores_default) {
     install_handler(signals::SIGUSR1, signals::SA_RESETHAND, 0);
-    g_leader->sig.pending = signals::sig_bit(signals::SIGUSR1);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGUSR1));
 
     uint32_t sig = 0;
     signals::k_sigaction act = {};
@@ -384,7 +384,7 @@ TEST(signal_state, take_deliverable_resethand_restores_default) {
 TEST(signal_state, untake_deliverable_restores_state) {
     install_handler(signals::SIGUSR1, signals::SA_RESETHAND,
                     signals::sig_bit(signals::SIGUSR2));
-    g_leader->sig.pending = signals::sig_bit(signals::SIGUSR1);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGUSR1));
 
     uint32_t sig = 0;
     signals::k_sigaction act = {};
@@ -394,7 +394,7 @@ TEST(signal_state, untake_deliverable_restores_state) {
         taken = signals::take_deliverable(g_leader, &sig, &act, &old_blocked);
     });
     ASSERT_TRUE(taken);
-    EXPECT_EQ(g_leader->sig.pending, 0ULL);
+    EXPECT_EQ(g_leader->sig.pending.load_relaxed(), 0ULL);
     EXPECT_EQ(g_tg->sig.actions[signals::SIGUSR1 - 1].handler, signals::SIG_DFL);
 
     // A deferred delivery puts the signal, the mask, and the one-shot
@@ -402,8 +402,8 @@ TEST(signal_state, untake_deliverable_restores_state) {
     RUN_ELEVATED({
         signals::untake_deliverable(g_leader, sig, &act, old_blocked);
     });
-    EXPECT_EQ(g_leader->sig.pending, signals::sig_bit(signals::SIGUSR1));
-    EXPECT_EQ(g_leader->sig.blocked, 0ULL);
+    EXPECT_EQ(g_leader->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGUSR1));
+    EXPECT_EQ(g_leader->sig.blocked.load_relaxed(), 0ULL);
     EXPECT_EQ(g_tg->sig.actions[signals::SIGUSR1 - 1].handler, 0x400000UL);
 }
 
@@ -420,20 +420,20 @@ TEST(signal_state, take_deliverable_skips_blocked_and_unhandled) {
     EXPECT_FALSE(taken);
 
     // Pending without a handler stays for the fatal path
-    g_leader->sig.pending = signals::sig_bit(signals::SIGTERM);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGTERM));
     RUN_ELEVATED({
         taken = signals::take_deliverable(g_leader, &sig, &act, &old_blocked);
     });
     EXPECT_FALSE(taken);
-    EXPECT_EQ(g_leader->sig.pending, signals::sig_bit(signals::SIGTERM));
+    EXPECT_EQ(g_leader->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGTERM));
 
     // A blocked handled signal is not deliverable
     install_handler(signals::SIGUSR1, 0, 0);
-    g_leader->sig.pending = signals::sig_bit(signals::SIGUSR1);
-    g_leader->sig.blocked = signals::sig_bit(signals::SIGUSR1);
+    g_leader->sig.pending .store_relaxed(signals::sig_bit(signals::SIGUSR1));
+    g_leader->sig.blocked .store_relaxed(signals::sig_bit(signals::SIGUSR1));
     RUN_ELEVATED({
         taken = signals::take_deliverable(g_leader, &sig, &act, &old_blocked);
     });
     EXPECT_FALSE(taken);
-    EXPECT_EQ(g_leader->sig.pending, signals::sig_bit(signals::SIGUSR1));
+    EXPECT_EQ(g_leader->sig.pending.load_relaxed(), signals::sig_bit(signals::SIGUSR1));
 }

--- a/kernel/tests/sync/futex.test.cpp
+++ b/kernel/tests/sync/futex.test.cpp
@@ -16,7 +16,7 @@ TEST_SUITE(futex);
 
 // --- wait returns EAGAIN on value mismatch ---
 
-static volatile uint32_t g_mismatch_val = 42;
+static uint32_t g_mismatch_val = 42;
 
 TEST(futex, wait_eagain_on_mismatch) {
     g_mismatch_val = 42;
@@ -30,7 +30,7 @@ TEST(futex, wait_eagain_on_mismatch) {
 
 // --- wake with no waiters returns 0 ---
 
-static volatile uint32_t g_nowait_val = 0;
+static uint32_t g_nowait_val = 0;
 
 TEST(futex, wake_no_waiters) {
     g_nowait_val = 0;
@@ -44,24 +44,24 @@ TEST(futex, wake_no_waiters) {
 
 // --- basic wait and wake ---
 
-static volatile uint32_t g_basic_val = 0;
-static volatile uint32_t g_basic_waiting = 0;
-static volatile uint32_t g_basic_woken = 0;
+static uint32_t g_basic_val = 0;
+static sync::atomic<uint32_t> g_basic_waiting;
+static sync::atomic<uint32_t> g_basic_woken;
 
 static void basic_waiter_fn(void*) {
-    __atomic_store_n(&g_basic_waiting, 1, __ATOMIC_RELEASE);
+    g_basic_waiting.store_release(1);
     RUN_ELEVATED({
         sync::futex_wait(
             reinterpret_cast<uintptr_t>(&g_basic_val), 0, 0);
     });
-    __atomic_store_n(&g_basic_woken, 1, __ATOMIC_RELEASE);
+    g_basic_woken.store_release(1);
     sched::exit(0);
 }
 
 TEST(futex, basic_wait_and_wake) {
     g_basic_val = 0;
-    g_basic_waiting = 0;
-    g_basic_woken = 0;
+    g_basic_waiting.store_relaxed(0);
+    g_basic_woken.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(
@@ -70,39 +70,39 @@ TEST(futex, basic_wait_and_wake) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_basic_waiting));
+    ASSERT_TRUE(spin_wait(g_basic_waiting));
     brief_delay();
 
-    __atomic_store_n(&g_basic_val, 1, __ATOMIC_RELEASE);
+    sync::atomic_ref<uint32_t>{g_basic_val}.store_release(1);
     RUN_ELEVATED({
         sync::futex_wake(
             reinterpret_cast<uintptr_t>(&g_basic_val), 1);
     });
 
-    EXPECT_TRUE(spin_wait(&g_basic_woken));
+    EXPECT_TRUE(spin_wait(g_basic_woken));
 }
 
 // --- wake respects count ---
 
 constexpr uint32_t WAKE_N_TASKS = 4;
-static volatile uint32_t g_wn_val = 0;
-static volatile uint32_t g_wn_ready = 0;
-static volatile uint32_t g_wn_woken = 0;
+static uint32_t g_wn_val = 0;
+static sync::atomic<uint32_t> g_wn_ready;
+static sync::atomic<uint32_t> g_wn_woken;
 
 static void wake_n_waiter_fn(void*) {
-    __atomic_fetch_add(&g_wn_ready, 1, __ATOMIC_ACQ_REL);
+    g_wn_ready.fetch_add_acq_rel(1);
     RUN_ELEVATED({
         sync::futex_wait(
             reinterpret_cast<uintptr_t>(&g_wn_val), 0, 0);
     });
-    __atomic_fetch_add(&g_wn_woken, 1, __ATOMIC_ACQ_REL);
+    g_wn_woken.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(futex, wake_count_respected) {
     g_wn_val = 0;
-    g_wn_ready = 0;
-    g_wn_woken = 0;
+    g_wn_ready.store_relaxed(0);
+    g_wn_woken.store_relaxed(0);
 
     RUN_ELEVATED({
         for (uint32_t i = 0; i < WAKE_N_TASKS; i++) {
@@ -113,7 +113,7 @@ TEST(futex, wake_count_respected) {
         }
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_wn_ready, WAKE_N_TASKS));
+    ASSERT_TRUE(spin_wait_ge(g_wn_ready, WAKE_N_TASKS));
     brief_delay();
 
     int32_t woken = 0;
@@ -123,9 +123,9 @@ TEST(futex, wake_count_respected) {
     });
     EXPECT_EQ(woken, static_cast<int32_t>(2));
 
-    ASSERT_TRUE(spin_wait_ge(&g_wn_woken, 2));
+    ASSERT_TRUE(spin_wait_ge(g_wn_woken, 2));
     brief_delay();
-    EXPECT_EQ(__atomic_load_n(&g_wn_woken, __ATOMIC_ACQUIRE), 2u);
+    EXPECT_EQ(g_wn_woken.load_acquire(), 2u);
 
     int32_t rest = 0;
     RUN_ELEVATED({
@@ -134,34 +134,33 @@ TEST(futex, wake_count_respected) {
     });
     EXPECT_EQ(rest, static_cast<int32_t>(2));
 
-    ASSERT_TRUE(spin_wait_ge(&g_wn_woken, WAKE_N_TASKS));
+    ASSERT_TRUE(spin_wait_ge(g_wn_woken, WAKE_N_TASKS));
 }
 
 // --- wait with timeout ---
 
-static volatile uint32_t g_timeout_val = 0;
-static volatile int32_t g_timeout_rc = 0;
-static volatile uint64_t g_timeout_elapsed = 0;
-static volatile uint32_t g_timeout_done = 0;
+static uint32_t g_timeout_val = 0;
+static sync::atomic<int32_t> g_timeout_rc;
+static sync::atomic<uint64_t> g_timeout_elapsed;
+static sync::atomic<uint32_t> g_timeout_done;
 
 static void timeout_waiter_fn(void*) {
     uint64_t before = clock::now_ns();
     RUN_ELEVATED({
-        g_timeout_rc = sync::futex_wait(
+        g_timeout_rc.store_relaxed(sync::futex_wait(
             reinterpret_cast<uintptr_t>(&g_timeout_val), 0,
-            50000000ULL); // 50ms
+            50000000ULL)); // 50ms
     });
-    __atomic_store_n(&g_timeout_elapsed,
-        clock::now_ns() - before, __ATOMIC_RELEASE);
-    __atomic_store_n(&g_timeout_done, 1, __ATOMIC_RELEASE);
+    g_timeout_elapsed.store_release(clock::now_ns() - before);
+    g_timeout_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(futex, wait_timeout) {
     g_timeout_val = 0;
-    g_timeout_rc = 0;
-    g_timeout_elapsed = 0;
-    g_timeout_done = 0;
+    g_timeout_rc.store_relaxed(0);
+    g_timeout_elapsed.store_relaxed(0);
+    g_timeout_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(
@@ -170,20 +169,20 @@ TEST(futex, wait_timeout) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_timeout_done));
-    EXPECT_EQ(static_cast<int32_t>(g_timeout_rc),
+    ASSERT_TRUE(spin_wait(g_timeout_done));
+    EXPECT_EQ(g_timeout_rc.load_relaxed(),
               static_cast<int32_t>(-110)); // ETIMEDOUT
-    EXPECT_GE(g_timeout_elapsed, 10000000ULL);
+    EXPECT_GE(g_timeout_elapsed.load_relaxed(), 10000000ULL);
 }
 
 // --- killed thread unblocks ---
 
-static volatile uint32_t g_kill_val = 0;
-static volatile uint32_t g_kill_entered = 0;
+static uint32_t g_kill_val = 0;
+static sync::atomic<uint32_t> g_kill_entered;
 static sched::task* g_kill_task = nullptr;
 
 static void kill_waiter_fn(void*) {
-    __atomic_store_n(&g_kill_entered, 1, __ATOMIC_RELEASE);
+    g_kill_entered.store_release(1);
     RUN_ELEVATED({
         sync::futex_wait(
             reinterpret_cast<uintptr_t>(&g_kill_val), 0, 0);
@@ -193,7 +192,7 @@ static void kill_waiter_fn(void*) {
 
 TEST(futex, killed_thread_unblocks) {
     g_kill_val = 0;
-    g_kill_entered = 0;
+    g_kill_entered.store_relaxed(0);
     g_kill_task = nullptr;
 
     RUN_ELEVATED({
@@ -203,7 +202,7 @@ TEST(futex, killed_thread_unblocks) {
         sched::enqueue(g_kill_task);
     });
 
-    ASSERT_TRUE(spin_wait(&g_kill_entered));
+    ASSERT_TRUE(spin_wait(g_kill_entered));
     brief_delay();
 
     RUN_ELEVATED({
@@ -219,24 +218,24 @@ TEST(futex, killed_thread_unblocks) {
 // --- wake_all wakes everyone ---
 
 constexpr uint32_t WALL_TASKS = 8;
-static volatile uint32_t g_wall_val = 0;
-static volatile uint32_t g_wall_ready = 0;
-static volatile uint32_t g_wall_woken = 0;
+static uint32_t g_wall_val = 0;
+static sync::atomic<uint32_t> g_wall_ready;
+static sync::atomic<uint32_t> g_wall_woken;
 
 static void wake_all_waiter_fn(void*) {
-    __atomic_fetch_add(&g_wall_ready, 1, __ATOMIC_ACQ_REL);
+    g_wall_ready.fetch_add_acq_rel(1);
     RUN_ELEVATED({
         sync::futex_wait(
             reinterpret_cast<uintptr_t>(&g_wall_val), 0, 0);
     });
-    __atomic_fetch_add(&g_wall_woken, 1, __ATOMIC_ACQ_REL);
+    g_wall_woken.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(futex, wake_all_wakes_everyone) {
     g_wall_val = 0;
-    g_wall_ready = 0;
-    g_wall_woken = 0;
+    g_wall_ready.store_relaxed(0);
+    g_wall_woken.store_relaxed(0);
 
     RUN_ELEVATED({
         for (uint32_t i = 0; i < WALL_TASKS; i++) {
@@ -247,7 +246,7 @@ TEST(futex, wake_all_wakes_everyone) {
         }
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_wall_ready, WALL_TASKS));
+    ASSERT_TRUE(spin_wait_ge(g_wall_ready, WALL_TASKS));
     brief_delay();
 
     int32_t woken = 0;
@@ -256,45 +255,45 @@ TEST(futex, wake_all_wakes_everyone) {
             reinterpret_cast<uintptr_t>(&g_wall_val));
     });
     EXPECT_EQ(woken, static_cast<int32_t>(WALL_TASKS));
-    EXPECT_TRUE(spin_wait_ge(&g_wall_woken, WALL_TASKS));
+    EXPECT_TRUE(spin_wait_ge(g_wall_woken, WALL_TASKS));
 }
 
 // --- different addresses are independent ---
 
-static volatile uint32_t g_ind_val_a = 0;
-static volatile uint32_t g_ind_val_b = 0;
-static volatile uint32_t g_ind_ready_a = 0;
-static volatile uint32_t g_ind_ready_b = 0;
-static volatile uint32_t g_ind_woken_a = 0;
-static volatile uint32_t g_ind_woken_b = 0;
+static uint32_t g_ind_val_a = 0;
+static uint32_t g_ind_val_b = 0;
+static sync::atomic<uint32_t> g_ind_ready_a;
+static sync::atomic<uint32_t> g_ind_ready_b;
+static sync::atomic<uint32_t> g_ind_woken_a;
+static sync::atomic<uint32_t> g_ind_woken_b;
 
 static void ind_waiter_a_fn(void*) {
-    __atomic_store_n(&g_ind_ready_a, 1, __ATOMIC_RELEASE);
+    g_ind_ready_a.store_release(1);
     RUN_ELEVATED({
         sync::futex_wait(
             reinterpret_cast<uintptr_t>(&g_ind_val_a), 0, 0);
     });
-    __atomic_store_n(&g_ind_woken_a, 1, __ATOMIC_RELEASE);
+    g_ind_woken_a.store_release(1);
     sched::exit(0);
 }
 
 static void ind_waiter_b_fn(void*) {
-    __atomic_store_n(&g_ind_ready_b, 1, __ATOMIC_RELEASE);
+    g_ind_ready_b.store_release(1);
     RUN_ELEVATED({
         sync::futex_wait(
             reinterpret_cast<uintptr_t>(&g_ind_val_b), 0, 0);
     });
-    __atomic_store_n(&g_ind_woken_b, 1, __ATOMIC_RELEASE);
+    g_ind_woken_b.store_release(1);
     sched::exit(0);
 }
 
 TEST(futex, different_addresses_independent) {
     g_ind_val_a = 0;
     g_ind_val_b = 0;
-    g_ind_ready_a = 0;
-    g_ind_ready_b = 0;
-    g_ind_woken_a = 0;
-    g_ind_woken_b = 0;
+    g_ind_ready_a.store_relaxed(0);
+    g_ind_ready_b.store_relaxed(0);
+    g_ind_woken_a.store_relaxed(0);
+    g_ind_woken_b.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* ta = sched::create_kernel_task(
@@ -307,8 +306,8 @@ TEST(futex, different_addresses_independent) {
         sched::enqueue(tb);
     });
 
-    ASSERT_TRUE(spin_wait(&g_ind_ready_a));
-    ASSERT_TRUE(spin_wait(&g_ind_ready_b));
+    ASSERT_TRUE(spin_wait(g_ind_ready_a));
+    ASSERT_TRUE(spin_wait(g_ind_ready_b));
     brief_delay();
 
     // Wake only address A
@@ -317,9 +316,9 @@ TEST(futex, different_addresses_independent) {
             reinterpret_cast<uintptr_t>(&g_ind_val_a), 1);
     });
 
-    ASSERT_TRUE(spin_wait(&g_ind_woken_a));
+    ASSERT_TRUE(spin_wait(g_ind_woken_a));
     brief_delay();
-    EXPECT_EQ(__atomic_load_n(&g_ind_woken_b, __ATOMIC_ACQUIRE), 0u);
+    EXPECT_EQ(g_ind_woken_b.load_acquire(), 0u);
 
     // Now wake B
     RUN_ELEVATED({
@@ -327,5 +326,5 @@ TEST(futex, different_addresses_independent) {
             reinterpret_cast<uintptr_t>(&g_ind_val_b), 1);
     });
 
-    EXPECT_TRUE(spin_wait(&g_ind_woken_b));
+    EXPECT_TRUE(spin_wait(g_ind_woken_b));
 }

--- a/kernel/tests/sync/mutex.test.cpp
+++ b/kernel/tests/sync/mutex.test.cpp
@@ -58,28 +58,28 @@ TEST(mutex, trylock_when_free) {
 // --- trylock_when_held ---
 
 static sync::mutex g_trylock_mtx;
-static volatile uint32_t g_trylock_result;
-static volatile uint32_t g_trylock_done;
+static sync::atomic<uint32_t> g_trylock_result;
+static sync::atomic<uint32_t> g_trylock_done;
 
 static void trylock_task_fn(void*) {
     bool got_it = false;
     RUN_ELEVATED({
         got_it = sync::mutex_trylock(g_trylock_mtx);
     });
-    __atomic_store_n(&g_trylock_result, got_it ? 1 : 0, __ATOMIC_RELEASE);
+    g_trylock_result.store_release(got_it ? 1 : 0);
     if (got_it) {
         RUN_ELEVATED({
             sync::mutex_unlock(g_trylock_mtx);
         });
     }
-    __atomic_store_n(&g_trylock_done, 1, __ATOMIC_RELEASE);
+    g_trylock_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(mutex, trylock_when_held) {
     g_trylock_mtx.init();
-    g_trylock_result = 0;
-    g_trylock_done = 0;
+    g_trylock_result.store_relaxed(0);
+    g_trylock_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sync::mutex_lock(g_trylock_mtx);
@@ -92,8 +92,8 @@ TEST(mutex, trylock_when_held) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_trylock_done));
-    EXPECT_EQ(__atomic_load_n(&g_trylock_result, __ATOMIC_ACQUIRE), 0u);
+    ASSERT_TRUE(spin_wait(g_trylock_done));
+    EXPECT_EQ(g_trylock_result.load_acquire(), 0u);
 
     RUN_ELEVATED({
         sync::mutex_unlock(g_trylock_mtx);
@@ -103,14 +103,14 @@ TEST(mutex, trylock_when_held) {
 // --- lock_blocks_until_unlock ---
 
 static sync::mutex g_block_mtx;
-static volatile uint32_t g_block_waiting;
-static volatile uint32_t g_block_acquired;
+static sync::atomic<uint32_t> g_block_waiting;
+static sync::atomic<uint32_t> g_block_acquired;
 
 static void block_waiter_fn(void*) {
-    __atomic_store_n(&g_block_waiting, 1, __ATOMIC_RELEASE);
+    g_block_waiting.store_release(1);
     RUN_ELEVATED({
         sync::mutex_lock(g_block_mtx);
-        __atomic_store_n(&g_block_acquired, 1, __ATOMIC_RELEASE);
+        g_block_acquired.store_release(1);
         sync::mutex_unlock(g_block_mtx);
     });
     sched::exit(0);
@@ -118,8 +118,8 @@ static void block_waiter_fn(void*) {
 
 TEST(mutex, lock_blocks_until_unlock) {
     g_block_mtx.init();
-    g_block_waiting = 0;
-    g_block_acquired = 0;
+    g_block_waiting.store_relaxed(0);
+    g_block_acquired.store_relaxed(0);
 
     RUN_ELEVATED({
         sync::mutex_lock(g_block_mtx);
@@ -132,16 +132,16 @@ TEST(mutex, lock_blocks_until_unlock) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_block_waiting));
+    ASSERT_TRUE(spin_wait(g_block_waiting));
     brief_delay();
 
-    EXPECT_EQ(__atomic_load_n(&g_block_acquired, __ATOMIC_ACQUIRE), 0u);
+    EXPECT_EQ(g_block_acquired.load_acquire(), 0u);
 
     RUN_ELEVATED({
         sync::mutex_unlock(g_block_mtx);
     });
 
-    EXPECT_TRUE(spin_wait(&g_block_acquired));
+    EXPECT_TRUE(spin_wait(g_block_acquired));
 }
 
 // --- multiple_waiters_all_complete ---
@@ -151,20 +151,20 @@ TEST(mutex, lock_blocks_until_unlock) {
 constexpr uint32_t MW_TASKS = 3;
 
 static sync::mutex g_mw_mtx;
-static volatile uint32_t g_mw_done_count;
+static sync::atomic<uint32_t> g_mw_done_count;
 
 static void mw_waiter_fn(void*) {
     RUN_ELEVATED({
         sync::mutex_lock(g_mw_mtx);
         sync::mutex_unlock(g_mw_mtx);
     });
-    __atomic_fetch_add(&g_mw_done_count, 1, __ATOMIC_ACQ_REL);
+    g_mw_done_count.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(mutex, multiple_waiters_all_complete) {
     g_mw_mtx.init();
-    g_mw_done_count = 0;
+    g_mw_done_count.store_relaxed(0);
 
     RUN_ELEVATED({
         sync::mutex_lock(g_mw_mtx);
@@ -180,13 +180,13 @@ TEST(mutex, multiple_waiters_all_complete) {
     });
 
     brief_delay();
-    EXPECT_EQ(__atomic_load_n(&g_mw_done_count, __ATOMIC_ACQUIRE), 0u);
+    EXPECT_EQ(g_mw_done_count.load_acquire(), 0u);
 
     RUN_ELEVATED({
         sync::mutex_unlock(g_mw_mtx);
     });
 
-    EXPECT_TRUE(spin_wait_ge(&g_mw_done_count, MW_TASKS));
+    EXPECT_TRUE(spin_wait_ge(g_mw_done_count, MW_TASKS));
 }
 
 // --- stress_mutual_exclusion ---
@@ -195,26 +195,26 @@ constexpr uint32_t STRESS_TASKS = 4;
 constexpr uint32_t STRESS_ITERS = 1000;
 
 static sync::mutex g_stress_mtx;
-static volatile uint32_t g_stress_counter;
-static volatile uint32_t g_stress_done_count;
+static sync::atomic<uint32_t> g_stress_counter;
+static sync::atomic<uint32_t> g_stress_done_count;
 
 static void stress_worker_fn(void*) {
     for (uint32_t i = 0; i < STRESS_ITERS; i++) {
         RUN_ELEVATED({
             sync::mutex_lock(g_stress_mtx);
-            uint32_t val = __atomic_load_n(&g_stress_counter, __ATOMIC_RELAXED);
-            __atomic_store_n(&g_stress_counter, val + 1, __ATOMIC_RELAXED);
+            uint32_t val = g_stress_counter.load_relaxed();
+            g_stress_counter.store_relaxed(val + 1);
             sync::mutex_unlock(g_stress_mtx);
         });
     }
-    __atomic_fetch_add(&g_stress_done_count, 1, __ATOMIC_ACQ_REL);
+    g_stress_done_count.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(mutex, stress_mutual_exclusion) {
     g_stress_mtx.init();
-    g_stress_counter = 0;
-    g_stress_done_count = 0;
+    g_stress_counter.store_relaxed(0);
+    g_stress_done_count.store_relaxed(0);
 
     RUN_ELEVATED({
         for (uint32_t i = 0; i < STRESS_TASKS; i++) {
@@ -225,7 +225,7 @@ TEST(mutex, stress_mutual_exclusion) {
         }
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_stress_done_count, STRESS_TASKS));
-    EXPECT_EQ(__atomic_load_n(&g_stress_counter, __ATOMIC_ACQUIRE),
+    ASSERT_TRUE(spin_wait_ge(g_stress_done_count, STRESS_TASKS));
+    EXPECT_EQ(g_stress_counter.load_acquire(),
               STRESS_TASKS * STRESS_ITERS);
 }

--- a/kernel/tests/sync/poll.test.cpp
+++ b/kernel/tests/sync/poll.test.cpp
@@ -19,9 +19,9 @@ TEST_SUITE(poll);
 // One task subscribes to a single wait queue, another fires it.
 
 static sync::wait_queue g_basic_wq;
-static volatile uint32_t g_basic_waiting;
-static volatile uint32_t g_basic_result;
-static volatile uint32_t g_basic_done;
+static sync::atomic<uint32_t> g_basic_waiting;
+static sync::atomic<uint32_t> g_basic_result;
+static sync::atomic<uint32_t> g_basic_done;
 
 static void basic_poll_fn(void*) {
     RUN_ELEVATED({
@@ -29,21 +29,21 @@ static void basic_poll_fn(void*) {
         pt.init(sched::current());
         sync::poll_subscribe(pt, g_basic_wq);
 
-        __atomic_store_n(&g_basic_waiting, 1, __ATOMIC_RELEASE);
+        g_basic_waiting.store_release(1);
         bool triggered = sync::poll_wait(pt, 0);
-        __atomic_store_n(&g_basic_result, triggered ? 1 : 0, __ATOMIC_RELEASE);
+        g_basic_result.store_release(triggered ? 1 : 0);
 
         sync::poll_cleanup(pt);
     });
-    __atomic_store_n(&g_basic_done, 1, __ATOMIC_RELEASE);
+    g_basic_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(poll, basic_subscribe_and_trigger) {
     g_basic_wq.init();
-    g_basic_waiting = 0;
-    g_basic_result = 0;
-    g_basic_done = 0;
+    g_basic_waiting.store_relaxed(0);
+    g_basic_result.store_relaxed(0);
+    g_basic_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(basic_poll_fn, nullptr, "poll_basic");
@@ -51,24 +51,24 @@ TEST(poll, basic_subscribe_and_trigger) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_basic_waiting));
+    ASSERT_TRUE(spin_wait(g_basic_waiting));
     brief_delay();
 
     RUN_ELEVATED({
         sync::wake_one(g_basic_wq);
     });
 
-    ASSERT_TRUE(spin_wait(&g_basic_done));
-    EXPECT_EQ(__atomic_load_n(&g_basic_result, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_basic_done));
+    EXPECT_EQ(g_basic_result.load_acquire(), 1u);
 }
 
 // multi_source_first_fires
 // Subscribe to 3 wait queues, fire the first one.
 
 static sync::wait_queue g_multi_wq[3];
-static volatile uint32_t g_multi_first_waiting;
-static volatile uint32_t g_multi_first_result;
-static volatile uint32_t g_multi_first_done;
+static sync::atomic<uint32_t> g_multi_first_waiting;
+static sync::atomic<uint32_t> g_multi_first_result;
+static sync::atomic<uint32_t> g_multi_first_done;
 
 static void multi_first_fn(void*) {
     RUN_ELEVATED({
@@ -78,21 +78,21 @@ static void multi_first_fn(void*) {
             sync::poll_subscribe(pt, g_multi_wq[i]);
         }
 
-        __atomic_store_n(&g_multi_first_waiting, 1, __ATOMIC_RELEASE);
+        g_multi_first_waiting.store_release(1);
         bool triggered = sync::poll_wait(pt, 0);
-        __atomic_store_n(&g_multi_first_result, triggered ? 1 : 0, __ATOMIC_RELEASE);
+        g_multi_first_result.store_release(triggered ? 1 : 0);
 
         sync::poll_cleanup(pt);
     });
-    __atomic_store_n(&g_multi_first_done, 1, __ATOMIC_RELEASE);
+    g_multi_first_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(poll, multi_source_first_fires) {
     for (int i = 0; i < 3; i++) g_multi_wq[i].init();
-    g_multi_first_waiting = 0;
-    g_multi_first_result = 0;
-    g_multi_first_done = 0;
+    g_multi_first_waiting.store_relaxed(0);
+    g_multi_first_result.store_relaxed(0);
+    g_multi_first_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(multi_first_fn, nullptr, "poll_mf");
@@ -100,23 +100,23 @@ TEST(poll, multi_source_first_fires) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_multi_first_waiting));
+    ASSERT_TRUE(spin_wait(g_multi_first_waiting));
     brief_delay();
 
     RUN_ELEVATED({
         sync::wake_one(g_multi_wq[0]);
     });
 
-    ASSERT_TRUE(spin_wait(&g_multi_first_done));
-    EXPECT_EQ(__atomic_load_n(&g_multi_first_result, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_multi_first_done));
+    EXPECT_EQ(g_multi_first_result.load_acquire(), 1u);
 }
 
 // multi_source_last_fires
 // Subscribe to 3 wait queues, fire the last one.
 
-static volatile uint32_t g_multi_last_waiting;
-static volatile uint32_t g_multi_last_result;
-static volatile uint32_t g_multi_last_done;
+static sync::atomic<uint32_t> g_multi_last_waiting;
+static sync::atomic<uint32_t> g_multi_last_result;
+static sync::atomic<uint32_t> g_multi_last_done;
 
 static void multi_last_fn(void*) {
     RUN_ELEVATED({
@@ -126,21 +126,21 @@ static void multi_last_fn(void*) {
             sync::poll_subscribe(pt, g_multi_wq[i]);
         }
 
-        __atomic_store_n(&g_multi_last_waiting, 1, __ATOMIC_RELEASE);
+        g_multi_last_waiting.store_release(1);
         bool triggered = sync::poll_wait(pt, 0);
-        __atomic_store_n(&g_multi_last_result, triggered ? 1 : 0, __ATOMIC_RELEASE);
+        g_multi_last_result.store_release(triggered ? 1 : 0);
 
         sync::poll_cleanup(pt);
     });
-    __atomic_store_n(&g_multi_last_done, 1, __ATOMIC_RELEASE);
+    g_multi_last_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(poll, multi_source_last_fires) {
     for (int i = 0; i < 3; i++) g_multi_wq[i].init();
-    g_multi_last_waiting = 0;
-    g_multi_last_result = 0;
-    g_multi_last_done = 0;
+    g_multi_last_waiting.store_relaxed(0);
+    g_multi_last_result.store_relaxed(0);
+    g_multi_last_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(multi_last_fn, nullptr, "poll_ml");
@@ -148,23 +148,23 @@ TEST(poll, multi_source_last_fires) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_multi_last_waiting));
+    ASSERT_TRUE(spin_wait(g_multi_last_waiting));
     brief_delay();
 
     RUN_ELEVATED({
         sync::wake_one(g_multi_wq[2]);
     });
 
-    ASSERT_TRUE(spin_wait(&g_multi_last_done));
-    EXPECT_EQ(__atomic_load_n(&g_multi_last_result, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_multi_last_done));
+    EXPECT_EQ(g_multi_last_result.load_acquire(), 1u);
 }
 
 // multi_source_all_fire
 // Subscribe to 3 wait queues, fire all of them. Task should wake once.
 
-static volatile uint32_t g_multi_all_waiting;
-static volatile uint32_t g_multi_all_result;
-static volatile uint32_t g_multi_all_done;
+static sync::atomic<uint32_t> g_multi_all_waiting;
+static sync::atomic<uint32_t> g_multi_all_result;
+static sync::atomic<uint32_t> g_multi_all_done;
 
 static void multi_all_fn(void*) {
     RUN_ELEVATED({
@@ -174,21 +174,21 @@ static void multi_all_fn(void*) {
             sync::poll_subscribe(pt, g_multi_wq[i]);
         }
 
-        __atomic_store_n(&g_multi_all_waiting, 1, __ATOMIC_RELEASE);
+        g_multi_all_waiting.store_release(1);
         bool triggered = sync::poll_wait(pt, 0);
-        __atomic_store_n(&g_multi_all_result, triggered ? 1 : 0, __ATOMIC_RELEASE);
+        g_multi_all_result.store_release(triggered ? 1 : 0);
 
         sync::poll_cleanup(pt);
     });
-    __atomic_store_n(&g_multi_all_done, 1, __ATOMIC_RELEASE);
+    g_multi_all_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(poll, multi_source_all_fire) {
     for (int i = 0; i < 3; i++) g_multi_wq[i].init();
-    g_multi_all_waiting = 0;
-    g_multi_all_result = 0;
-    g_multi_all_done = 0;
+    g_multi_all_waiting.store_relaxed(0);
+    g_multi_all_result.store_relaxed(0);
+    g_multi_all_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(multi_all_fn, nullptr, "poll_ma");
@@ -196,7 +196,7 @@ TEST(poll, multi_source_all_fire) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_multi_all_waiting));
+    ASSERT_TRUE(spin_wait(g_multi_all_waiting));
     brief_delay();
 
     RUN_ELEVATED({
@@ -205,15 +205,15 @@ TEST(poll, multi_source_all_fire) {
         sync::wake_one(g_multi_wq[2]);
     });
 
-    ASSERT_TRUE(spin_wait(&g_multi_all_done));
-    EXPECT_EQ(__atomic_load_n(&g_multi_all_result, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_multi_all_done));
+    EXPECT_EQ(g_multi_all_result.load_acquire(), 1u);
 }
 
 // timeout_no_trigger
 // Subscribe but never fire. Wait with timeout. Verify returns false.
 
-static volatile uint32_t g_timeout_result;
-static volatile uint32_t g_timeout_done;
+static sync::atomic<uint32_t> g_timeout_result;
+static sync::atomic<uint32_t> g_timeout_done;
 
 static void timeout_fn(void*) {
     RUN_ELEVATED({
@@ -224,17 +224,17 @@ static void timeout_fn(void*) {
         sync::poll_subscribe(pt, wq);
 
         bool triggered = sync::poll_wait(pt, 50000000ULL); // 50ms
-        __atomic_store_n(&g_timeout_result, triggered ? 1 : 0, __ATOMIC_RELEASE);
+        g_timeout_result.store_release(triggered ? 1 : 0);
 
         sync::poll_cleanup(pt);
     });
-    __atomic_store_n(&g_timeout_done, 1, __ATOMIC_RELEASE);
+    g_timeout_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(poll, timeout_no_trigger) {
-    g_timeout_result = 0;
-    g_timeout_done = 0;
+    g_timeout_result.store_relaxed(0);
+    g_timeout_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(timeout_fn, nullptr, "poll_to");
@@ -242,15 +242,15 @@ TEST(poll, timeout_no_trigger) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_timeout_done));
-    EXPECT_EQ(__atomic_load_n(&g_timeout_result, __ATOMIC_ACQUIRE), 0u);
+    ASSERT_TRUE(spin_wait(g_timeout_done));
+    EXPECT_EQ(g_timeout_result.load_acquire(), 0u);
 }
 
 // immediate_trigger_no_block
 // Fire the source before poll_wait, should return immediately.
 
-static volatile uint32_t g_imm_result;
-static volatile uint32_t g_imm_done;
+static sync::atomic<uint32_t> g_imm_result;
+static sync::atomic<uint32_t> g_imm_done;
 
 static void immediate_fn(void*) {
     RUN_ELEVATED({
@@ -264,17 +264,17 @@ static void immediate_fn(void*) {
         sync::wake_one(wq);
 
         bool triggered = sync::poll_wait(pt, 0);
-        __atomic_store_n(&g_imm_result, triggered ? 1 : 0, __ATOMIC_RELEASE);
+        g_imm_result.store_release(triggered ? 1 : 0);
 
         sync::poll_cleanup(pt);
     });
-    __atomic_store_n(&g_imm_done, 1, __ATOMIC_RELEASE);
+    g_imm_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(poll, immediate_trigger_no_block) {
-    g_imm_result = 0;
-    g_imm_done = 0;
+    g_imm_result.store_relaxed(0);
+    g_imm_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(immediate_fn, nullptr, "poll_imm");
@@ -282,14 +282,14 @@ TEST(poll, immediate_trigger_no_block) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_imm_done));
-    EXPECT_EQ(__atomic_load_n(&g_imm_result, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_imm_done));
+    EXPECT_EQ(g_imm_result.load_acquire(), 1u);
 }
 
 // cleanup_removes_all_observers
 // Subscribe to 3 wqs, cleanup, verify observer lists are empty.
 
-static volatile uint32_t g_cleanup_done;
+static sync::atomic<uint32_t> g_cleanup_done;
 
 static void cleanup_fn(void*) {
     RUN_ELEVATED({
@@ -312,16 +312,16 @@ static void cleanup_fn(void*) {
             sync::spin_unlock_irqrestore(wqs[i].lock, irq);
         }
         if (!all_empty) {
-            __atomic_store_n(&g_cleanup_done, 2, __ATOMIC_RELEASE);
+            g_cleanup_done.store_release(2);
         } else {
-            __atomic_store_n(&g_cleanup_done, 1, __ATOMIC_RELEASE);
+            g_cleanup_done.store_release(1);
         }
     });
     sched::exit(0);
 }
 
 TEST(poll, cleanup_removes_all_observers) {
-    g_cleanup_done = 0;
+    g_cleanup_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(cleanup_fn, nullptr, "poll_cl");
@@ -329,20 +329,20 @@ TEST(poll, cleanup_removes_all_observers) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_cleanup_done));
-    EXPECT_EQ(__atomic_load_n(&g_cleanup_done, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_cleanup_done));
+    EXPECT_EQ(g_cleanup_done.load_acquire(), 1u);
 }
 
 // kill_pending_wakes_poll
 // Task in poll_wait, force_wake_for_kill wakes it.
 
 static sync::wait_queue g_kill_wq;
-static volatile uint32_t g_kill_waiting;
-static volatile uint32_t g_kill_result;
-static volatile uint32_t g_kill_kp;
-static volatile uint32_t g_kill_sched_linked;
-static volatile uint32_t g_kill_state_after_wait;
-static volatile uint32_t g_kill_done;
+static sync::atomic<uint32_t> g_kill_waiting;
+static sync::atomic<uint32_t> g_kill_result;
+static sync::atomic<uint32_t> g_kill_kp;
+static sync::atomic<uint32_t> g_kill_sched_linked;
+static sync::atomic<uint32_t> g_kill_state_after_wait;
+static sync::atomic<uint32_t> g_kill_done;
 
 static void kill_poll_fn(void*) {
     RUN_ELEVATED({
@@ -350,30 +350,27 @@ static void kill_poll_fn(void*) {
         pt.init(sched::current());
         sync::poll_subscribe(pt, g_kill_wq);
 
-        __atomic_store_n(&g_kill_waiting, 1, __ATOMIC_RELEASE);
+        g_kill_waiting.store_release(1);
         bool triggered = sync::poll_wait(pt, 0);
-        __atomic_store_n(&g_kill_result, triggered ? 1 : 0, __ATOMIC_RELEASE);
-        __atomic_store_n(&g_kill_kp,
-            sched::is_kill_pending() ? 1 : 0, __ATOMIC_RELEASE);
-        __atomic_store_n(&g_kill_sched_linked,
-            sched::current()->sched_link.is_linked() ? 1 : 0, __ATOMIC_RELEASE);
-        __atomic_store_n(&g_kill_state_after_wait,
-            sched::current()->state.load_relaxed(), __ATOMIC_RELEASE);
+        g_kill_result.store_release(triggered ? 1 : 0);
+        g_kill_kp.store_release(sched::is_kill_pending() ? 1 : 0);
+        g_kill_sched_linked.store_release(sched::current()->sched_link.is_linked() ? 1 : 0);
+        g_kill_state_after_wait.store_release(sched::current()->state.load_relaxed());
 
         sync::poll_cleanup(pt);
     });
-    __atomic_store_n(&g_kill_done, 1, __ATOMIC_RELEASE);
+    g_kill_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(poll, kill_pending_wakes_poll) {
     g_kill_wq.init();
-    g_kill_waiting = 0;
-    g_kill_result = 0;
-    g_kill_kp = 0;
-    g_kill_sched_linked = 0;
-    g_kill_state_after_wait = 0;
-    g_kill_done = 0;
+    g_kill_waiting.store_relaxed(0);
+    g_kill_result.store_relaxed(0);
+    g_kill_kp.store_relaxed(0);
+    g_kill_sched_linked.store_relaxed(0);
+    g_kill_state_after_wait.store_relaxed(0);
+    g_kill_done.store_relaxed(0);
 
     sched::task* t = nullptr;
     RUN_ELEVATED({
@@ -382,19 +379,19 @@ TEST(poll, kill_pending_wakes_poll) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_kill_waiting));
+    ASSERT_TRUE(spin_wait(g_kill_waiting));
     brief_delay();
 
     RUN_ELEVATED({
         sched::force_wake_for_kill(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_kill_done));
+    ASSERT_TRUE(spin_wait(g_kill_done));
     // Source was not fired, so triggered should be 0
-    EXPECT_EQ(__atomic_load_n(&g_kill_result, __ATOMIC_ACQUIRE), 0u);
-    EXPECT_EQ(__atomic_load_n(&g_kill_kp, __ATOMIC_ACQUIRE), 1u);
-    EXPECT_EQ(__atomic_load_n(&g_kill_sched_linked, __ATOMIC_ACQUIRE), 0u);
-    EXPECT_EQ(__atomic_load_n(&g_kill_state_after_wait, __ATOMIC_ACQUIRE),
+    EXPECT_EQ(g_kill_result.load_acquire(), 0u);
+    EXPECT_EQ(g_kill_kp.load_acquire(), 1u);
+    EXPECT_EQ(g_kill_sched_linked.load_acquire(), 0u);
+    EXPECT_EQ(g_kill_state_after_wait.load_acquire(),
               sched::TASK_STATE_RUNNING);
 }
 
@@ -403,9 +400,9 @@ TEST(poll, kill_pending_wakes_poll) {
 
 static sync::wait_queue g_repeat_wq;
 static sync::spinlock g_repeat_lock;
-static volatile uint32_t g_repeat_counter;
-static volatile uint32_t g_repeat_waiting;
-static volatile uint32_t g_repeat_progress;
+static sync::atomic<uint32_t> g_repeat_counter;
+static sync::atomic<uint32_t> g_repeat_waiting;
+static sync::atomic<uint32_t> g_repeat_progress;
 
 constexpr uint32_t REPEAT_CYCLES = 10;
 
@@ -416,11 +413,11 @@ static void repeat_poll_fn(void*) {
             pt.init(sched::current());
             sync::poll_subscribe(pt, g_repeat_wq);
 
-            __atomic_store_n(&g_repeat_waiting, iter + 1, __ATOMIC_RELEASE);
+            g_repeat_waiting.store_release(iter + 1);
             sync::poll_wait(pt, 0);
             sync::poll_cleanup(pt);
         });
-        __atomic_store_n(&g_repeat_progress, iter + 1, __ATOMIC_RELEASE);
+        g_repeat_progress.store_release(iter + 1);
     }
     sched::exit(0);
 }
@@ -428,9 +425,9 @@ static void repeat_poll_fn(void*) {
 TEST(poll, repeated_poll_cycles) {
     g_repeat_wq.init();
     g_repeat_lock = sync::SPINLOCK_INIT;
-    g_repeat_counter = 0;
-    g_repeat_waiting = 0;
-    g_repeat_progress = 0;
+    g_repeat_counter.store_relaxed(0);
+    g_repeat_waiting.store_relaxed(0);
+    g_repeat_progress.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(repeat_poll_fn, nullptr, "poll_rep");
@@ -439,13 +436,13 @@ TEST(poll, repeated_poll_cycles) {
     });
 
     for (uint32_t iter = 0; iter < REPEAT_CYCLES; iter++) {
-        ASSERT_TRUE(spin_wait_ge(&g_repeat_waiting, iter + 1));
+        ASSERT_TRUE(spin_wait_ge(g_repeat_waiting, iter + 1));
         brief_delay();
         RUN_ELEVATED({
             sync::wake_one(g_repeat_wq);
         });
-        ASSERT_TRUE(spin_wait_ge(&g_repeat_progress, iter + 1));
+        ASSERT_TRUE(spin_wait_ge(g_repeat_progress, iter + 1));
     }
 
-    EXPECT_EQ(__atomic_load_n(&g_repeat_progress, __ATOMIC_ACQUIRE), REPEAT_CYCLES);
+    EXPECT_EQ(g_repeat_progress.load_acquire(), REPEAT_CYCLES);
 }

--- a/kernel/tests/sync/poll.test.cpp
+++ b/kernel/tests/sync/poll.test.cpp
@@ -358,7 +358,7 @@ static void kill_poll_fn(void*) {
         __atomic_store_n(&g_kill_sched_linked,
             sched::current()->sched_link.is_linked() ? 1 : 0, __ATOMIC_RELEASE);
         __atomic_store_n(&g_kill_state_after_wait,
-            sched::current()->state, __ATOMIC_RELEASE);
+            sched::current()->state.load_relaxed(), __ATOMIC_RELEASE);
 
         sync::poll_cleanup(pt);
     });

--- a/kernel/tests/sync/poll_resource.test.cpp
+++ b/kernel/tests/sync/poll_resource.test.cpp
@@ -128,9 +128,9 @@ TEST(poll_resource, ring_buffer_poll_err) {
 // ring_buffer_poll_subscribes_read_wq
 
 static sync::wait_queue g_rb_poll_wq;
-static volatile uint32_t g_rb_poll_waiting;
-static volatile uint32_t g_rb_poll_result;
-static volatile uint32_t g_rb_poll_done;
+static sync::atomic<uint32_t> g_rb_poll_waiting;
+static sync::atomic<uint32_t> g_rb_poll_result;
+static sync::atomic<uint32_t> g_rb_poll_done;
 
 static void rb_poll_waiter_fn(void* arg) {
     auto* rb = static_cast<ring_buffer*>(arg);
@@ -140,28 +140,28 @@ static void rb_poll_waiter_fn(void* arg) {
 
         uint32_t mask = ring_buffer_poll_read(rb, &pt);
         if (mask & sync::POLL_IN) {
-            __atomic_store_n(&g_rb_poll_result, 1, __ATOMIC_RELEASE);
+            g_rb_poll_result.store_release(1);
             sync::poll_cleanup(pt);
-            __atomic_store_n(&g_rb_poll_done, 1, __ATOMIC_RELEASE);
+            g_rb_poll_done.store_release(1);
             sched::exit(0);
             return;
         }
 
-        __atomic_store_n(&g_rb_poll_waiting, 1, __ATOMIC_RELEASE);
+        g_rb_poll_waiting.store_release(1);
         sync::poll_wait(pt, 0);
         // Re-check after wake
         mask = ring_buffer_poll_read(rb, nullptr);
-        __atomic_store_n(&g_rb_poll_result, (mask & sync::POLL_IN) ? 1 : 0, __ATOMIC_RELEASE);
+        g_rb_poll_result.store_release((mask & sync::POLL_IN) ? 1 : 0);
         sync::poll_cleanup(pt);
     });
-    __atomic_store_n(&g_rb_poll_done, 1, __ATOMIC_RELEASE);
+    g_rb_poll_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(poll_resource, ring_buffer_poll_subscribes_read_wq) {
-    g_rb_poll_waiting = 0;
-    g_rb_poll_result = 0;
-    g_rb_poll_done = 0;
+    g_rb_poll_waiting.store_relaxed(0);
+    g_rb_poll_result.store_relaxed(0);
+    g_rb_poll_done.store_relaxed(0);
 
     ring_buffer* rb = nullptr;
     RUN_ELEVATED({ rb = ring_buffer_create(256); });
@@ -173,15 +173,15 @@ TEST(poll_resource, ring_buffer_poll_subscribes_read_wq) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(test_helpers::spin_wait(&g_rb_poll_waiting));
+    ASSERT_TRUE(test_helpers::spin_wait(g_rb_poll_waiting));
     test_helpers::brief_delay();
 
     // Write data to trigger the observer
     uint8_t data[] = {42};
     RUN_ELEVATED({ (void)ring_buffer_write(rb, data, 1, true); });
 
-    ASSERT_TRUE(test_helpers::spin_wait(&g_rb_poll_done));
-    EXPECT_EQ(__atomic_load_n(&g_rb_poll_result, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(test_helpers::spin_wait(g_rb_poll_done));
+    EXPECT_EQ(g_rb_poll_result.load_acquire(), 1u);
 
     RUN_ELEVATED({ ring_buffer_destroy(rb); });
 }

--- a/kernel/tests/sync/smp_mutex.test.cpp
+++ b/kernel/tests/sync/smp_mutex.test.cpp
@@ -24,20 +24,20 @@ constexpr uint32_t MAX_TEST_CPUS = 16;
 constexpr uint32_t ME_ITERS = 500;
 
 static sync::mutex g_me_mtx;
-static volatile uint32_t g_me_counter;
-static volatile uint32_t g_me_done[MAX_TEST_CPUS] = {};
+static sync::atomic<uint32_t> g_me_counter;
+static sync::atomic<uint32_t> g_me_done[MAX_TEST_CPUS] = {};
 
 static void me_worker_fn(void* arg) {
     uint32_t idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg));
     for (uint32_t i = 0; i < ME_ITERS; i++) {
         RUN_ELEVATED({
             sync::mutex_lock(g_me_mtx);
-            uint32_t val = __atomic_load_n(&g_me_counter, __ATOMIC_RELAXED);
-            __atomic_store_n(&g_me_counter, val + 1, __ATOMIC_RELAXED);
+            uint32_t val = g_me_counter.load_relaxed();
+            g_me_counter.store_relaxed(val + 1);
             sync::mutex_unlock(g_me_mtx);
         });
     }
-    __atomic_store_n(&g_me_done[idx], 1, __ATOMIC_RELEASE);
+    g_me_done[idx].store_release(1);
     sched::exit(0);
 }
 
@@ -46,9 +46,9 @@ TEST(smp_mutex, cross_cpu_mutual_exclusion) {
     if (cpus < 2 || cpus > MAX_TEST_CPUS) return;
 
     g_me_mtx.init();
-    g_me_counter = 0;
+    g_me_counter.store_relaxed(0);
     for (uint32_t i = 0; i < cpus; i++) {
-        g_me_done[i] = 0;
+        g_me_done[i].store_relaxed(0);
     }
 
     RUN_ELEVATED({
@@ -63,10 +63,10 @@ TEST(smp_mutex, cross_cpu_mutual_exclusion) {
     });
 
     for (uint32_t i = 0; i < cpus; i++) {
-        ASSERT_TRUE(spin_wait(&g_me_done[i]));
+        ASSERT_TRUE(spin_wait(g_me_done[i]));
     }
 
-    EXPECT_EQ(__atomic_load_n(&g_me_counter, __ATOMIC_ACQUIRE),
+    EXPECT_EQ(g_me_counter.load_acquire(),
               cpus * ME_ITERS);
 }
 
@@ -74,14 +74,14 @@ TEST(smp_mutex, cross_cpu_mutual_exclusion) {
 // Proves: mutex_lock blocks a task on a remote CPU until the holder unlocks.
 
 static sync::mutex g_block_mtx;
-static volatile uint32_t g_block_waiting;
-static volatile uint32_t g_block_acquired;
+static sync::atomic<uint32_t> g_block_waiting;
+static sync::atomic<uint32_t> g_block_acquired;
 
 static void block_remote_fn(void*) {
-    __atomic_store_n(&g_block_waiting, 1, __ATOMIC_RELEASE);
+    g_block_waiting.store_release(1);
     RUN_ELEVATED({
         sync::mutex_lock(g_block_mtx);
-        __atomic_store_n(&g_block_acquired, 1, __ATOMIC_RELEASE);
+        g_block_acquired.store_release(1);
         sync::mutex_unlock(g_block_mtx);
     });
     sched::exit(0);
@@ -92,8 +92,8 @@ TEST(smp_mutex, cross_cpu_lock_blocks) {
     if (cpus < 2) return;
 
     g_block_mtx.init();
-    g_block_waiting = 0;
-    g_block_acquired = 0;
+    g_block_waiting.store_relaxed(0);
+    g_block_acquired.store_relaxed(0);
 
     RUN_ELEVATED({
         sync::mutex_lock(g_block_mtx);
@@ -106,16 +106,16 @@ TEST(smp_mutex, cross_cpu_lock_blocks) {
         sched::enqueue_on(t, 1);
     });
 
-    ASSERT_TRUE(spin_wait(&g_block_waiting));
+    ASSERT_TRUE(spin_wait(g_block_waiting));
     brief_delay();
 
-    EXPECT_EQ(__atomic_load_n(&g_block_acquired, __ATOMIC_ACQUIRE), 0u);
+    EXPECT_EQ(g_block_acquired.load_acquire(), 0u);
 
     RUN_ELEVATED({
         sync::mutex_unlock(g_block_mtx);
     });
 
-    EXPECT_TRUE(spin_wait(&g_block_acquired));
+    EXPECT_TRUE(spin_wait(g_block_acquired));
 }
 
 // --- cross_cpu_trylock ---
@@ -123,33 +123,33 @@ TEST(smp_mutex, cross_cpu_lock_blocks) {
 // and succeeds once the holder releases.
 
 static sync::mutex g_try_mtx;
-static volatile uint32_t g_try_result_held;
-static volatile uint32_t g_try_phase1_done;
-static volatile uint32_t g_try_result_free;
-static volatile uint32_t g_try_phase2_go;
-static volatile uint32_t g_try_phase2_done;
+static sync::atomic<uint32_t> g_try_result_held;
+static sync::atomic<uint32_t> g_try_phase1_done;
+static sync::atomic<uint32_t> g_try_result_free;
+static sync::atomic<uint32_t> g_try_phase2_go;
+static sync::atomic<uint32_t> g_try_phase2_done;
 
 static void try_remote_fn(void*) {
     bool got_it = false;
     RUN_ELEVATED({
         got_it = sync::mutex_trylock(g_try_mtx);
     });
-    __atomic_store_n(&g_try_result_held, got_it ? 1 : 0, __ATOMIC_RELEASE);
+    g_try_result_held.store_release(got_it ? 1 : 0);
     if (got_it) {
         RUN_ELEVATED({ sync::mutex_unlock(g_try_mtx); });
     }
-    __atomic_store_n(&g_try_phase1_done, 1, __ATOMIC_RELEASE);
+    g_try_phase1_done.store_release(1);
 
-    while (!__atomic_load_n(&g_try_phase2_go, __ATOMIC_ACQUIRE)) {}
+    while (!g_try_phase2_go.load_acquire()) {}
 
     RUN_ELEVATED({
         got_it = sync::mutex_trylock(g_try_mtx);
     });
-    __atomic_store_n(&g_try_result_free, got_it ? 1 : 0, __ATOMIC_RELEASE);
+    g_try_result_free.store_release(got_it ? 1 : 0);
     if (got_it) {
         RUN_ELEVATED({ sync::mutex_unlock(g_try_mtx); });
     }
-    __atomic_store_n(&g_try_phase2_done, 1, __ATOMIC_RELEASE);
+    g_try_phase2_done.store_release(1);
     sched::exit(0);
 }
 
@@ -158,11 +158,11 @@ TEST(smp_mutex, cross_cpu_trylock) {
     if (cpus < 2) return;
 
     g_try_mtx.init();
-    g_try_result_held = 0;
-    g_try_phase1_done = 0;
-    g_try_result_free = 0;
-    g_try_phase2_go = 0;
-    g_try_phase2_done = 0;
+    g_try_result_held.store_relaxed(0);
+    g_try_phase1_done.store_relaxed(0);
+    g_try_result_free.store_relaxed(0);
+    g_try_phase2_go.store_relaxed(0);
+    g_try_phase2_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sync::mutex_lock(g_try_mtx);
@@ -175,17 +175,17 @@ TEST(smp_mutex, cross_cpu_trylock) {
         sched::enqueue_on(t, 1);
     });
 
-    ASSERT_TRUE(spin_wait(&g_try_phase1_done));
-    EXPECT_EQ(__atomic_load_n(&g_try_result_held, __ATOMIC_ACQUIRE), 0u);
+    ASSERT_TRUE(spin_wait(g_try_phase1_done));
+    EXPECT_EQ(g_try_result_held.load_acquire(), 0u);
 
     RUN_ELEVATED({
         sync::mutex_unlock(g_try_mtx);
     });
 
-    __atomic_store_n(&g_try_phase2_go, 1, __ATOMIC_RELEASE);
+    g_try_phase2_go.store_release(1);
 
-    ASSERT_TRUE(spin_wait(&g_try_phase2_done));
-    EXPECT_EQ(__atomic_load_n(&g_try_result_free, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_try_phase2_done));
+    EXPECT_EQ(g_try_result_free.load_acquire(), 1u);
 }
 
 // --- cross_cpu_mutex_stress ---
@@ -195,19 +195,19 @@ TEST(smp_mutex, cross_cpu_trylock) {
 constexpr uint32_t STRESS_PER_CPU = 2;
 constexpr uint32_t STRESS_ITERS = 500;
 static sync::mutex g_stress_mtx;
-static volatile uint32_t g_stress_counter;
-static volatile uint32_t g_stress_done_count;
+static sync::atomic<uint32_t> g_stress_counter;
+static sync::atomic<uint32_t> g_stress_done_count;
 
 static void stress_worker_fn(void*) {
     for (uint32_t i = 0; i < STRESS_ITERS; i++) {
         RUN_ELEVATED({
             sync::mutex_lock(g_stress_mtx);
-            uint32_t val = __atomic_load_n(&g_stress_counter, __ATOMIC_RELAXED);
-            __atomic_store_n(&g_stress_counter, val + 1, __ATOMIC_RELAXED);
+            uint32_t val = g_stress_counter.load_relaxed();
+            g_stress_counter.store_relaxed(val + 1);
             sync::mutex_unlock(g_stress_mtx);
         });
     }
-    __atomic_fetch_add(&g_stress_done_count, 1, __ATOMIC_ACQ_REL);
+    g_stress_done_count.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
@@ -216,8 +216,8 @@ TEST(smp_mutex, cross_cpu_mutex_stress) {
     if (cpus < 2) return;
 
     g_stress_mtx.init();
-    g_stress_counter = 0;
-    g_stress_done_count = 0;
+    g_stress_counter.store_relaxed(0);
+    g_stress_done_count.store_relaxed(0);
 
     uint32_t total_tasks = STRESS_PER_CPU * cpus;
 
@@ -230,7 +230,7 @@ TEST(smp_mutex, cross_cpu_mutex_stress) {
         }
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_stress_done_count, total_tasks));
-    EXPECT_EQ(__atomic_load_n(&g_stress_counter, __ATOMIC_ACQUIRE),
+    ASSERT_TRUE(spin_wait_ge(g_stress_done_count, total_tasks));
+    EXPECT_EQ(g_stress_counter.load_acquire(),
               total_tasks * STRESS_ITERS);
 }

--- a/kernel/tests/sync/smp_poll.test.cpp
+++ b/kernel/tests/sync/smp_poll.test.cpp
@@ -21,9 +21,9 @@ TEST_SUITE(smp_poll);
 // Polling task on CPU 1, source fired from CPU 0.
 
 static sync::wait_queue g_xcpu_wq;
-static volatile uint32_t g_xcpu_waiting;
-static volatile uint32_t g_xcpu_result;
-static volatile uint32_t g_xcpu_done;
+static sync::atomic<uint32_t> g_xcpu_waiting;
+static sync::atomic<uint32_t> g_xcpu_result;
+static sync::atomic<uint32_t> g_xcpu_done;
 
 static void xcpu_poll_fn(void*) {
     RUN_ELEVATED({
@@ -31,13 +31,13 @@ static void xcpu_poll_fn(void*) {
         pt.init(sched::current());
         sync::poll_subscribe(pt, g_xcpu_wq);
 
-        __atomic_store_n(&g_xcpu_waiting, 1, __ATOMIC_RELEASE);
+        g_xcpu_waiting.store_release(1);
         bool triggered = sync::poll_wait(pt, 0);
-        __atomic_store_n(&g_xcpu_result, triggered ? 1 : 0, __ATOMIC_RELEASE);
+        g_xcpu_result.store_release(triggered ? 1 : 0);
 
         sync::poll_cleanup(pt);
     });
-    __atomic_store_n(&g_xcpu_done, 1, __ATOMIC_RELEASE);
+    g_xcpu_done.store_release(1);
     sched::exit(0);
 }
 
@@ -46,9 +46,9 @@ TEST(smp_poll, cross_cpu_trigger) {
     if (cpus < 2) return;
 
     g_xcpu_wq.init();
-    g_xcpu_waiting = 0;
-    g_xcpu_result = 0;
-    g_xcpu_done = 0;
+    g_xcpu_waiting.store_relaxed(0);
+    g_xcpu_result.store_relaxed(0);
+    g_xcpu_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(xcpu_poll_fn, nullptr, "smp_poll1");
@@ -56,7 +56,7 @@ TEST(smp_poll, cross_cpu_trigger) {
         sched::enqueue_on(t, 1);
     });
 
-    ASSERT_TRUE(spin_wait(&g_xcpu_waiting));
+    ASSERT_TRUE(spin_wait(g_xcpu_waiting));
     brief_delay();
 
     // Fire from CPU 0 (BSP)
@@ -64,17 +64,17 @@ TEST(smp_poll, cross_cpu_trigger) {
         sync::wake_one(g_xcpu_wq);
     });
 
-    ASSERT_TRUE(spin_wait(&g_xcpu_done));
-    EXPECT_EQ(__atomic_load_n(&g_xcpu_result, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_xcpu_done));
+    EXPECT_EQ(g_xcpu_result.load_acquire(), 1u);
 }
 
 // cross_cpu_multi_source
 // Polling task on CPU 1, 3 sources each fired from the BSP.
 
 static sync::wait_queue g_xmulti_wq[3];
-static volatile uint32_t g_xmulti_waiting;
-static volatile uint32_t g_xmulti_result;
-static volatile uint32_t g_xmulti_done;
+static sync::atomic<uint32_t> g_xmulti_waiting;
+static sync::atomic<uint32_t> g_xmulti_result;
+static sync::atomic<uint32_t> g_xmulti_done;
 
 static void xmulti_poll_fn(void*) {
     RUN_ELEVATED({
@@ -84,13 +84,13 @@ static void xmulti_poll_fn(void*) {
             sync::poll_subscribe(pt, g_xmulti_wq[i]);
         }
 
-        __atomic_store_n(&g_xmulti_waiting, 1, __ATOMIC_RELEASE);
+        g_xmulti_waiting.store_release(1);
         bool triggered = sync::poll_wait(pt, 0);
-        __atomic_store_n(&g_xmulti_result, triggered ? 1 : 0, __ATOMIC_RELEASE);
+        g_xmulti_result.store_release(triggered ? 1 : 0);
 
         sync::poll_cleanup(pt);
     });
-    __atomic_store_n(&g_xmulti_done, 1, __ATOMIC_RELEASE);
+    g_xmulti_done.store_release(1);
     sched::exit(0);
 }
 
@@ -99,9 +99,9 @@ TEST(smp_poll, cross_cpu_multi_source) {
     if (cpus < 2) return;
 
     for (int i = 0; i < 3; i++) g_xmulti_wq[i].init();
-    g_xmulti_waiting = 0;
-    g_xmulti_result = 0;
-    g_xmulti_done = 0;
+    g_xmulti_waiting.store_relaxed(0);
+    g_xmulti_result.store_relaxed(0);
+    g_xmulti_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(xmulti_poll_fn, nullptr, "smp_pollm");
@@ -109,7 +109,7 @@ TEST(smp_poll, cross_cpu_multi_source) {
         sched::enqueue_on(t, 1);
     });
 
-    ASSERT_TRUE(spin_wait(&g_xmulti_waiting));
+    ASSERT_TRUE(spin_wait(g_xmulti_waiting));
     brief_delay();
 
     // Fire all 3 sources from BSP
@@ -119,8 +119,8 @@ TEST(smp_poll, cross_cpu_multi_source) {
         sync::wake_one(g_xmulti_wq[2]);
     });
 
-    ASSERT_TRUE(spin_wait(&g_xmulti_done));
-    EXPECT_EQ(__atomic_load_n(&g_xmulti_result, __ATOMIC_ACQUIRE), 1u);
+    ASSERT_TRUE(spin_wait(g_xmulti_done));
+    EXPECT_EQ(g_xmulti_result.load_acquire(), 1u);
 }
 
 // cross_cpu_immediate_wake_preserves_scheduler_state
@@ -129,11 +129,11 @@ TEST(smp_poll, cross_cpu_multi_source) {
 // RUNNING and not leave sched_link queued.
 
 static sync::wait_queue g_xfast_wq;
-static volatile uint32_t g_xfast_waiting;
-static volatile uint32_t g_xfast_done;
-static volatile uint32_t g_xfast_trigger_failures;
-static volatile uint32_t g_xfast_state_failures;
-static volatile uint32_t g_xfast_link_failures;
+static sync::atomic<uint32_t> g_xfast_waiting;
+static sync::atomic<uint32_t> g_xfast_done;
+static sync::atomic<uint32_t> g_xfast_trigger_failures;
+static sync::atomic<uint32_t> g_xfast_state_failures;
+static sync::atomic<uint32_t> g_xfast_link_failures;
 
 constexpr uint32_t XFAST_ITERS = 128;
 
@@ -144,23 +144,23 @@ static void xfast_poll_fn(void*) {
             pt.init(sched::current());
             sync::poll_subscribe(pt, g_xfast_wq);
 
-            __atomic_store_n(&g_xfast_waiting, iter + 1, __ATOMIC_RELEASE);
+            g_xfast_waiting.store_release(iter + 1);
             bool triggered = sync::poll_wait(pt, 0);
 
             sched::task* self = sched::current();
             if (!triggered) {
-                __atomic_fetch_add(&g_xfast_trigger_failures, 1, __ATOMIC_ACQ_REL);
+                g_xfast_trigger_failures.fetch_add_acq_rel(1);
             }
             if (self->state.load_relaxed() != sched::TASK_STATE_RUNNING) {
-                __atomic_fetch_add(&g_xfast_state_failures, 1, __ATOMIC_ACQ_REL);
+                g_xfast_state_failures.fetch_add_acq_rel(1);
             }
             if (self->sched_link.is_linked()) {
-                __atomic_fetch_add(&g_xfast_link_failures, 1, __ATOMIC_ACQ_REL);
+                g_xfast_link_failures.fetch_add_acq_rel(1);
             }
 
             sync::poll_cleanup(pt);
         });
-        __atomic_store_n(&g_xfast_done, iter + 1, __ATOMIC_RELEASE);
+        g_xfast_done.store_release(iter + 1);
     }
     sched::exit(0);
 }
@@ -170,11 +170,11 @@ TEST(smp_poll, cross_cpu_immediate_wake_preserves_scheduler_state) {
     if (cpus < 2) return;
 
     g_xfast_wq.init();
-    g_xfast_waiting = 0;
-    g_xfast_done = 0;
-    g_xfast_trigger_failures = 0;
-    g_xfast_state_failures = 0;
-    g_xfast_link_failures = 0;
+    g_xfast_waiting.store_relaxed(0);
+    g_xfast_done.store_relaxed(0);
+    g_xfast_trigger_failures.store_relaxed(0);
+    g_xfast_state_failures.store_relaxed(0);
+    g_xfast_link_failures.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(xfast_poll_fn, nullptr, "smp_pollf");
@@ -183,16 +183,16 @@ TEST(smp_poll, cross_cpu_immediate_wake_preserves_scheduler_state) {
     });
 
     for (uint32_t iter = 0; iter < XFAST_ITERS; iter++) {
-        ASSERT_TRUE(spin_wait_ge(&g_xfast_waiting, iter + 1));
+        ASSERT_TRUE(spin_wait_ge(g_xfast_waiting, iter + 1));
         RUN_ELEVATED({
             sync::wake_one(g_xfast_wq);
         });
-        ASSERT_TRUE(spin_wait_ge(&g_xfast_done, iter + 1));
+        ASSERT_TRUE(spin_wait_ge(g_xfast_done, iter + 1));
     }
 
-    EXPECT_EQ(__atomic_load_n(&g_xfast_trigger_failures, __ATOMIC_ACQUIRE), 0u);
-    EXPECT_EQ(__atomic_load_n(&g_xfast_state_failures, __ATOMIC_ACQUIRE), 0u);
-    EXPECT_EQ(__atomic_load_n(&g_xfast_link_failures, __ATOMIC_ACQUIRE), 0u);
+    EXPECT_EQ(g_xfast_trigger_failures.load_acquire(), 0u);
+    EXPECT_EQ(g_xfast_state_failures.load_acquire(), 0u);
+    EXPECT_EQ(g_xfast_link_failures.load_acquire(), 0u);
 }
 
 // cross_cpu_cleanup_race
@@ -200,7 +200,7 @@ TEST(smp_poll, cross_cpu_immediate_wake_preserves_scheduler_state) {
 // Source on CPU 0 fires concurrently. No crash, no corruption.
 
 static sync::wait_queue g_xrace_wq;
-static volatile uint32_t g_xrace_done;
+static sync::atomic<uint32_t> g_xrace_done;
 
 static void xrace_poll_fn(void*) {
     RUN_ELEVATED({
@@ -212,7 +212,7 @@ static void xrace_poll_fn(void*) {
         sync::poll_wait(pt, 10000000ULL); // 10ms
         sync::poll_cleanup(pt);
     });
-    __atomic_store_n(&g_xrace_done, 1, __ATOMIC_RELEASE);
+    g_xrace_done.store_release(1);
     sched::exit(0);
 }
 
@@ -221,7 +221,7 @@ TEST(smp_poll, cross_cpu_cleanup_race) {
     if (cpus < 2) return;
 
     g_xrace_wq.init();
-    g_xrace_done = 0;
+    g_xrace_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(xrace_poll_fn, nullptr, "smp_pollr");
@@ -237,5 +237,5 @@ TEST(smp_poll, cross_cpu_cleanup_race) {
         brief_delay();
     }
 
-    ASSERT_TRUE(spin_wait(&g_xrace_done));
+    ASSERT_TRUE(spin_wait(g_xrace_done));
 }

--- a/kernel/tests/sync/smp_poll.test.cpp
+++ b/kernel/tests/sync/smp_poll.test.cpp
@@ -151,7 +151,7 @@ static void xfast_poll_fn(void*) {
             if (!triggered) {
                 __atomic_fetch_add(&g_xfast_trigger_failures, 1, __ATOMIC_ACQ_REL);
             }
-            if (self->state != sched::TASK_STATE_RUNNING) {
+            if (self->state.load_relaxed() != sched::TASK_STATE_RUNNING) {
                 __atomic_fetch_add(&g_xfast_state_failures, 1, __ATOMIC_ACQ_REL);
             }
             if (self->sched_link.is_linked()) {

--- a/kernel/tests/sync/smp_wait_queue.test.cpp
+++ b/kernel/tests/sync/smp_wait_queue.test.cpp
@@ -25,20 +25,20 @@ constexpr uint32_t MAX_TEST_CPUS = 16;
 
 static sync::wait_queue g_xwake_wq;
 static sync::spinlock g_xwake_lock;
-static volatile uint32_t g_xwake_go;
-static volatile uint32_t g_xwake_waiting;
-static volatile uint32_t g_xwake_done;
+static sync::atomic<uint32_t> g_xwake_go;
+static sync::atomic<uint32_t> g_xwake_waiting;
+static sync::atomic<uint32_t> g_xwake_done;
 
 static void xwake_waiter_fn(void*) {
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_xwake_lock);
-        __atomic_store_n(&g_xwake_waiting, 1, __ATOMIC_RELEASE);
-        while (!__atomic_load_n(&g_xwake_go, __ATOMIC_ACQUIRE)) {
+        g_xwake_waiting.store_release(1);
+        while (!g_xwake_go.load_acquire()) {
             irq = sync::wait(g_xwake_wq, g_xwake_lock, irq);
         }
         sync::spin_unlock_irqrestore(g_xwake_lock, irq);
     });
-    __atomic_store_n(&g_xwake_done, 1, __ATOMIC_RELEASE);
+    g_xwake_done.store_release(1);
     sched::exit(0);
 }
 
@@ -48,9 +48,9 @@ TEST(smp_wait_queue, cross_cpu_wake_one) {
 
     g_xwake_wq.init();
     g_xwake_lock = sync::SPINLOCK_INIT;
-    g_xwake_go = 0;
-    g_xwake_waiting = 0;
-    g_xwake_done = 0;
+    g_xwake_go.store_relaxed(0);
+    g_xwake_waiting.store_relaxed(0);
+    g_xwake_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(
@@ -59,17 +59,17 @@ TEST(smp_wait_queue, cross_cpu_wake_one) {
         sched::enqueue_on(t, 1);
     });
 
-    ASSERT_TRUE(spin_wait(&g_xwake_waiting));
+    ASSERT_TRUE(spin_wait(g_xwake_waiting));
     brief_delay();
 
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_xwake_lock);
-        __atomic_store_n(&g_xwake_go, 1, __ATOMIC_RELEASE);
+        g_xwake_go.store_release(1);
         sync::spin_unlock_irqrestore(g_xwake_lock, irq);
         sync::wake_one(g_xwake_wq);
     });
 
-    EXPECT_TRUE(spin_wait(&g_xwake_done));
+    EXPECT_TRUE(spin_wait(g_xwake_done));
 }
 
 // --- cross_cpu_wake_all ---
@@ -78,21 +78,21 @@ TEST(smp_wait_queue, cross_cpu_wake_one) {
 
 static sync::wait_queue g_xall_wq;
 static sync::spinlock g_xall_lock;
-static volatile uint32_t g_xall_go;
-static volatile uint32_t g_xall_ready[MAX_TEST_CPUS] = {};
-static volatile uint32_t g_xall_done[MAX_TEST_CPUS] = {};
+static sync::atomic<uint32_t> g_xall_go;
+static sync::atomic<uint32_t> g_xall_ready[MAX_TEST_CPUS] = {};
+static sync::atomic<uint32_t> g_xall_done[MAX_TEST_CPUS] = {};
 
 static void xall_waiter_fn(void* arg) {
     uint32_t idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg));
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_xall_lock);
-        __atomic_store_n(&g_xall_ready[idx], 1, __ATOMIC_RELEASE);
-        while (!__atomic_load_n(&g_xall_go, __ATOMIC_ACQUIRE)) {
+        g_xall_ready[idx].store_release(1);
+        while (!g_xall_go.load_acquire()) {
             irq = sync::wait(g_xall_wq, g_xall_lock, irq);
         }
         sync::spin_unlock_irqrestore(g_xall_lock, irq);
     });
-    __atomic_store_n(&g_xall_done[idx], 1, __ATOMIC_RELEASE);
+    g_xall_done[idx].store_release(1);
     sched::exit(0);
 }
 
@@ -102,12 +102,12 @@ TEST(smp_wait_queue, cross_cpu_wake_all) {
 
     g_xall_wq.init();
     g_xall_lock = sync::SPINLOCK_INIT;
-    g_xall_go = 0;
+    g_xall_go.store_relaxed(0);
 
     uint32_t waiter_count = cpus - 1;
     for (uint32_t i = 0; i < waiter_count; i++) {
-        g_xall_ready[i] = 0;
-        g_xall_done[i] = 0;
+        g_xall_ready[i].store_relaxed(0);
+        g_xall_done[i].store_relaxed(0);
     }
 
     RUN_ELEVATED({
@@ -122,19 +122,19 @@ TEST(smp_wait_queue, cross_cpu_wake_all) {
     });
 
     for (uint32_t i = 0; i < waiter_count; i++) {
-        ASSERT_TRUE(spin_wait(&g_xall_ready[i]));
+        ASSERT_TRUE(spin_wait(g_xall_ready[i]));
     }
     brief_delay();
 
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_xall_lock);
-        __atomic_store_n(&g_xall_go, 1, __ATOMIC_RELEASE);
+        g_xall_go.store_release(1);
         sync::spin_unlock_irqrestore(g_xall_lock, irq);
         sync::wake_all(g_xall_wq);
     });
 
     for (uint32_t i = 0; i < waiter_count; i++) {
-        EXPECT_TRUE(spin_wait(&g_xall_done[i]));
+        EXPECT_TRUE(spin_wait(g_xall_done[i]));
     }
 }
 
@@ -147,36 +147,36 @@ constexpr uint32_t PC_TARGET = 50;
 
 static sync::wait_queue g_xpc_wq;
 static sync::spinlock g_xpc_lock;
-static volatile uint32_t g_xpc_counter;
-static volatile uint32_t g_xpc_consumer_ready;
-static volatile uint32_t g_xpc_producer_done;
-static volatile uint32_t g_xpc_consumer_done;
+static sync::atomic<uint32_t> g_xpc_counter;
+static sync::atomic<uint32_t> g_xpc_consumer_ready;
+static sync::atomic<uint32_t> g_xpc_producer_done;
+static sync::atomic<uint32_t> g_xpc_consumer_done;
 
 static void xpc_consumer_fn(void*) {
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_xpc_lock);
-        __atomic_store_n(&g_xpc_consumer_ready, 1, __ATOMIC_RELEASE);
-        while (__atomic_load_n(&g_xpc_counter, __ATOMIC_RELAXED) < PC_TARGET) {
+        g_xpc_consumer_ready.store_release(1);
+        while (g_xpc_counter.load_relaxed() < PC_TARGET) {
             irq = sync::wait(g_xpc_wq, g_xpc_lock, irq);
         }
         sync::spin_unlock_irqrestore(g_xpc_lock, irq);
     });
-    __atomic_store_n(&g_xpc_consumer_done, 1, __ATOMIC_RELEASE);
+    g_xpc_consumer_done.store_release(1);
     sched::exit(0);
 }
 
 static void xpc_producer_fn(void*) {
-    while (!__atomic_load_n(&g_xpc_consumer_ready, __ATOMIC_ACQUIRE)) {}
+    while (!g_xpc_consumer_ready.load_acquire()) {}
 
     for (uint32_t i = 0; i < PC_TARGET; i++) {
         RUN_ELEVATED({
             sync::irq_state irq = sync::spin_lock_irqsave(g_xpc_lock);
-            __atomic_fetch_add(&g_xpc_counter, 1, __ATOMIC_RELAXED);
+            g_xpc_counter.fetch_add_relaxed(1);
             sync::spin_unlock_irqrestore(g_xpc_lock, irq);
             sync::wake_one(g_xpc_wq);
         });
     }
-    __atomic_store_n(&g_xpc_producer_done, 1, __ATOMIC_RELEASE);
+    g_xpc_producer_done.store_release(1);
     sched::exit(0);
 }
 
@@ -186,10 +186,10 @@ TEST(smp_wait_queue, cross_cpu_producer_consumer) {
 
     g_xpc_wq.init();
     g_xpc_lock = sync::SPINLOCK_INIT;
-    g_xpc_counter = 0;
-    g_xpc_consumer_ready = 0;
-    g_xpc_producer_done = 0;
-    g_xpc_consumer_done = 0;
+    g_xpc_counter.store_relaxed(0);
+    g_xpc_consumer_ready.store_relaxed(0);
+    g_xpc_producer_done.store_relaxed(0);
+    g_xpc_consumer_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* consumer = sched::create_kernel_task(
@@ -202,7 +202,7 @@ TEST(smp_wait_queue, cross_cpu_producer_consumer) {
         sched::enqueue_on(producer, 0);
     });
 
-    EXPECT_TRUE(spin_wait(&g_xpc_producer_done));
-    EXPECT_TRUE(spin_wait(&g_xpc_consumer_done));
-    EXPECT_EQ(__atomic_load_n(&g_xpc_counter, __ATOMIC_ACQUIRE), PC_TARGET);
+    EXPECT_TRUE(spin_wait(g_xpc_producer_done));
+    EXPECT_TRUE(spin_wait(g_xpc_consumer_done));
+    EXPECT_EQ(g_xpc_counter.load_acquire(), PC_TARGET);
 }

--- a/kernel/tests/sync/wait_queue.test.cpp
+++ b/kernel/tests/sync/wait_queue.test.cpp
@@ -20,29 +20,29 @@ TEST_SUITE(wait_queue);
 
 static sync::wait_queue g_basic_wq;
 static sync::spinlock g_basic_lock;
-static volatile uint32_t g_basic_go;
-static volatile uint32_t g_basic_waiting;
-static volatile uint32_t g_basic_done;
+static sync::atomic<uint32_t> g_basic_go;
+static sync::atomic<uint32_t> g_basic_waiting;
+static sync::atomic<uint32_t> g_basic_done;
 
 static void basic_waiter_fn(void*) {
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_basic_lock);
-        __atomic_store_n(&g_basic_waiting, 1, __ATOMIC_RELEASE);
-        while (!__atomic_load_n(&g_basic_go, __ATOMIC_ACQUIRE)) {
+        g_basic_waiting.store_release(1);
+        while (!g_basic_go.load_acquire()) {
             irq = sync::wait(g_basic_wq, g_basic_lock, irq);
         }
         sync::spin_unlock_irqrestore(g_basic_lock, irq);
     });
-    __atomic_store_n(&g_basic_done, 1, __ATOMIC_RELEASE);
+    g_basic_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(wait_queue, basic_wait_wake_one) {
     g_basic_wq.init();
     g_basic_lock = sync::SPINLOCK_INIT;
-    g_basic_go = 0;
-    g_basic_waiting = 0;
-    g_basic_done = 0;
+    g_basic_go.store_relaxed(0);
+    g_basic_waiting.store_relaxed(0);
+    g_basic_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(
@@ -51,16 +51,16 @@ TEST(wait_queue, basic_wait_wake_one) {
         sched::enqueue(t);
     });
 
-    ASSERT_TRUE(spin_wait(&g_basic_waiting));
+    ASSERT_TRUE(spin_wait(g_basic_waiting));
 
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_basic_lock);
-        __atomic_store_n(&g_basic_go, 1, __ATOMIC_RELEASE);
+        g_basic_go.store_release(1);
         sync::spin_unlock_irqrestore(g_basic_lock, irq);
         sync::wake_one(g_basic_wq);
     });
 
-    EXPECT_TRUE(spin_wait(&g_basic_done));
+    EXPECT_TRUE(spin_wait(g_basic_done));
 }
 
 // --- wake_one_empty_queue ---
@@ -98,33 +98,33 @@ constexpr uint32_t MULTI_COUNT = 4;
 
 static sync::wait_queue g_all_wq;
 static sync::spinlock g_all_lock;
-static volatile uint32_t g_all_go;
-static volatile uint32_t g_all_ready[MULTI_COUNT];
-static volatile uint32_t g_all_done[MULTI_COUNT];
+static sync::atomic<uint32_t> g_all_go;
+static sync::atomic<uint32_t> g_all_ready[MULTI_COUNT];
+static sync::atomic<uint32_t> g_all_done[MULTI_COUNT];
 
 static void wake_all_waiter_fn(void* arg) {
     uint32_t idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg));
 
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_all_lock);
-        __atomic_store_n(&g_all_ready[idx], 1, __ATOMIC_RELEASE);
-        while (!__atomic_load_n(&g_all_go, __ATOMIC_ACQUIRE)) {
+        g_all_ready[idx].store_release(1);
+        while (!g_all_go.load_acquire()) {
             irq = sync::wait(g_all_wq, g_all_lock, irq);
         }
         sync::spin_unlock_irqrestore(g_all_lock, irq);
     });
 
-    __atomic_store_n(&g_all_done[idx], 1, __ATOMIC_RELEASE);
+    g_all_done[idx].store_release(1);
     sched::exit(0);
 }
 
 TEST(wait_queue, wake_all_wakes_everyone) {
     g_all_wq.init();
     g_all_lock = sync::SPINLOCK_INIT;
-    g_all_go = 0;
+    g_all_go.store_relaxed(0);
     for (uint32_t i = 0; i < MULTI_COUNT; i++) {
-        g_all_ready[i] = 0;
-        g_all_done[i] = 0;
+        g_all_ready[i].store_relaxed(0);
+        g_all_done[i].store_relaxed(0);
     }
 
     RUN_ELEVATED({
@@ -139,18 +139,18 @@ TEST(wait_queue, wake_all_wakes_everyone) {
     });
 
     for (uint32_t i = 0; i < MULTI_COUNT; i++) {
-        ASSERT_TRUE(spin_wait(&g_all_ready[i]));
+        ASSERT_TRUE(spin_wait(g_all_ready[i]));
     }
 
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_all_lock);
-        __atomic_store_n(&g_all_go, 1, __ATOMIC_RELEASE);
+        g_all_go.store_release(1);
         sync::spin_unlock_irqrestore(g_all_lock, irq);
         sync::wake_all(g_all_wq);
     });
 
     for (uint32_t i = 0; i < MULTI_COUNT; i++) {
-        EXPECT_TRUE(spin_wait(&g_all_done[i]));
+        EXPECT_TRUE(spin_wait(g_all_done[i]));
     }
 }
 
@@ -163,41 +163,41 @@ constexpr uint32_t PC_TARGET = 50;
 
 static sync::wait_queue g_pc_wq;
 static sync::spinlock g_pc_lock;
-static volatile uint32_t g_pc_counter;
-static volatile uint32_t g_pc_producer_done;
-static volatile uint32_t g_pc_consumer_done;
+static sync::atomic<uint32_t> g_pc_counter;
+static sync::atomic<uint32_t> g_pc_producer_done;
+static sync::atomic<uint32_t> g_pc_consumer_done;
 
 static void pc_producer_fn(void*) {
     for (uint32_t i = 0; i < PC_TARGET; i++) {
         RUN_ELEVATED({
             sync::irq_state irq = sync::spin_lock_irqsave(g_pc_lock);
-            __atomic_fetch_add(&g_pc_counter, 1, __ATOMIC_RELAXED);
+            g_pc_counter.fetch_add_relaxed(1);
             sync::spin_unlock_irqrestore(g_pc_lock, irq);
             sync::wake_one(g_pc_wq);
         });
     }
-    __atomic_store_n(&g_pc_producer_done, 1, __ATOMIC_RELEASE);
+    g_pc_producer_done.store_release(1);
     sched::exit(0);
 }
 
 static void pc_consumer_fn(void*) {
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_pc_lock);
-        while (__atomic_load_n(&g_pc_counter, __ATOMIC_RELAXED) < PC_TARGET) {
+        while (g_pc_counter.load_relaxed() < PC_TARGET) {
             irq = sync::wait(g_pc_wq, g_pc_lock, irq);
         }
         sync::spin_unlock_irqrestore(g_pc_lock, irq);
     });
-    __atomic_store_n(&g_pc_consumer_done, 1, __ATOMIC_RELEASE);
+    g_pc_consumer_done.store_release(1);
     sched::exit(0);
 }
 
 TEST(wait_queue, producer_consumer) {
     g_pc_wq.init();
     g_pc_lock = sync::SPINLOCK_INIT;
-    g_pc_counter = 0;
-    g_pc_producer_done = 0;
-    g_pc_consumer_done = 0;
+    g_pc_counter.store_relaxed(0);
+    g_pc_producer_done.store_relaxed(0);
+    g_pc_consumer_done.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* consumer = sched::create_kernel_task(
@@ -210,9 +210,9 @@ TEST(wait_queue, producer_consumer) {
         sched::enqueue(producer);
     });
 
-    EXPECT_TRUE(spin_wait(&g_pc_producer_done));
-    EXPECT_TRUE(spin_wait(&g_pc_consumer_done));
-    EXPECT_EQ(__atomic_load_n(&g_pc_counter, __ATOMIC_ACQUIRE), PC_TARGET);
+    EXPECT_TRUE(spin_wait(g_pc_producer_done));
+    EXPECT_TRUE(spin_wait(g_pc_consumer_done));
+    EXPECT_EQ(g_pc_counter.load_acquire(), PC_TARGET);
 }
 
 // --- repeated_wait_wake ---
@@ -223,21 +223,21 @@ constexpr uint32_t REPEAT_COUNT = 10;
 
 static sync::wait_queue g_repeat_wq;
 static sync::spinlock g_repeat_lock;
-static volatile uint32_t g_repeat_counter;
-static volatile uint32_t g_repeat_progress;
-static volatile uint32_t g_repeat_iter_waiting;
+static sync::atomic<uint32_t> g_repeat_counter;
+static sync::atomic<uint32_t> g_repeat_progress;
+static sync::atomic<uint32_t> g_repeat_iter_waiting;
 
 static void repeat_waiter_fn(void*) {
     for (uint32_t iter = 0; iter < REPEAT_COUNT; iter++) {
         RUN_ELEVATED({
             sync::irq_state irq = sync::spin_lock_irqsave(g_repeat_lock);
-            __atomic_store_n(&g_repeat_iter_waiting, iter + 1, __ATOMIC_RELEASE);
-            while (__atomic_load_n(&g_repeat_counter, __ATOMIC_ACQUIRE) <= iter) {
+            g_repeat_iter_waiting.store_release(iter + 1);
+            while (g_repeat_counter.load_acquire() <= iter) {
                 irq = sync::wait(g_repeat_wq, g_repeat_lock, irq);
             }
             sync::spin_unlock_irqrestore(g_repeat_lock, irq);
         });
-        __atomic_store_n(&g_repeat_progress, iter + 1, __ATOMIC_RELEASE);
+        g_repeat_progress.store_release(iter + 1);
     }
     sched::exit(0);
 }
@@ -245,9 +245,9 @@ static void repeat_waiter_fn(void*) {
 TEST(wait_queue, repeated_wait_wake) {
     g_repeat_wq.init();
     g_repeat_lock = sync::SPINLOCK_INIT;
-    g_repeat_counter = 0;
-    g_repeat_progress = 0;
-    g_repeat_iter_waiting = 0;
+    g_repeat_counter.store_relaxed(0);
+    g_repeat_progress.store_relaxed(0);
+    g_repeat_iter_waiting.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t = sched::create_kernel_task(
@@ -257,19 +257,19 @@ TEST(wait_queue, repeated_wait_wake) {
     });
 
     for (uint32_t iter = 0; iter < REPEAT_COUNT; iter++) {
-        ASSERT_TRUE(spin_wait_ge(&g_repeat_iter_waiting, iter + 1));
+        ASSERT_TRUE(spin_wait_ge(g_repeat_iter_waiting, iter + 1));
 
         RUN_ELEVATED({
             sync::irq_state irq = sync::spin_lock_irqsave(g_repeat_lock);
-            __atomic_fetch_add(&g_repeat_counter, 1, __ATOMIC_RELAXED);
+            g_repeat_counter.fetch_add_relaxed(1);
             sync::spin_unlock_irqrestore(g_repeat_lock, irq);
             sync::wake_one(g_repeat_wq);
         });
 
-        ASSERT_TRUE(spin_wait_ge(&g_repeat_progress, iter + 1));
+        ASSERT_TRUE(spin_wait_ge(g_repeat_progress, iter + 1));
     }
 
-    EXPECT_EQ(__atomic_load_n(&g_repeat_progress, __ATOMIC_ACQUIRE), REPEAT_COUNT);
+    EXPECT_EQ(g_repeat_progress.load_acquire(), REPEAT_COUNT);
 }
 
 // --- wake_one_only_wakes_one ---
@@ -280,29 +280,29 @@ constexpr uint32_t WAKE_ONE_TASKS = 3;
 
 static sync::wait_queue g_wone_wq;
 static sync::spinlock g_wone_lock;
-static volatile uint32_t g_wone_go;
-static volatile uint32_t g_wone_ready_count;
-static volatile uint32_t g_wone_done_count;
+static sync::atomic<uint32_t> g_wone_go;
+static sync::atomic<uint32_t> g_wone_ready_count;
+static sync::atomic<uint32_t> g_wone_done_count;
 
 static void wake_one_worker_fn(void*) {
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_wone_lock);
-        __atomic_fetch_add(&g_wone_ready_count, 1, __ATOMIC_ACQ_REL);
-        while (!__atomic_load_n(&g_wone_go, __ATOMIC_ACQUIRE)) {
+        g_wone_ready_count.fetch_add_acq_rel(1);
+        while (!g_wone_go.load_acquire()) {
             irq = sync::wait(g_wone_wq, g_wone_lock, irq);
         }
         sync::spin_unlock_irqrestore(g_wone_lock, irq);
     });
-    __atomic_fetch_add(&g_wone_done_count, 1, __ATOMIC_ACQ_REL);
+    g_wone_done_count.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(wait_queue, wake_one_only_wakes_one) {
     g_wone_wq.init();
     g_wone_lock = sync::SPINLOCK_INIT;
-    g_wone_go = 0;
-    g_wone_ready_count = 0;
-    g_wone_done_count = 0;
+    g_wone_go.store_relaxed(0);
+    g_wone_ready_count.store_relaxed(0);
+    g_wone_done_count.store_relaxed(0);
 
     RUN_ELEVATED({
         for (uint32_t i = 0; i < WAKE_ONE_TASKS; i++) {
@@ -313,11 +313,11 @@ TEST(wait_queue, wake_one_only_wakes_one) {
         }
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_wone_ready_count, WAKE_ONE_TASKS));
+    ASSERT_TRUE(spin_wait_ge(g_wone_ready_count, WAKE_ONE_TASKS));
 
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_wone_lock);
-        __atomic_store_n(&g_wone_go, 1, __ATOMIC_RELEASE);
+        g_wone_go.store_release(1);
         sync::spin_unlock_irqrestore(g_wone_lock, irq);
     });
 
@@ -325,9 +325,9 @@ TEST(wait_queue, wake_one_only_wakes_one) {
         RUN_ELEVATED({
             sync::wake_one(g_wone_wq);
         });
-        ASSERT_TRUE(spin_wait_ge(&g_wone_done_count, i + 1));
+        ASSERT_TRUE(spin_wait_ge(g_wone_done_count, i + 1));
         brief_delay();
-        EXPECT_EQ(__atomic_load_n(&g_wone_done_count, __ATOMIC_ACQUIRE), i + 1);
+        EXPECT_EQ(g_wone_done_count.load_acquire(), i + 1);
     }
 }
 
@@ -339,34 +339,34 @@ TEST(wait_queue, wake_one_only_wakes_one) {
 
 static sync::wait_queue g_recheck_wq;
 static sync::spinlock g_recheck_lock;
-static volatile uint32_t g_recheck_go[2];
-static volatile uint32_t g_recheck_ready[2];
-static volatile uint32_t g_recheck_done_count;
+static sync::atomic<uint32_t> g_recheck_go[2];
+static sync::atomic<uint32_t> g_recheck_ready[2];
+static sync::atomic<uint32_t> g_recheck_done_count;
 
 static void recheck_waiter_fn(void* arg) {
     uint32_t idx = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(arg));
 
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_recheck_lock);
-        __atomic_store_n(&g_recheck_ready[idx], 1, __ATOMIC_RELEASE);
-        while (!__atomic_load_n(&g_recheck_go[idx], __ATOMIC_ACQUIRE)) {
+        g_recheck_ready[idx].store_release(1);
+        while (!g_recheck_go[idx].load_acquire()) {
             irq = sync::wait(g_recheck_wq, g_recheck_lock, irq);
         }
         sync::spin_unlock_irqrestore(g_recheck_lock, irq);
     });
 
-    __atomic_fetch_add(&g_recheck_done_count, 1, __ATOMIC_ACQ_REL);
+    g_recheck_done_count.fetch_add_acq_rel(1);
     sched::exit(0);
 }
 
 TEST(wait_queue, wake_with_condition_recheck) {
     g_recheck_wq.init();
     g_recheck_lock = sync::SPINLOCK_INIT;
-    g_recheck_go[0] = 0;
-    g_recheck_go[1] = 0;
-    g_recheck_ready[0] = 0;
-    g_recheck_ready[1] = 0;
-    g_recheck_done_count = 0;
+    g_recheck_go[0].store_relaxed(0);
+    g_recheck_go[1].store_relaxed(0);
+    g_recheck_ready[0].store_relaxed(0);
+    g_recheck_ready[1].store_relaxed(0);
+    g_recheck_done_count.store_relaxed(0);
 
     RUN_ELEVATED({
         sched::task* t0 = sched::create_kernel_task(
@@ -383,27 +383,27 @@ TEST(wait_queue, wake_with_condition_recheck) {
         sched::enqueue(t1);
     });
 
-    ASSERT_TRUE(spin_wait(&g_recheck_ready[0]));
-    ASSERT_TRUE(spin_wait(&g_recheck_ready[1]));
+    ASSERT_TRUE(spin_wait(g_recheck_ready[0]));
+    ASSERT_TRUE(spin_wait(g_recheck_ready[1]));
 
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_recheck_lock);
-        __atomic_store_n(&g_recheck_go[0], 1, __ATOMIC_RELEASE);
+        g_recheck_go[0].store_release(1);
         sync::spin_unlock_irqrestore(g_recheck_lock, irq);
         sync::wake_all(g_recheck_wq);
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_recheck_done_count, 1));
+    ASSERT_TRUE(spin_wait_ge(g_recheck_done_count, 1));
     brief_delay();
-    EXPECT_EQ(__atomic_load_n(&g_recheck_done_count, __ATOMIC_ACQUIRE), 1u);
+    EXPECT_EQ(g_recheck_done_count.load_acquire(), 1u);
 
     RUN_ELEVATED({
         sync::irq_state irq = sync::spin_lock_irqsave(g_recheck_lock);
-        __atomic_store_n(&g_recheck_go[1], 1, __ATOMIC_RELEASE);
+        g_recheck_go[1].store_release(1);
         sync::spin_unlock_irqrestore(g_recheck_lock, irq);
         sync::wake_all(g_recheck_wq);
     });
 
-    ASSERT_TRUE(spin_wait_ge(&g_recheck_done_count, 2));
-    EXPECT_EQ(__atomic_load_n(&g_recheck_done_count, __ATOMIC_ACQUIRE), 2u);
+    ASSERT_TRUE(spin_wait_ge(g_recheck_done_count, 2));
+    EXPECT_EQ(g_recheck_done_count.load_acquire(), 2u);
 }

--- a/kernel/trace/ktrace.cpp
+++ b/kernel/trace/ktrace.cpp
@@ -1,5 +1,6 @@
 #include "trace/ktrace.h"
 #include "common/logging.h"
+#include "sync/atomic.h"
 #include "mm/kva.h"
 #include "mm/paging_types.h"
 #include "mm/pmm_types.h"
@@ -54,7 +55,7 @@ void record_event(const trace_record& rec) {
     }
 
     // Atomically reserve a slot in the ring buffer 
-    uint64_t slot = __atomic_fetch_add(&head_idx, 1, __ATOMIC_RELAXED);
+    uint64_t slot = sync::atomic_ref<uint64_t>{head_idx}.fetch_add_relaxed(1);
 
     // Insert the event record
     buffer[slot % PERCPU_RECORD_BUFFER_RECORDS] = rec;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mechanical but very broad changes in scheduler, signal delivery, and SMP boot synchronization; any mismatched memory order or non-atomic access on a formerly shared field could cause rare races or AP boot hangs.
> 
> **Overview**
> Replaces widespread `__atomic_*` and `volatile` flag usage with **`sync::atomic<T>`** and **`sync::atomic_ref`** across the kernel (scheduling, signals, SMP, timers, IRQ/MSI dispatch, networking, PTY, reaper, sync primitives, and tests).
> 
> **Type-level changes:** hot shared fields are now atomics in structs—e.g. `sched::task` **`state`**, **`cleanup_stage`**, **`run_ticks`**; signal **`blocked`/`pending`** and group **`shared_pending`/`exit_signal`**; **`smp::cpu_info::state`**; poll/mutex **`owner`**, **`triggered`**, **`error`**; PTY/console foreground group; MSI handler slots; DHCP RX **`ready`/`active`**.
> 
> **Access pattern:** standalone counters and flags use `sync::atomic` methods (`load_acquire`, `store_release`, `fetch_add_relaxed`, `cmpxchg_strong_acq_rel`, etc.). Fields that stay plain scalars for layout/assembly (e.g. **`task_exec_core::on_cpu`**, **`exec.cpu`**, per-CPU epochs) are updated via **`sync::atomic_ref<uint32_t>`** / **`uint64_t`**.
> 
> **Fences:** IRQ registration and similar handoffs use **`sync::atomic_fence_release`/`acquire`**; kill/block and signal wake paths use a new **`sync::atomic_fence_seq_cst`**. A few failed-CMpxchg paths add an explicit acquire fence when adopting another thread’s winning value (e.g. group exit signal / **`exit_group`** status).
> 
> Test helpers and kernel tests switch from `volatile` + builtins to the same typed atomics for handshakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b9fb80983bacd4bd32066d273780b16ed7360c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->