### PR TITLE
feat(power): introduced a power subsystem with shutdown and reboot support

### DIFF
--- a/kernel/acpi/acpi.cpp
+++ b/kernel/acpi/acpi.cpp
@@ -56,6 +56,27 @@ __PRIVILEGED_CODE static uint64_t read_u64(const void* ptr) {
 }
 
 /**
+ * Map an SDT at the given physical address, extending the mapping when
+ * the table is longer than one page. Returns nullptr unless the whole
+ * table ended up mapped.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static const sdt_header* map_sdt(uint64_t phys) {
+    auto* hdr = static_cast<const sdt_header*>(
+        map_acpi_region(phys, pmm::PAGE_SIZE));
+    if (!hdr) {
+        return nullptr;
+    }
+
+    uint32_t length = read_u32(&hdr->length);
+    if (length > pmm::PAGE_SIZE) {
+        hdr = static_cast<const sdt_header*>(map_acpi_region(phys, length));
+    }
+
+    return hdr;
+}
+
+/**
  * Get the physical address of the Nth XSDT/RSDT entry.
  * @note Privilege: **required**
  */
@@ -188,6 +209,32 @@ __PRIVILEGED_CODE int32_t init() {
 /**
  * @note Privilege: **required**
  */
+__PRIVILEGED_CODE const sdt_header* map_table(uint64_t phys) {
+    if (phys == 0) {
+        return nullptr;
+    }
+
+    const sdt_header* hdr = map_sdt(phys);
+    if (!hdr) {
+        return nullptr;
+    }
+
+    uint32_t length = read_u32(&hdr->length);
+    if (length < sizeof(sdt_header)) {
+        return nullptr;
+    }
+
+    if (!validate_checksum(hdr, length)) {
+        log::error("acpi: table '%.4s' checksum failed", hdr->signature);
+        return nullptr;
+    }
+
+    return hdr;
+}
+
+/**
+ * @note Privilege: **required**
+ */
 __PRIVILEGED_CODE const sdt_header* find_table(const char signature[4]) {
     for (size_t i = 0; i < g_entry_count; i++) {
         const sdt_header* hdr = g_table_cache[i];
@@ -196,21 +243,8 @@ __PRIVILEGED_CODE const sdt_header* find_table(const char signature[4]) {
             uint64_t phys = get_entry_phys(i);
             if (phys == 0) continue;
 
-            // Map 1 page to read the header
-            hdr = static_cast<const sdt_header*>(
-                map_acpi_region(phys, pmm::PAGE_SIZE));
+            hdr = map_sdt(phys);
             if (!hdr) continue;
-
-            uint32_t length = read_u32(&hdr->length);
-
-            // If table exceeds 1 page, create a full mapping
-            if (length > pmm::PAGE_SIZE) {
-                auto* full = static_cast<const sdt_header*>(
-                    map_acpi_region(phys, length));
-                if (full) {
-                    hdr = full;
-                }
-            }
 
             g_table_cache[i] = hdr;
         }

--- a/kernel/acpi/acpi.cpp
+++ b/kernel/acpi/acpi.cpp
@@ -229,4 +229,20 @@ __PRIVILEGED_CODE const sdt_header* find_table(const char signature[4]) {
     return nullptr;
 }
 
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE const fadt* get_fadt() {
+    const sdt_header* hdr = find_table("FACP");
+    if (!hdr) {
+        return nullptr;
+    }
+
+    if (read_u32(&hdr->length) < FADT_REV1_LENGTH) {
+        return nullptr;
+    }
+
+    return reinterpret_cast<const fadt*>(hdr);
+}
+
 } // namespace acpi

--- a/kernel/acpi/acpi.h
+++ b/kernel/acpi/acpi.h
@@ -30,6 +30,15 @@ __PRIVILEGED_CODE int32_t init();
  */
 __PRIVILEGED_CODE const sdt_header* find_table(const char signature[4]);
 
+/**
+ * @brief Typed view of the FADT ("FACP") table.
+ * Fields past the ACPI 1.0 fixed block exist only when header.length
+ * covers them, which callers gate with FADT_HAS_FIELD.
+ * @return Pointer to the FADT, or nullptr if missing or truncated.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE const fadt* get_fadt();
+
 } // namespace acpi
 
 #endif // STELLUX_ACPI_ACPI_H

--- a/kernel/acpi/acpi.h
+++ b/kernel/acpi/acpi.h
@@ -21,6 +21,15 @@ constexpr int32_t ERR_MAP_FAILED   = -4;
 __PRIVILEGED_CODE int32_t init();
 
 /**
+ * @brief Map an ACPI table by physical address and validate its checksum.
+ * For tables referenced by pointer instead of an XSDT/RSDT entry, such
+ * as the DSDT. The mapping is permanent (never unmapped).
+ * @return Pointer to the table header, or nullptr on failure.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE const sdt_header* map_table(uint64_t phys);
+
+/**
  * @brief Find an ACPI table by its 4-byte signature.
  * Maps the table on demand via vmm::map_phys() and caches the result.
  * Returned pointer is permanently valid (never unmapped).

--- a/kernel/acpi/tables.h
+++ b/kernel/acpi/tables.h
@@ -67,6 +67,104 @@ constexpr uint8_t MADT_TYPE_GICD                 = 0x0C;
 constexpr uint8_t MADT_TYPE_GIC_MSI_FRAME        = 0x0D;
 constexpr uint8_t MADT_TYPE_GICR                 = 0x0E;
 
+// Generic address structure address space IDs
+constexpr uint8_t GAS_SPACE_SYSTEM_MEMORY = 0;
+constexpr uint8_t GAS_SPACE_SYSTEM_IO     = 1;
+constexpr uint8_t GAS_SPACE_PCI_CONFIG    = 2;
+
+struct __attribute__((packed)) generic_address {
+    uint8_t  space;       // Address space ID (GAS_SPACE_*)
+    uint8_t  bit_width;
+    uint8_t  bit_offset;
+    uint8_t  access_size;
+    uint64_t address;
+};
+
+static_assert(sizeof(generic_address) == 12, "GAS must be 12 bytes");
+
+// The ACPI 1.0 fixed block ends after the flags field. Later revisions
+// appended fields, so anything past this offset needs a length check.
+constexpr uint32_t FADT_REV1_LENGTH = 116;
+
+// FADT fixed feature flags
+constexpr uint32_t FADT_FLAG_RESET_REG_SUP = (1 << 10);
+
+// FADT arm_boot_arch flags (ACPI 5.1+)
+constexpr uint16_t FADT_ARM_PSCI_COMPLIANT = (1 << 0);
+constexpr uint16_t FADT_ARM_PSCI_USE_HVC   = (1 << 1);
+
+struct __attribute__((packed)) fadt {
+    sdt_header header;               // signature = "FACP"
+    uint32_t   firmware_ctrl;
+    uint32_t   dsdt;
+    uint8_t    reserved0;
+    uint8_t    preferred_pm_profile;
+    uint16_t   sci_int;
+    uint32_t   smi_cmd;
+    uint8_t    acpi_enable;
+    uint8_t    acpi_disable;
+    uint8_t    s4bios_req;
+    uint8_t    pstate_cnt;
+    uint32_t   pm1a_evt_blk;
+    uint32_t   pm1b_evt_blk;
+    uint32_t   pm1a_cnt_blk;
+    uint32_t   pm1b_cnt_blk;
+    uint32_t   pm2_cnt_blk;
+    uint32_t   pm_tmr_blk;
+    uint32_t   gpe0_blk;
+    uint32_t   gpe1_blk;
+    uint8_t    pm1_evt_len;
+    uint8_t    pm1_cnt_len;
+    uint8_t    pm2_cnt_len;
+    uint8_t    pm_tmr_len;
+    uint8_t    gpe0_blk_len;
+    uint8_t    gpe1_blk_len;
+    uint8_t    gpe1_base;
+    uint8_t    cst_cnt;
+    uint16_t   p_lvl2_lat;
+    uint16_t   p_lvl3_lat;
+    uint16_t   flush_size;
+    uint16_t   flush_stride;
+    uint8_t    duty_offset;
+    uint8_t    duty_width;
+    uint8_t    day_alrm;
+    uint8_t    mon_alrm;
+    uint8_t    century;              // CMOS century register index, 0 if absent
+    uint16_t   iapc_boot_arch;
+    uint8_t    reserved1;
+    uint32_t   flags;
+    generic_address reset_reg;
+    uint8_t    reset_value;
+    uint16_t   arm_boot_arch;        // FADT_ARM_* flags (ACPI 5.1+)
+    uint8_t    fadt_minor_version;
+    uint64_t   x_firmware_ctrl;
+    uint64_t   x_dsdt;
+    generic_address x_pm1a_evt_blk;
+    generic_address x_pm1b_evt_blk;
+    generic_address x_pm1a_cnt_blk;
+    generic_address x_pm1b_cnt_blk;
+    generic_address x_pm2_cnt_blk;
+    generic_address x_pm_tmr_blk;
+    generic_address x_gpe0_blk;
+    generic_address x_gpe1_blk;
+    generic_address sleep_control_reg;
+    generic_address sleep_status_reg;
+    uint64_t   hypervisor_id;
+};
+
+static_assert(sizeof(fadt) == 276, "FADT must be 276 bytes");
+static_assert(__builtin_offsetof(fadt, century) == 108);
+static_assert(__builtin_offsetof(fadt, flags) == 112);
+static_assert(__builtin_offsetof(fadt, reset_reg) == FADT_REV1_LENGTH);
+static_assert(__builtin_offsetof(fadt, arm_boot_arch) == 129);
+static_assert(__builtin_offsetof(fadt, x_dsdt) == 140);
+
+// Check that a FADT is long enough to contain a given field, since
+// firmware ships whatever revision of the table it was built against.
+#define FADT_HAS_FIELD(f, field) \
+    ((f)->header.length >= \
+     __builtin_offsetof(acpi::fadt, field) + sizeof((f)->field))
+
 /**
  * Validate ACPI checksum: sum of all bytes must be 0 (mod 256).
  */

--- a/kernel/arch/aarch64/hw/psci.cpp
+++ b/kernel/arch/aarch64/hw/psci.cpp
@@ -1,0 +1,31 @@
+#include "hw/psci.h"
+#include "acpi/acpi.h"
+
+namespace psci {
+
+constexpr uint64_t ID_AA64PFR0_EL3_SHIFT = 12;
+
+static inline uint64_t read_id_aa64pfr0_el1() {
+    uint64_t val;
+    asm volatile("mrs %0, id_aa64pfr0_el1" : "=r"(val));
+    return val;
+}
+
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE conduit detect_conduit() {
+    const acpi::fadt* fadt = acpi::get_fadt();
+    if (fadt && FADT_HAS_FIELD(fadt, arm_boot_arch)) {
+        if (fadt->arm_boot_arch & acpi::FADT_ARM_PSCI_COMPLIANT) {
+            return (fadt->arm_boot_arch & acpi::FADT_ARM_PSCI_USE_HVC)
+                ? conduit::HVC
+                : conduit::SMC;
+        }
+    }
+
+    bool has_el3 = ((read_id_aa64pfr0_el1() >> ID_AA64PFR0_EL3_SHIFT) & 0xF) != 0;
+    return has_el3 ? conduit::SMC : conduit::HVC;
+}
+
+} // namespace psci

--- a/kernel/arch/aarch64/hw/psci.h
+++ b/kernel/arch/aarch64/hw/psci.h
@@ -6,8 +6,10 @@
 namespace psci {
 
 // PSCI function IDs (SMC64 calling convention)
-constexpr uint32_t PSCI_VERSION   = 0x84000000;
-constexpr uint64_t PSCI_CPU_ON_64 = 0xC4000003;
+constexpr uint32_t PSCI_VERSION      = 0x84000000;
+constexpr uint64_t PSCI_CPU_ON_64    = 0xC4000003;
+constexpr uint32_t PSCI_SYSTEM_OFF   = 0x84000008;
+constexpr uint32_t PSCI_SYSTEM_RESET = 0x84000009;
 
 // PSCI return codes
 constexpr int32_t SUCCESS          = 0;
@@ -92,6 +94,33 @@ __PRIVILEGED_CODE inline int32_t cpu_on(conduit c, uint64_t target_mpidr,
                                          uint64_t context_id) {
     return call(c, PSCI_CPU_ON_64, target_mpidr, entry_point, context_id);
 }
+
+/**
+ * Power off the whole machine via PSCI SYSTEM_OFF.
+ * Does not return on success.
+ * @return PSCI result code, only ever seen on failure.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE inline int32_t system_off(conduit c) {
+    return call(c, PSCI_SYSTEM_OFF, 0, 0, 0);
+}
+
+/**
+ * Reset the whole machine via PSCI SYSTEM_RESET.
+ * Does not return on success.
+ * @return PSCI result code, only ever seen on failure.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE inline int32_t system_reset(conduit c) {
+    return call(c, PSCI_SYSTEM_RESET, 0, 0, 0);
+}
+
+/**
+ * Determine the PSCI conduit from FADT arm_boot_arch flags.
+ * Falls back to ID_AA64PFR0_EL1 EL3 detection if FADT is unavailable.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE conduit detect_conduit();
 
 } // namespace psci
 

--- a/kernel/arch/aarch64/power/power.cpp
+++ b/kernel/arch/aarch64/power/power.cpp
@@ -1,0 +1,36 @@
+#include "power/power.h"
+#include "hw/psci.h"
+#include "hw/cpu.h"
+#include "common/logging.h"
+
+namespace power {
+
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE int32_t shutdown() {
+    psci::conduit c = psci::detect_conduit();
+
+    // Firmware tears down the whole machine, secondary CPUs included,
+    // so no CPU coordination is needed before the call.
+    cpu::irq_disable();
+    int32_t rc = psci::system_off(c);
+
+    log::warn("power: PSCI SYSTEM_OFF failed (rc=%d)", rc);
+    return ERR_UNSUPPORTED;
+}
+
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE int32_t reboot() {
+    psci::conduit c = psci::detect_conduit();
+
+    cpu::irq_disable();
+    int32_t rc = psci::system_reset(c);
+
+    log::warn("power: PSCI SYSTEM_RESET failed (rc=%d)", rc);
+    return ERR_UNSUPPORTED;
+}
+
+} // namespace power

--- a/kernel/arch/aarch64/smp/smp.cpp
+++ b/kernel/arch/aarch64/smp/smp.cpp
@@ -37,8 +37,6 @@ constexpr uint32_t AP_BOOT_TIMEOUT_MS = 200;
 constexpr uint32_t PERCPU_PAGES = 2;
 constexpr size_t CACHE_LINE_SIZE = 64;
 
-constexpr uint64_t ID_AA64PFR0_EL3_SHIFT = 12;
-
 // Startup data shared between BSP and AP (matches trampoline offsets at entry + 0x100)
 struct ap_startup_data {
     uint64_t mair_el1;     // +0x00
@@ -61,12 +59,6 @@ static psci::conduit g_psci_conduit = psci::conduit::HVC;
 static inline uint64_t read_mpidr_el1() {
     uint64_t val;
     asm volatile("mrs %0, mpidr_el1" : "=r"(val));
-    return val;
-}
-
-static inline uint64_t read_id_aa64pfr0_el1() {
-    uint64_t val;
-    asm volatile("mrs %0, id_aa64pfr0_el1" : "=r"(val));
     return val;
 }
 
@@ -249,29 +241,10 @@ __PRIVILEGED_CODE uint32_t smp_enumerate(smp::cpu_info* cpus, uint32_t max) {
 }
 
 /**
- * Determine the PSCI conduit from FADT arm_boot_arch flags.
- * Falls back to ID_AA64PFR0_EL1 EL3 detection if FADT is unavailable.
- * @note Privilege: **required**
- */
-__PRIVILEGED_CODE static psci::conduit detect_psci_conduit() {
-    const acpi::fadt* fadt = acpi::get_fadt();
-    if (fadt && FADT_HAS_FIELD(fadt, arm_boot_arch)) {
-        if (fadt->arm_boot_arch & acpi::FADT_ARM_PSCI_COMPLIANT) {
-            return (fadt->arm_boot_arch & acpi::FADT_ARM_PSCI_USE_HVC)
-                ? psci::conduit::HVC
-                : psci::conduit::SMC;
-        }
-    }
-
-    bool has_el3 = ((read_id_aa64pfr0_el1() >> ID_AA64PFR0_EL3_SHIFT) & 0xF) != 0;
-    return has_el3 ? psci::conduit::SMC : psci::conduit::HVC;
-}
-
-/**
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE int32_t smp_prepare() {
-    g_psci_conduit = detect_psci_conduit();
+    g_psci_conduit = psci::detect_conduit();
     log::info("smp: PSCI conduit: %s",
               g_psci_conduit == psci::conduit::HVC ? "HVC" : "SMC");
 

--- a/kernel/arch/aarch64/smp/smp.cpp
+++ b/kernel/arch/aarch64/smp/smp.cpp
@@ -37,10 +37,6 @@ constexpr uint32_t AP_BOOT_TIMEOUT_MS = 200;
 constexpr uint32_t PERCPU_PAGES = 2;
 constexpr size_t CACHE_LINE_SIZE = 64;
 
-// ACPI FADT arm_boot_flags (offset 129, ACPI 5.1+)
-constexpr size_t FADT_ARM_BOOT_FLAGS_OFFSET = 129;
-constexpr uint16_t FADT_PSCI_COMPLIANT = (1 << 0);
-constexpr uint16_t FADT_PSCI_USE_HVC   = (1 << 1);
 constexpr uint64_t ID_AA64PFR0_EL3_SHIFT = 12;
 
 // Startup data shared between BSP and AP (matches trampoline offsets at entry + 0x100)
@@ -253,25 +249,17 @@ __PRIVILEGED_CODE uint32_t smp_enumerate(smp::cpu_info* cpus, uint32_t max) {
 }
 
 /**
- * Determine the PSCI conduit from ACPI FADT arm_boot_flags.
+ * Determine the PSCI conduit from FADT arm_boot_arch flags.
  * Falls back to ID_AA64PFR0_EL1 EL3 detection if FADT is unavailable.
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE static psci::conduit detect_psci_conduit() {
-    const auto* fadt = acpi::find_table("FACP");
-    if (fadt) {
-        uint32_t length;
-        string::memcpy(&length, &fadt->length, sizeof(length));
-        if (length >= FADT_ARM_BOOT_FLAGS_OFFSET + sizeof(uint16_t)) {
-            auto* base = reinterpret_cast<const uint8_t*>(fadt);
-            uint16_t flags;
-            string::memcpy(&flags, base + FADT_ARM_BOOT_FLAGS_OFFSET,
-                           sizeof(flags));
-            if (flags & FADT_PSCI_COMPLIANT) {
-                return (flags & FADT_PSCI_USE_HVC)
-                    ? psci::conduit::HVC
-                    : psci::conduit::SMC;
-            }
+    const acpi::fadt* fadt = acpi::get_fadt();
+    if (fadt && FADT_HAS_FIELD(fadt, arm_boot_arch)) {
+        if (fadt->arm_boot_arch & acpi::FADT_ARM_PSCI_COMPLIANT) {
+            return (fadt->arm_boot_arch & acpi::FADT_ARM_PSCI_USE_HVC)
+                ? psci::conduit::HVC
+                : psci::conduit::SMC;
         }
     }
 

--- a/kernel/arch/x86_64/hw/rtc.cpp
+++ b/kernel/arch/x86_64/hw/rtc.cpp
@@ -3,7 +3,6 @@
 #include "common/time_util.h"
 #include "common/logging.h"
 #include "acpi/acpi.h"
-#include "common/string.h"
 
 namespace rtc {
 
@@ -28,8 +27,6 @@ constexpr uint8_t STATUS_A_UIP     = 0x80;
 constexpr uint8_t STATUS_B_24HR    = 0x02;
 constexpr uint8_t STATUS_B_BINARY  = 0x04;
 
-constexpr size_t FADT_CENTURY_OFFSET = 108;
-
 /** @note Privilege: **required** */
 __PRIVILEGED_CODE static uint8_t cmos_read(uint8_t reg) {
     portio::out8(CMOS_ADDR, reg | NMI_DISABLE);
@@ -41,27 +38,17 @@ static uint8_t bcd_to_bin(uint8_t val) {
 }
 
 /**
- * Read the FADT century register index (ACPI 2.0+, offset 108).
- * Returns 0 if FADT is unavailable or field is zero.
+ * Read the FADT century register index.
+ * Returns 0 if FADT is unavailable or the field is zero.
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE static uint8_t get_fadt_century_register() {
-    const auto* fadt = acpi::find_table("FACP");
+    const acpi::fadt* fadt = acpi::get_fadt();
     if (!fadt) {
         return 0;
     }
 
-    uint32_t length;
-    string::memcpy(&length, &fadt->length, sizeof(length));
-    if (length < FADT_CENTURY_OFFSET + sizeof(uint8_t)) {
-        return 0;
-    }
-
-    uint8_t century_reg;
-    string::memcpy(&century_reg,
-                   reinterpret_cast<const uint8_t*>(fadt) + FADT_CENTURY_OFFSET,
-                   sizeof(century_reg));
-    return century_reg;
+    return fadt->century;
 }
 
 struct rtc_time {

--- a/kernel/arch/x86_64/power/power.cpp
+++ b/kernel/arch/x86_64/power/power.cpp
@@ -1,0 +1,119 @@
+#include "power/power.h"
+#include "acpi/acpi.h"
+#include "hw/portio.h"
+#include "hw/cpu.h"
+#include "hw/delay.h"
+#include "hw/mmio.h"
+#include "mm/vmm.h"
+#include "mm/paging_types.h"
+#include "trap/idt.h"
+#include "common/logging.h"
+
+namespace power {
+
+constexpr uint16_t KBC_CMD_PORT        = 0x64;
+constexpr uint8_t  KBC_STATUS_IBF      = 0x02;
+constexpr uint8_t  KBC_CMD_PULSE_RESET = 0xFE;
+constexpr uint32_t KBC_DRAIN_ATTEMPTS  = 500;
+
+constexpr uint16_t RESET_CTRL_PORT = 0xCF9;
+constexpr uint8_t  RESET_CTRL_ARM  = 0x02;  // Select CPU reset without power cycle
+constexpr uint8_t  RESET_CTRL_FIRE = 0x06;  // RST_CPU + SYS_RST, triggers the reset
+
+constexpr uint64_t MECHANISM_WAIT_US = 50000;
+
+/**
+ * Reset through the FADT reset register, the mechanism the firmware
+ * declares for the board. Absent or unusable registers are skipped.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static void acpi_reset() {
+    const acpi::fadt* fadt = acpi::get_fadt();
+    if (!fadt || !FADT_HAS_FIELD(fadt, reset_value)) {
+        return;
+    }
+
+    if (!(fadt->flags & acpi::FADT_FLAG_RESET_REG_SUP) ||
+        fadt->reset_reg.address == 0) {
+        return;
+    }
+
+    switch (fadt->reset_reg.space) {
+    case acpi::GAS_SPACE_SYSTEM_IO:
+        portio::out8(static_cast<uint16_t>(fadt->reset_reg.address),
+                     fadt->reset_value);
+        break;
+    case acpi::GAS_SPACE_SYSTEM_MEMORY: {
+        uintptr_t base = 0;
+        uintptr_t va = 0;
+        int32_t rc = vmm::map_phys(
+            static_cast<pmm::phys_addr_t>(fadt->reset_reg.address), 1,
+            paging::PAGE_KERNEL_RW | paging::PAGE_DEVICE, base, va);
+
+        if (rc == vmm::OK) {
+            mmio::write8(va, fadt->reset_value);
+        }
+        break;
+    }
+    default:
+        log::warn("power: unhandled reset register space %u",
+                  static_cast<uint32_t>(fadt->reset_reg.space));
+        break;
+    }
+}
+
+/**
+ * Pulse the CPU reset line through the keyboard controller.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static void kbc_reset() {
+    for (uint32_t i = 0; i < KBC_DRAIN_ATTEMPTS; i++) {
+        if ((portio::in8(KBC_CMD_PORT) & KBC_STATUS_IBF) == 0) {
+            break;
+        }
+
+        delay::us(10);
+    }
+
+    portio::out8(KBC_CMD_PORT, KBC_CMD_PULSE_RESET);
+}
+
+/**
+ * Load an empty IDT and trap. The fault cannot be delivered, which
+ * escalates to a triple fault and resets the CPU.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static void triple_fault() {
+    x86::idt_ptr null_idt = {0, 0};
+    asm volatile("lidt %0; int3" :: "m"(null_idt));
+}
+
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE int32_t shutdown() {
+    // Powering off requires the _S5 sleep type values from the DSDT.
+    return ERR_UNSUPPORTED;
+}
+
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE int32_t reboot() {
+    cpu::irq_disable();
+
+    acpi_reset();
+    delay::us(MECHANISM_WAIT_US);
+
+    kbc_reset();
+    delay::us(MECHANISM_WAIT_US);
+
+    portio::out8(RESET_CTRL_PORT, RESET_CTRL_ARM);
+    portio::out8(RESET_CTRL_PORT, RESET_CTRL_FIRE);
+    delay::us(MECHANISM_WAIT_US);
+
+    triple_fault();
+    return ERR_UNSUPPORTED;
+}
+
+} // namespace power

--- a/kernel/arch/x86_64/power/power.cpp
+++ b/kernel/arch/x86_64/power/power.cpp
@@ -1,4 +1,5 @@
 #include "power/power.h"
+#include "power/s5.h"
 #include "acpi/acpi.h"
 #include "hw/portio.h"
 #include "hw/cpu.h"
@@ -8,8 +9,17 @@
 #include "mm/paging_types.h"
 #include "trap/idt.h"
 #include "common/logging.h"
+#include "common/string.h"
 
 namespace power {
+
+// Resolved PM1 control register, either an I/O port or mapped MMIO
+struct pm1_block {
+    bool valid;
+    bool is_io;
+    uint16_t port;
+    uintptr_t va;
+};
 
 constexpr uint16_t KBC_CMD_PORT        = 0x64;
 constexpr uint8_t  KBC_STATUS_IBF      = 0x02;
@@ -21,6 +31,15 @@ constexpr uint8_t  RESET_CTRL_ARM  = 0x02;  // Select CPU reset without power cy
 constexpr uint8_t  RESET_CTRL_FIRE = 0x06;  // RST_CPU + SYS_RST, triggers the reset
 
 constexpr uint64_t MECHANISM_WAIT_US = 50000;
+
+// PM1 control register bits
+constexpr uint16_t PM1_SCI_EN       = (1 << 0);
+constexpr uint16_t PM1_SLP_EN       = (1 << 13);
+constexpr uint16_t PM1_SLP_TYP_MASK = (0x7 << 10);
+constexpr uint32_t PM1_SLP_TYP_SHIFT = 10;
+
+constexpr uint32_t SCI_EN_POLL_ATTEMPTS = 10000;
+constexpr uint64_t SCI_EN_POLL_DELAY_US = 100;
 
 /**
  * Reset through the FADT reset register, the mechanism the firmware
@@ -89,10 +108,159 @@ __PRIVILEGED_CODE static void triple_fault() {
 }
 
 /**
+ * Map the DSDT through the FADT pointer and extract the \_S5 values.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static bool lookup_s5_sleep_types(const acpi::fadt* fadt,
+                                                    uint8_t* typ_a,
+                                                    uint8_t* typ_b) {
+    uint64_t dsdt_phys = fadt->dsdt;
+    if (FADT_HAS_FIELD(fadt, x_dsdt) && fadt->x_dsdt != 0) {
+        dsdt_phys = fadt->x_dsdt;
+    }
+
+    const acpi::sdt_header* dsdt = acpi::map_table(dsdt_phys);
+    if (!dsdt || string::memcmp(dsdt->signature, "DSDT", 4) != 0) {
+        return false;
+    }
+
+    const auto* aml = reinterpret_cast<const uint8_t*>(dsdt)
+                    + sizeof(acpi::sdt_header);
+    size_t aml_len = dsdt->length - sizeof(acpi::sdt_header);
+
+    return find_s5_sleep_types(aml, aml_len, typ_a, typ_b);
+}
+
+/**
+ * Resolve a PM1 control block, preferring the extended GAS form over
+ * the legacy port field when the FADT provides a usable one.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static pm1_block resolve_pm1_cnt(
+    const acpi::generic_address* xreg, uint32_t legacy_port
+) {
+    pm1_block blk = {};
+
+    if (xreg && xreg->address != 0) {
+        if (xreg->space == acpi::GAS_SPACE_SYSTEM_IO) {
+            blk.valid = true;
+            blk.is_io = true;
+            blk.port = static_cast<uint16_t>(xreg->address);
+            return blk;
+        }
+
+        if (xreg->space == acpi::GAS_SPACE_SYSTEM_MEMORY) {
+            uintptr_t base = 0;
+            uintptr_t va = 0;
+            int32_t rc = vmm::map_phys(
+                static_cast<pmm::phys_addr_t>(xreg->address), sizeof(uint16_t),
+                paging::PAGE_KERNEL_RW | paging::PAGE_DEVICE, base, va);
+            if (rc == vmm::OK) {
+                blk.valid = true;
+                blk.va = va;
+                return blk;
+            }
+        }
+    }
+
+    if (legacy_port != 0) {
+        blk.valid = true;
+        blk.is_io = true;
+        blk.port = static_cast<uint16_t>(legacy_port);
+    }
+
+    return blk;
+}
+
+/** @note Privilege: **required** */
+__PRIVILEGED_CODE static uint16_t pm1_read(const pm1_block& blk) {
+    return blk.is_io ? portio::in16(blk.port) : mmio::read16(blk.va);
+}
+
+/** @note Privilege: **required** */
+__PRIVILEGED_CODE static void pm1_write(const pm1_block& blk, uint16_t val) {
+    if (blk.is_io) {
+        portio::out16(blk.port, val);
+    } else {
+        mmio::write16(blk.va, val);
+    }
+}
+
+/**
+ * Put the chipset into ACPI mode if firmware left it in legacy mode.
+ * The PM1 sleep bits have no effect until SCI_EN is set.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE static void enable_acpi_mode(const acpi::fadt* fadt,
+                                               const pm1_block& pm1a) {
+    if (pm1_read(pm1a) & PM1_SCI_EN) {
+        return;
+    }
+
+    if (fadt->smi_cmd == 0 || fadt->acpi_enable == 0) {
+        return;
+    }
+
+    portio::out8(static_cast<uint16_t>(fadt->smi_cmd), fadt->acpi_enable);
+
+    for (uint32_t i = 0; i < SCI_EN_POLL_ATTEMPTS; i++) {
+        if (pm1_read(pm1a) & PM1_SCI_EN) {
+            return;
+        }
+        delay::us(SCI_EN_POLL_DELAY_US);
+    }
+
+    log::warn("power: SCI_EN did not latch after the ACPI enable command");
+}
+
+/**
  * @note Privilege: **required**
  */
 __PRIVILEGED_CODE int32_t shutdown() {
-    // Powering off requires the _S5 sleep type values from the DSDT.
+    const acpi::fadt* fadt = acpi::get_fadt();
+    if (!fadt) {
+        log::warn("power: no FADT, cannot power off");
+        return ERR_UNSUPPORTED;
+    }
+
+    uint8_t typ_a = 0;
+    uint8_t typ_b = 0;
+    if (!lookup_s5_sleep_types(fadt, &typ_a, &typ_b)) {
+        log::warn("power: _S5 sleep values not found, cannot power off");
+        return ERR_UNSUPPORTED;
+    }
+
+    pm1_block pm1a = resolve_pm1_cnt(
+        FADT_HAS_FIELD(fadt, x_pm1a_cnt_blk) ? &fadt->x_pm1a_cnt_blk : nullptr,
+        fadt->pm1a_cnt_blk);
+    if (!pm1a.valid) {
+        log::warn("power: PM1a control block unavailable");
+        return ERR_UNSUPPORTED;
+    }
+
+    pm1_block pm1b = resolve_pm1_cnt(
+        FADT_HAS_FIELD(fadt, x_pm1b_cnt_blk) ? &fadt->x_pm1b_cnt_blk : nullptr,
+        fadt->pm1b_cnt_blk);
+
+    cpu::irq_disable();
+    enable_acpi_mode(fadt, pm1a);
+
+    // Enter S5: write SLP_TYP with SLP_EN to PM1a, then PM1b if present
+    uint16_t val = pm1_read(pm1a);
+    val &= static_cast<uint16_t>(~(PM1_SLP_TYP_MASK | PM1_SLP_EN));
+    pm1_write(pm1a, val
+        | static_cast<uint16_t>(typ_a << PM1_SLP_TYP_SHIFT) | PM1_SLP_EN);
+
+    if (pm1b.valid) {
+        val = pm1_read(pm1b);
+        val &= static_cast<uint16_t>(~(PM1_SLP_TYP_MASK | PM1_SLP_EN));
+        pm1_write(pm1b, val
+            | static_cast<uint16_t>(typ_b << PM1_SLP_TYP_SHIFT) | PM1_SLP_EN);
+    }
+
+    delay::us(MECHANISM_WAIT_US);
+
+    log::warn("power: ACPI S5 entry had no effect");
     return ERR_UNSUPPORTED;
 }
 

--- a/kernel/arch/x86_64/power/s5.cpp
+++ b/kernel/arch/x86_64/power/s5.cpp
@@ -1,0 +1,141 @@
+#include "power/s5.h"
+#include "common/string.h"
+
+namespace power {
+
+// AML opcodes involved in the Name(_S5_, Package(...)) pattern
+constexpr uint8_t AML_NAME_OP      = 0x08;
+constexpr uint8_t AML_ROOT_CHAR    = 0x5C;
+constexpr uint8_t AML_PACKAGE_OP   = 0x12;
+constexpr uint8_t AML_ZERO_OP      = 0x00;
+constexpr uint8_t AML_ONE_OP       = 0x01;
+constexpr uint8_t AML_BYTE_PREFIX  = 0x0A;
+constexpr uint8_t AML_WORD_PREFIX  = 0x0B;
+constexpr uint8_t AML_DWORD_PREFIX = 0x0C;
+constexpr uint8_t AML_ONES_OP      = 0xFF;
+
+// SLP_TYP is a 3-bit field in the PM1 control register
+constexpr uint8_t SLP_TYP_VALUE_MASK = 0x07;
+
+/**
+ * Decode an AML PkgLength. The two top bits of the lead byte give the
+ * count of extra bytes, and the encoding splits the value across them.
+ * Returns the bytes consumed, or 0 on malformed input.
+ */
+static size_t skip_pkg_length(const uint8_t* p, size_t remaining) {
+    if (remaining == 0) {
+        return 0;
+    }
+
+    size_t extra_bytes = p[0] >> 6;
+    if (remaining < 1 + extra_bytes) {
+        return 0;
+    }
+
+    return 1 + extra_bytes;
+}
+
+/**
+ * Decode one integer package element (ZeroOp, OneOp, OnesOp, or a
+ * Byte/Word/DWord constant). Returns the bytes consumed, or 0 on
+ * anything that is not an integer constant.
+ */
+static size_t decode_integer(const uint8_t* p, size_t remaining,
+                             uint64_t* out) {
+    if (remaining == 0) {
+        return 0;
+    }
+
+    switch (p[0]) {
+    case AML_ZERO_OP:
+        *out = 0;
+        return 1;
+    case AML_ONE_OP:
+        *out = 1;
+        return 1;
+    case AML_ONES_OP:
+        *out = 0xFF;
+        return 1;
+    case AML_BYTE_PREFIX:
+        if (remaining < 2) return 0;
+        *out = p[1];
+        return 2;
+    case AML_WORD_PREFIX:
+        if (remaining < 3) return 0;
+        *out = static_cast<uint64_t>(p[1]) | (static_cast<uint64_t>(p[2]) << 8);
+        return 3;
+    case AML_DWORD_PREFIX:
+        if (remaining < 5) return 0;
+        *out = static_cast<uint64_t>(p[1])
+             | (static_cast<uint64_t>(p[2]) << 8)
+             | (static_cast<uint64_t>(p[3]) << 16)
+             | (static_cast<uint64_t>(p[4]) << 24);
+        return 5;
+    default:
+        return 0;
+    }
+}
+
+/**
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE bool find_s5_sleep_types(const uint8_t* aml, size_t len,
+                                           uint8_t* typ_a, uint8_t* typ_b) {
+    for (size_t i = 0; i + 5 <= len; i++) {
+        if (string::memcmp(aml + i, "_S5_", 4) != 0) {
+            continue;
+        }
+
+        if (aml[i + 4] != AML_PACKAGE_OP) {
+            continue;
+        }
+
+        // The name must come from a NameOp, optionally through the
+        // root prefix ("\_S5_"), or the match is unrelated bytes.
+        bool named = (i >= 1 && aml[i - 1] == AML_NAME_OP)
+                  || (i >= 2 && aml[i - 1] == AML_ROOT_CHAR
+                             && aml[i - 2] == AML_NAME_OP);
+        if (!named) {
+            continue;
+        }
+
+        const uint8_t* p = aml + i + 5;
+        size_t remaining = len - (i + 5);
+
+        size_t consumed = skip_pkg_length(p, remaining);
+        if (consumed == 0) {
+            continue;
+        }
+        p += consumed;
+        remaining -= consumed;
+
+        // NumElements, the package must hold at least SLP_TYPa and SLP_TYPb
+        if (remaining == 0 || p[0] < 2) {
+            continue;
+        }
+        p += 1;
+        remaining -= 1;
+
+        uint64_t value_a = 0;
+        consumed = decode_integer(p, remaining, &value_a);
+        if (consumed == 0) {
+            continue;
+        }
+        p += consumed;
+        remaining -= consumed;
+
+        uint64_t value_b = 0;
+        consumed = decode_integer(p, remaining, &value_b);
+        if (consumed == 0) {
+            continue;
+        }
+
+        *typ_a = static_cast<uint8_t>(value_a) & SLP_TYP_VALUE_MASK;
+        *typ_b = static_cast<uint8_t>(value_b) & SLP_TYP_VALUE_MASK;
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace power

--- a/kernel/arch/x86_64/power/s5.h
+++ b/kernel/arch/x86_64/power/s5.h
@@ -1,0 +1,25 @@
+#ifndef STELLUX_ARCH_X86_64_POWER_S5_H
+#define STELLUX_ARCH_X86_64_POWER_S5_H
+
+#include "common/types.h"
+
+namespace power {
+
+/**
+ * @brief Extract the SLP_TYP values from the \_S5 package in AML bytecode.
+ * Scans for the Name(_S5_, Package(...)) pattern instead of interpreting
+ * the bytecode, which works because firmware defines \_S5 as a package of
+ * integer constants.
+ * @param aml    DSDT definition block, exclusive of the table header.
+ * @param len    Length of the definition block in bytes.
+ * @param typ_a  Receives the SLP_TYPa value for PM1a_CNT.
+ * @param typ_b  Receives the SLP_TYPb value for PM1b_CNT.
+ * @return true when both values were found and decoded.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE bool find_s5_sleep_types(const uint8_t* aml, size_t len,
+                                           uint8_t* typ_a, uint8_t* typ_b);
+
+} // namespace power
+
+#endif // STELLUX_ARCH_X86_64_POWER_S5_H

--- a/kernel/drivers/platform_driver.cpp
+++ b/kernel/drivers/platform_driver.cpp
@@ -70,11 +70,11 @@ static void platform_task_entry(void* arg) {
 
 // Detect RPi4 via ACPI FADT OEM IDs (same check as PCI subsystem).
 static bool is_rpi4() {
-    const auto* fadt = acpi::find_table("FACP");
+    const acpi::fadt* fadt = acpi::get_fadt();
     if (!fadt) return false;
 
-    return string::memcmp(fadt->oem_id, "RPIFDN", 6) == 0
-        && string::memcmp(fadt->oem_table_id, "RPI4", 4) == 0;
+    return string::memcmp(fadt->header.oem_id, "RPIFDN", 6) == 0
+        && string::memcmp(fadt->header.oem_table_id, "RPI4", 4) == 0;
 }
 
 // Known RPi4 GENET addresses (used when FDT doesn't have them or ACPI is used)

--- a/kernel/pci/pci.cpp
+++ b/kernel/pci/pci.cpp
@@ -504,10 +504,10 @@ constexpr uint64_t BCM2711_PCIE_BASE = 0xfd500000;
 constexpr uint64_t BCM2711_PCIE_SIZE = 0x9310;
 
 __PRIVILEGED_CODE static bool is_rpi4_firmware() {
-    const auto* fadt = acpi::find_table("FACP");
+    const acpi::fadt* fadt = acpi::get_fadt();
     if (!fadt) return false;
-    return string::memcmp(fadt->oem_id, "RPIFDN", 6) == 0
-        && string::memcmp(fadt->oem_table_id, "RPI4", 4) == 0;
+    return string::memcmp(fadt->header.oem_id, "RPIFDN", 6) == 0
+        && string::memcmp(fadt->header.oem_table_id, "RPI4", 4) == 0;
 }
 
 // Known RPi4 outbound window (from upstream bcm2711 device tree)

--- a/kernel/power/power.h
+++ b/kernel/power/power.h
@@ -1,0 +1,33 @@
+#ifndef STELLUX_POWER_POWER_H
+#define STELLUX_POWER_POWER_H
+
+#include "common/types.h"
+
+namespace power {
+
+constexpr int32_t OK              = 0;
+constexpr int32_t ERR_UNSUPPORTED = -1;
+
+/**
+ * @brief Power off the machine.
+ * Tries every mechanism the platform offers, so it returns only when
+ * all of them failed or none is available. The caller decides whether
+ * to halt or report the error.
+ * @return ERR_UNSUPPORTED if the platform cannot power off.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE int32_t shutdown();
+
+/**
+ * @brief Reboot the machine.
+ * Tries every mechanism the platform offers, so it returns only when
+ * all of them failed or none is available. The caller decides whether
+ * to halt or report the error.
+ * @return ERR_UNSUPPORTED if the platform cannot reboot.
+ * @note Privilege: **required**
+ */
+__PRIVILEGED_CODE int32_t reboot();
+
+} // namespace power
+
+#endif // STELLUX_POWER_POWER_H


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes privileged shutdown/reboot paths (ACPI PM1/AML, I/O ports, MMIO, PSCI) that can hang or misbehave on wrong firmware; bugs affect every platform build.
> 
> **Overview**
> Introduces a shared **`power::shutdown()`** / **`power::reboot()`** API and arch-specific implementations that drive real hardware power transitions instead of only halting.
> 
> **ACPI** gains typed **FADT** / **GAS** layouts, **`acpi::get_fadt()`**, **`acpi::map_table()`** (for DSDT and other pointer-referenced tables), and shared **`map_sdt()`** mapping logic. Existing FACP users (RTC century, RPi4 detection, SMP) move off raw header hacks to these helpers.
> 
> On **x86_64**, shutdown walks ACPI **S5**: map DSDT, scan AML for **`\_S5_`** sleep types, enable ACPI mode if needed, then program **PM1a/PM1b** with **SLP_EN**. Reboot tries FADT reset register, keyboard-controller pulse, **0xCF9**, then triple-fault.
> 
> On **aarch64**, shutdown/reboot use **PSCI SYSTEM_OFF** / **SYSTEM_RESET** after **`psci::detect_conduit()`** (moved out of SMP). PSCI helpers and conduit detection are centralized in **`psci`**.
> 
> Call sites return **`ERR_UNSUPPORTED`** when a mechanism fails so upper layers can fall back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8230c5729a53434bc9c42ff2bb2fa04ce5bac9c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->