### PR TITLE
feat(ci): registered the Stellux developer packages workflow

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,78 @@
+#
+# Stellux Developer Packages
+#
+# Builds the prebuilt Stellux programs the image build can fetch (the GCC
+# toolchain, binutils) for both architectures and publishes them as a
+# GitHub release. Runs on demand, since each architecture takes about an
+# hour, and packages/packages.lock pins the result.
+#
+# Job graph:
+#
+#   build  (2 jobs: arch)
+#     |
+#     v
+#   publish
+#
+name: Stellux Developer Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "Release tag, for example packages-2026.09.03"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: build (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: [x86_64, aarch64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Archive timestamps derive from the recipe's last commit, which a
+          # shallow clone cannot see
+          fetch-depth: 0
+
+      - name: Build packages
+        run: ./packages/build.sh ${{ matrix.arch }}
+
+      - name: Upload archives
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages-${{ matrix.arch }}
+          path: userland/toolchain/packages/*.tar.zst
+          if-no-files-found: error
+
+  publish:
+    name: publish
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Collect archives
+        uses: actions/download-artifact@v4
+        with:
+          pattern: packages-*
+          merge-multiple: true
+          path: dist
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./packages/publish.sh "${{ inputs.release }}" dist


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> On-demand CI only; risk is limited to mistaken manual releases or failed long builds, not runtime or security-critical application code.
> 
> **Overview**
> Adds a **manual** GitHub Actions workflow (**Stellux Developer Packages**) that builds prebuilt toolchain/binutils archives for **x86_64** and **aarch64**, then publishes them as a GitHub release.
> 
> The **build** job runs `./packages/build.sh` per architecture (5-hour timeout, full `fetch-depth: 0` checkout for recipe commit timestamps), uploads `userland/toolchain/packages/*.tar.zst` as artifacts, and the **publish** job merges artifacts and runs `./packages/publish.sh` with the operator-supplied release tag (e.g. `packages-2026.09.03`). Workflow grants **`contents: write`** so releases can be created with `github.token`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9720a21583451c8b8cf0c4cee9c1b7a39b778c96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->